### PR TITLE
Add basic websocket messaging

### DIFF
--- a/apps/backend/src/api/index.ts
+++ b/apps/backend/src/api/index.ts
@@ -4,12 +4,14 @@ import profileRoutes from './routes/profile.route'
 import tagsRoutes from './routes/tags.route'
 import citiesRoutes from './routes/city.route'
 import captchaRoutes from './routes/captcha.route'
+import messageRoutes from './routes/message.route'
 
 
 const api: FastifyPluginAsync = async (fastify) => {
   fastify.register(userRoutes, { prefix: '/users' })
   fastify.register(tagsRoutes, { prefix: '/tags' })
   fastify.register(profileRoutes, { prefix: '/profiles' })
+  fastify.register(messageRoutes, { prefix: '/messages' })
   fastify.register(citiesRoutes, { prefix: '/cities' })
   fastify.register(captchaRoutes, { prefix: '/captcha' })
 }

--- a/apps/backend/src/api/routes/message.route.ts
+++ b/apps/backend/src/api/routes/message.route.ts
@@ -1,8 +1,11 @@
 import { FastifyPluginAsync } from 'fastify'
 
 const messageRoutes: FastifyPluginAsync = async (fastify) => {
-  fastify.get('/', async () => {
-    return { messages: [] }
+  fastify.get('/:userId', { onRequest: [fastify.authenticate] }, async (req, reply) => {
+    const { userId } = req.params as { userId: string }
+    const current = req.user!.userId
+    const messages = await fastify.messageService.getConversation(current, userId)
+    reply.send({ messages })
   })
 }
 

--- a/apps/backend/src/main.ts
+++ b/apps/backend/src/main.ts
@@ -45,6 +45,8 @@ app.register(import('./plugins/user-service'))
 app.register(import('./plugins/profile-service'))
 app.register(import('./plugins/gallery-service'))
 app.register(import('./plugins/tag-service'))
+app.register(import('./plugins/message-service'))
+app.register(import('./plugins/websocket'))
 app.register(import('./api'), { prefix: '/api' })
 
 const ok = checkImageRoot()

--- a/apps/backend/src/plugins/message-service.ts
+++ b/apps/backend/src/plugins/message-service.ts
@@ -1,0 +1,14 @@
+import fp from 'fastify-plugin'
+import { MessageService } from '../services/message.service'
+
+export default fp(async (fastify) => {
+  const service = MessageService.getInstance()
+  fastify.decorate('messageService', service)
+})
+
+// type declarations
+declare module 'fastify' {
+  interface FastifyInstance {
+    messageService: MessageService
+  }
+}

--- a/apps/backend/src/plugins/websocket.ts
+++ b/apps/backend/src/plugins/websocket.ts
@@ -1,0 +1,41 @@
+import fp from 'fastify-plugin'
+import websocket, { SocketStream } from '@fastify/websocket'
+import { FastifyInstance } from 'fastify'
+
+interface WsMessage {
+  to: string
+  content: string
+}
+
+export default fp(async (fastify: FastifyInstance) => {
+  fastify.register(websocket)
+  fastify.decorate('connections', {} as Record<string, SocketStream['socket']>)
+
+  fastify.get('/ws', { websocket: true, onRequest: [fastify.authenticate] }, (conn, req) => {
+    const userId = req.user!.userId
+    fastify.connections[userId] = conn.socket
+
+    conn.socket.on('close', () => {
+      delete fastify.connections[userId]
+    })
+
+    conn.socket.on('message', async (raw) => {
+      try {
+        const data = JSON.parse(raw.toString()) as WsMessage
+        if (!data.to || !data.content) return
+        const msg = await fastify.messageService.sendMessage(userId, data.to, data.content)
+        const receiver = fastify.connections[data.to]
+        if (receiver && receiver.readyState === receiver.OPEN) {
+          receiver.send(JSON.stringify({
+            id: msg.id,
+            from: userId,
+            content: msg.content,
+            createdAt: msg.createdAt
+          }))
+        }
+      } catch (err) {
+        fastify.log.error('Invalid WS message', err)
+      }
+    })
+  })
+})

--- a/apps/backend/src/services/message.service.ts
+++ b/apps/backend/src/services/message.service.ts
@@ -1,1 +1,33 @@
-// TODO: implement message service
+import { prisma } from '../lib/prisma'
+import { Message } from '@prisma/client'
+
+export class MessageService {
+  private static instance: MessageService
+
+  private constructor () {}
+
+  public static getInstance (): MessageService {
+    if (!MessageService.instance) {
+      MessageService.instance = new MessageService()
+    }
+    return MessageService.instance
+  }
+
+  async sendMessage (senderId: string, receiverId: string, content: string): Promise<Message> {
+    return prisma.message.create({
+      data: { senderId, receiverId, content }
+    })
+  }
+
+  async getConversation (userAId: string, userBId: string): Promise<Message[]> {
+    return prisma.message.findMany({
+      where: {
+        OR: [
+          { senderId: userAId, receiverId: userBId },
+          { senderId: userBId, receiverId: userAId }
+        ]
+      },
+      orderBy: { createdAt: 'asc' }
+    })
+  }
+}

--- a/apps/backend/src/types/fastify.d.ts
+++ b/apps/backend/src/types/fastify.d.ts
@@ -1,5 +1,6 @@
 import 'fastify'
 import { PrismaClient } from '@prisma/client'
+import type { MessageService } from '../services/message.service'
 import type { SocketStream } from '@fastify/websocket'
 import '@fastify/jwt'
 
@@ -8,6 +9,7 @@ declare module 'fastify' {
     prisma: PrismaClient
     authenticate: (req: FastifyRequest, reply: FastifyReply) => Promise<void>
     connections: Record<string, SocketStream['socket']>
+    messageService: MessageService
   }
 }
 


### PR DESCRIPTION
## Summary
- implement `MessageService` for storing conversations
- expose a Fastify plugin for MessageService
- handle websockets and in-memory connection registry
- add messages API route
- register plugins and route in backend entry

## Testing
- `pnpm --filter backend build`

------
https://chatgpt.com/codex/tasks/task_e_6845905d403883319cf3f78a9aed1768