### PR TITLE
Localize frontend strings

### DIFF
--- a/apps/frontend/src/components/LoadingComponent.vue
+++ b/apps/frontend/src/components/LoadingComponent.vue
@@ -1,18 +1,22 @@
 <template>
   <div class="loading-spinner">
     <div class="text-center">
-      <div class="spinner-border"
-           role="status">
-        <span class="visually-hidden">Loading...</span>
+      <div class="spinner-border" role="status">
+        <span class="visually-hidden">{{ t('uicomponents.loading') }}</span>
       </div>
     </div>
   </div>
 </template>
 
 <script lang="ts">
-import { defineComponent } from 'vue';
+import { defineComponent } from 'vue'
+import { useI18n } from 'vue-i18n'
 
 export default defineComponent({
   name: 'LoadingComponent',
+  setup() {
+    const { t } = useI18n()
+    return { t }
+  },
 })
 </script>

--- a/apps/frontend/src/components/auth/LoginConfirmComponent.vue
+++ b/apps/frontend/src/components/auth/LoginConfirmComponent.vue
@@ -1,19 +1,20 @@
 <template>
-
   <div class="login-success-component">
     <div class="d-flex justify-content-center align-items-center flex-column h-100">
       <div class="icon-inner text-success animate__animated animate__fadeIn">
         <IconSun class="svg-icon welcome-icon" />
       </div>
-      <div class="text-success fs-3 animate__animated animate__fadeIn">Welcome!</div>
+      <div class="text-success fs-3 animate__animated animate__fadeIn">{{ t('auth.welcome') }}</div>
     </div>
   </div>
-
 </template>
 
 <script lang="ts" setup>
 import 'animate.css'
-import { IconSun } from '@/components/icons/DoodleIcons';
+import { IconSun } from '@/components/icons/DoodleIcons'
+import { useI18n } from 'vue-i18n'
+
+const { t } = useI18n()
 </script>
 
 <style scoped>

--- a/apps/frontend/src/components/auth/OtpLoginComponent.vue
+++ b/apps/frontend/src/components/auth/OtpLoginComponent.vue
@@ -1,11 +1,11 @@
 <script setup lang="ts">
 import { ref } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { type LoginUser } from '@zod/user.schema'
-import { otpRegex } from '@/lib/utils';
+import { otpRegex } from '@/lib/utils'
 
 import { IconMail } from '@/components/icons/DoodleIcons'
 import { IconMessage } from '@/components/icons/DoodleIcons'
-
 
 const props = defineProps<{
   user: LoginUser
@@ -16,6 +16,7 @@ const emit = defineEmits<{
   (e: 'otp:submit', otp: string): void
 }>()
 
+const { t } = useI18n()
 // Reactive variables
 const otpInput = ref('')
 const error = ref('' as string)
@@ -33,9 +34,7 @@ function validateOtp(node: any) {
   // Simple validation for OTP: must be a number and 6 digits long
   return otpRegex.test(value)
 }
-
 </script>
-
 
 <template>
   <div class="otp-form">
@@ -48,58 +47,59 @@ function validateOtp(node: any) {
           <IconMail class="svg-icon" />
         </span>
       </span>
-      Check your messages
+      {{ t('auth.check_your_messages') }}
     </div>
     <div class="mb-3 form-text mb-3">
       <div v-if="user.phonenumber">
-        We have sent you a little code to your phone number,
-        please enter it below.
+        {{ t('auth.otp_sms_instruction') }}
       </div>
       <div v-else>
-        We have sent you a login link, check your inbox.
-        If you don't see it, please check your spam folder.
+        {{ t('auth.otp_email_instruction') }}
       </div>
     </div>
 
-    <FormKit type="form"
-             id="otpForm"
-             :actions="false"
-             :disabled="isLoading"
-             #default="{ state: { valid } }"
-             @submit="handleOTPEntered">
-
+    <FormKit
+      type="form"
+      id="otpForm"
+      :actions="false"
+      :disabled="isLoading"
+      #default="{ state: { valid } }"
+      @submit="handleOTPEntered"
+    >
       <div class="mb-3">
-        <FormKit type="text"
-                 v-model="otpInput"
-                 label="Login code..."
-                 id="otp"
-                 :floating-label="true"
-                 input-class="form-control-lg"
-                 aria-autocomplete="none"
-                 autocomplete="off"
-                 autofocus
-                 validation="+validateOtp"
-                 :validation-rules="{
-                  validateOtp,
-                }"
-                 validation-visibility="live" />
+        <FormKit
+          type="text"
+          v-model="otpInput"
+          :label="t('auth.otp_label')"
+          id="otp"
+          :floating-label="true"
+          input-class="form-control-lg"
+          aria-autocomplete="none"
+          autocomplete="off"
+          autofocus
+          validation="+validateOtp"
+          :validation-rules="{
+            validateOtp,
+          }"
+          validation-visibility="live"
+        />
       </div>
 
-      <FormKit type="submit"
-               wrapper-class="d-grid gap-2 mb-3"
-               input-class="btn-primary btn-lg w-100"
-               label="Continue"
-               :disabled="!valid || isLoading" />
+      <FormKit
+        type="submit"
+        wrapper-class="d-grid gap-2 mb-3"
+        input-class="btn-primary btn-lg w-100"
+        :label="t('auth.continue')"
+        :disabled="!valid || isLoading"
+      />
     </FormKit>
   </div>
 </template>
-
 
 <style scoped>
 :deep(ul.formkit-messages) {
   display: none;
 }
-
 
 .suffix-icon {
   position: absolute;

--- a/apps/frontend/src/components/messaging/SendMessageDialog.vue
+++ b/apps/frontend/src/components/messaging/SendMessageDialog.vue
@@ -1,10 +1,9 @@
 <script setup lang="ts">
+import { useI18n } from 'vue-i18n'
 
+const { t } = useI18n()
 </script>
 
-
 <template>
-
-<h4>Send Message</h4>
-
+  <h4>{{ t('messaging.send_message') }}</h4>
 </template>

--- a/apps/frontend/src/components/nav/LogoutButton.vue
+++ b/apps/frontend/src/components/nav/LogoutButton.vue
@@ -1,23 +1,23 @@
 <template>
-  <a @click="handleClick"
-     href="#"
-     class="btn btn-secondary">
-     <IconLogout class=svg-icon />
-     Logout</a>
+  <a @click="handleClick" href="#" class="btn btn-secondary">
+    <IconLogout class="svg-icon" />
+    {{ t('authentication.logout') }}</a
+  >
 </template>
 
-
 <script lang="ts" setup>
-import { useAuthStore } from '@/store/authStore';
-import { useRouter } from 'vue-router';
-import {IconLogout} from '@/components/icons/DoodleIcons';
+import { useAuthStore } from '@/store/authStore'
+import { useRouter } from 'vue-router'
+import { IconLogout } from '@/components/icons/DoodleIcons'
+import { useI18n } from 'vue-i18n'
 
-const auth = useAuthStore();
-const router = useRouter();
+const { t } = useI18n()
+
+const auth = useAuthStore()
+const router = useRouter()
 
 function handleClick() {
-  auth.logout(); // Clear the authentication state
-  router.push({ name: 'Login' }); // Redirect to the login page
+  auth.logout() // Clear the authentication state
+  router.push({ name: 'Login' }) // Redirect to the login page
 }
-
 </script>

--- a/apps/frontend/src/views/BrowseProfiles.vue
+++ b/apps/frontend/src/views/BrowseProfiles.vue
@@ -1,14 +1,14 @@
 <script setup lang="ts">
-import { reactive, onMounted, computed } from 'vue';
-import { useProfileStore } from '@/store/profileStore';
-import router from '@/router';
+import { reactive, onMounted, computed } from 'vue'
+import { useProfileStore } from '@/store/profileStore'
+import router from '@/router'
 
-import { type PublicProfile } from '@zod/profile.schema';
+import { type PublicProfile } from '@zod/profile.schema'
 
-import LoadingComponent from '@/components/LoadingComponent.vue';
-import ProfileCardComponent from '@/components/profiles/public/ProfileCardComponent.vue';
-import NoProfileInfoCTAComponent from '@/components/profiles/NoProfileInfoCTAComponent.vue';
-
+import LoadingComponent from '@/components/LoadingComponent.vue'
+import ProfileCardComponent from '@/components/profiles/public/ProfileCardComponent.vue'
+import NoProfileInfoCTAComponent from '@/components/profiles/NoProfileInfoCTAComponent.vue'
+import { useI18n } from 'vue-i18n'
 
 const profileStore = useProfileStore()
 
@@ -18,64 +18,58 @@ const state = reactive({
   isLoading: false,
   error: null as string | null,
   showModal: false,
-});
+})
+const { t } = useI18n()
 
 onMounted(async () => {
   state.isLoading = true
   try {
     // Fetch profiles from the store
     const profiles = await profileStore.findProfiles()
-    if (profiles != null) state.profiles = profiles;
+    if (profiles != null) state.profiles = profiles
   } catch (error) {
-    state.error = 'Failed to fetch profiles';
-    state.showModal = true;
+    state.error = t('profile.fetch_error')
+    state.showModal = true
     // console.error('Error fetching profiles:', error);
   } finally {
-    state.isLoading = false;
+    state.isLoading = false
   }
 })
 
 const handleCardClick = (profile: PublicProfile) => {
-  console.log('Card clicked:', profile);
-  router.push({ name: 'PublicProfile', params: { id: profile.id } });
-};
-
+  console.log('Card clicked:', profile)
+  router.push({ name: 'PublicProfile', params: { id: profile.id } })
+}
 </script>
-
-
 
 <template>
   <div>
     <div class="container">
-
       <div class="browse-profiles-view">
         <LoadingComponent v-if="state.isLoading" />
 
         <div class="container-fluid">
           <div class="row row-cols-1 row-cols-sm-2 row-cols-md-3 g-4">
-
-            <div v-for="profile in state.profiles"
-                 :key="profile.id"
-                 class="col">
-              <ProfileCardComponent :profile="profile"
-                                    @click="handleCardClick(profile)" />
+            <div v-for="profile in state.profiles" :key="profile.id" class="col">
+              <ProfileCardComponent :profile="profile" @click="handleCardClick(profile)" />
             </div>
           </div>
         </div>
       </div>
     </div>
-    <BModal v-model="state.showModal"
-            centered
-            button-size="sm"
-            :focus="false"
-            :no-close-on-backdrop="true"
-            :no-footer="true"
-            :no-header="true"
-            cancel-title="Nevermind"
-            initial-animation
-            title="Add a photo">
+    <BModal
+      v-model="state.showModal"
+      centered
+      button-size="sm"
+      :focus="false"
+      :no-close-on-backdrop="true"
+      :no-footer="true"
+      :no-header="true"
+      :cancel-title="t('uicomponents.modal.close')"
+      initial-animation
+      :title="t('profile.add_photo')"
+    >
       <NoProfileInfoCTAComponent v-if="state.error" />
-
     </BModal>
   </div>
 </template>

--- a/apps/frontend/src/views/Login.vue
+++ b/apps/frontend/src/views/Login.vue
@@ -9,6 +9,7 @@ import ErrorComponent from '@/components/ErrorComponent.vue'
 import LoginConfirmComponent from '@/components/auth/LoginConfirmComponent.vue'
 
 import ChevronLeftIcon from '@/assets/icons/arrows/arrow-single-left.svg'
+import { useI18n } from 'vue-i18n'
 
 // Reactive variables
 const error = ref('' as string)
@@ -33,7 +34,7 @@ const showConfirmScreen = ref(false)
 const router = useRouter()
 const route = useRoute()
 const authStore = useAuthStore()
-
+const { t } = useI18n()
 
 // // On mounted lifecycle hook
 onMounted(async () => {
@@ -61,10 +62,10 @@ async function handleSendOtp(payload: SendOtpPayload) {
       showOtpForm.value = true
       showUserIdForm.value = false
     } else {
-      error.value = 'An unknown error occurred, please try again a bit later.'
+      error.value = t('errors.unknown')
     }
   } catch (err: any) {
-    error.value = err || 'An unexpected error occurred.'
+    error.value = err || t('errors.unexpected')
     console.error('Login error:', err)
   } finally {
     isLoading.value = false
@@ -84,20 +85,20 @@ async function doOtpLogin(otp: string) {
       showConfirmScreen.value = true
       showOtpForm.value = false
       showUserIdForm.value = false
-      await new Promise(resolve => setTimeout(resolve, 2000))
+      await new Promise((resolve) => setTimeout(resolve, 2000))
       await router.push({ name: 'Onboarding' })
       return true
     } else {
       console.log('OTP login failed:', res)
       // Handle different status flags
       if (res.status === 'storage_error') {
-        error.value = 'Something is off with this browser. Please try again in a different one (or try clearing your browser storage.)'
+        error.value = t('errors.browser_storage')
       }
       if (res.status === 'missing_userid') {
-        error.value = 'Something went wrong here with the code.  Try again?'
+        error.value = t('errors.missing_code')
       }
       if (res.status === 'missing_otp' || res.status === 'invalid_token') {
-        error.value = 'Oops, this code has probably expired. Try again?'
+        error.value = t('errors.otp_expired')
       }
       showUserIdForm.value = true
       showOtpForm.value = false
@@ -105,7 +106,7 @@ async function doOtpLogin(otp: string) {
     }
   } catch (err: any) {
     console.error(err)
-    error.value = err.response?.data?.message || 'Failed to confirm email.'
+    error.value = err.response?.data?.message || t('errors.confirm_email_failed')
   } finally {
     isLoading.value = false
   }
@@ -117,55 +118,52 @@ function handleBackButton() {
   showOtpForm.value = false
   error.value = ''
   isLoading.value = false
-} 
+}
 </script>
-
 
 <template>
   <div class="login-container">
-   
-    <BModal v-model="showModal"
-            title="Login"
-            size="md"
-            :backdrop="'static'"
-            centered
-            button-size="sm"
-            :focus="false"
-            :no-close-on-backdrop="true"
-            :no-footer="true"
-            :no-header="true"
-            cancel-title="Nevermind"
-            initial-animation
-            fullscreen="md"
-            body-class="d-flex flex-row align-items-center justify-content-center overflow-hidden"
-            :keyboard="false">
+    <BModal
+      v-model="showModal"
+      :title="t('authentication.login')"
+      size="md"
+      :backdrop="'static'"
+      centered
+      button-size="sm"
+      :focus="false"
+      :no-close-on-backdrop="true"
+      :no-footer="true"
+      :no-header="true"
+      :cancel-title="t('uicomponents.modal.close')"
+      initial-animation
+      fullscreen="md"
+      body-class="d-flex flex-row align-items-center justify-content-center overflow-hidden"
+      :keyboard="false"
+    >
       <div class="w-100">
         <div v-if="showOtpForm">
           <div class="back-button">
-            <a class="btn btn-secondary-outline"
-               @click="handleBackButton">
+            <a class="btn btn-secondary-outline" @click="handleBackButton">
               <ChevronLeftIcon class="svg-icon" />
             </a>
           </div>
         </div>
         <ErrorComponent :error="error" />
 
-        <AuthIdComponent :isLoading="isLoading"
-                         @otp:send="handleSendOtp"
-                         v-if="showUserIdForm" />
+        <AuthIdComponent :isLoading="isLoading" @otp:send="handleSendOtp" v-if="showUserIdForm" />
 
-
-        <OtpLoginComponent :isLoading="isLoading"
-                           :user="user"
-                           @otp:submit="handleOTPSubmitted"
-                           v-if="showOtpForm" />
+        <OtpLoginComponent
+          :isLoading="isLoading"
+          :user="user"
+          @otp:submit="handleOTPSubmitted"
+          v-if="showOtpForm"
+        />
 
         <LoginConfirmComponent v-if="showConfirmScreen" />
       </div>
     </BModal>
   </div>
 </template>
-
 
 <style scoped>
 .back-button {

--- a/apps/frontend/src/views/Messaging.vue
+++ b/apps/frontend/src/views/Messaging.vue
@@ -4,7 +4,7 @@ import { useProfileStore } from '@/store/profileStore'
 import type { ProfileImages, PublicProfile } from '@zod/profile.schema'
 import { useMessageStore } from '@/store/messageStore'
 import type { ConversationSummary } from '@zod/messaging.schema'
-
+import { useI18n } from 'vue-i18n'
 
 const profileStore = useProfileStore()
 const messageStore = useMessageStore()
@@ -14,7 +14,7 @@ const recipient = ref('')
 const content = ref('')
 const isLoading = ref(false)
 
-
+const { t } = useI18n()
 
 async function sendMessage() {
   if (!recipient.value || !content.value) return
@@ -42,9 +42,9 @@ const messages = computed(() => messageStore.messages)
 // TODO refactor into ProfileImageComponent
 const profileImage = computed(() => {
   return (profile: ProfileImages) => {
-    return profile.profileImages.length > 0 ? profile.profileImages[0] : undefined;
-  };
-});
+    return profile.profileImages.length > 0 ? profile.profileImages[0] : undefined
+  }
+})
 
 async function handleSelectConvo(convo: ConversationSummary) {
   recipient.value = convo.partnerProfile.id
@@ -52,19 +52,20 @@ async function handleSelectConvo(convo: ConversationSummary) {
 }
 </script>
 
-
 <template>
   <div class="container mt-3">
-    <h2 class="mb-3">Messaging</h2>
+    <h2 class="mb-3">{{ t('messaging.title') }}</h2>
     <!-- TODO implement left sidebar with user list. user items should be clickable  -->
     <div class="row">
       <div class="col-md-3">
-        <h6>Convos</h6>
+        <h6>{{ t('messaging.conversations') }}</h6>
         <ul class="list-group mb-3">
-          <li v-for="convo in conversations"
-              :key="convo.conversationId"
-              class="list-group-item d-flex justify-content-between align-items-center"
-              @click="handleSelectConvo(convo)">
+          <li
+            v-for="convo in conversations"
+            :key="convo.conversationId"
+            class="list-group-item d-flex justify-content-between align-items-center"
+            @click="handleSelectConvo(convo)"
+          >
             <span class="publicname">{{ convo.partnerProfile.publicName }}</span>
             <div class="thumbnail">
               <ProfileImageComponent :image="profileImage(convo.partnerProfile)" />
@@ -74,48 +75,49 @@ async function handleSelectConvo(convo: ConversationSummary) {
       </div>
       <div class="col-md-9">
         <div class="mb-2">
-          <input v-model="recipient"
-                 class="form-control mb-2"
-                 placeholder="Recipient user id" />
-          <div class="border p-2 mb-2"
-               style="height: 200px; overflow-y: auto;">
-            <div v-for="msg in messages"
-                 :key="msg.id"
-                 class="mb-1">
+          <input
+            v-model="recipient"
+            class="form-control mb-2"
+            :placeholder="t('messaging.recipient_placeholder')"
+          />
+          <div class="border p-2 mb-2" style="height: 200px; overflow-y: auto">
+            <div v-for="msg in messages" :key="msg.id" class="mb-1">
               {{ msg.content }}
             </div>
           </div>
           <div class="input-group">
-            <input v-model="content"
-                   class="form-control"
-                   placeholder="Type a message"
-                   @keyup.enter="sendMessage" />
-            <button class="btn btn-primary"
-                    @click="sendMessage">Send</button>
+            <input
+              v-model="content"
+              class="form-control"
+              :placeholder="t('messaging.message_placeholder')"
+              @keyup.enter="sendMessage"
+            />
+            <button class="btn btn-primary" @click="sendMessage">
+              {{ t('messaging.send_button') }}
+            </button>
           </div>
         </div>
 
         <div class="mb-4">
-          <h4>Users</h4>
+          <h4>{{ t('messaging.users') }}</h4>
           <ul class="list-group">
-            <li v-for="profile in profiles"
-                :key="profile.id"
-                class="list-group-item d-flex justify-content-between align-items-center"
-                @click="recipient = profile.id">
+            <li
+              v-for="profile in profiles"
+              :key="profile.id"
+              class="list-group-item d-flex justify-content-between align-items-center"
+              @click="recipient = profile.id"
+            >
               <span class="publicname">{{ profile.publicName }}</span>
               <div class="thumbnail">
                 <ProfileImageComponent :image="profileImage(profile)" />
               </div>
             </li>
           </ul>
-
-
         </div>
       </div>
     </div>
   </div>
 </template>
-
 
 <style scoped>
 .thumbnail {

--- a/apps/frontend/src/views/Onboarding.vue
+++ b/apps/frontend/src/views/Onboarding.vue
@@ -2,26 +2,23 @@
 import { onMounted, reactive, toRefs } from 'vue'
 import { useProfileStore } from '@/store/profileStore'
 
-import type {
-  OwnerProfile,
-  ProfileFormSubmit,
-  UpdateProfilePayload
-} from '@zod/profile.schema'
-import { OwnerProfileSchema, UpdatedProfileFragmentSchema, } from '@zod/profile.schema'
+import type { OwnerProfile, ProfileFormSubmit, UpdateProfilePayload } from '@zod/profile.schema'
+import { OwnerProfileSchema, UpdatedProfileFragmentSchema } from '@zod/profile.schema'
 import { type ConnectionTypeType } from '@zod/generated'
+import { useI18n } from 'vue-i18n'
 
 import ConnectionTypeSelector from '@/components/ConnectionTypeSelector.vue'
 import ProfileForm from '@/components/profiles/ProfileForm.vue'
 import ErrorComponent from '@/components/ErrorComponent.vue'
 import DatingProfileForm from '@/components/profiles/DatingProfileForm.vue'
 
-
 const profileStore = useProfileStore()
+const { t } = useI18n()
 
 const state = reactive({
   activeTab: 'friend' as ConnectionTypeType,
   isLoading: false,
-  error: ''
+  error: '',
 })
 
 const { activeTab, isLoading, error } = toRefs(state)
@@ -38,8 +35,7 @@ async function handleProfileFormSubmit(formData: ProfileFormSubmit) {
 
   // map Tag[] to tagId[]
   let tags: string[] = []
-  if (formData.tags && formData.tags.length > 0)
-    tags = formData.tags.map(tag => tag.id)
+  if (formData.tags && formData.tags.length > 0) tags = formData.tags.map((tag) => tag.id)
 
   const payload: UpdateProfilePayload = {
     ...formData,
@@ -53,7 +49,7 @@ async function handleProfileFormSubmit(formData: ProfileFormSubmit) {
       Object.assign(profile, updated)
       state.error = ''
     } else {
-      state.error = 'Failed to update profile.'
+      state.error = t('profile.update_failed')
     }
   } catch (err: any) {
     state.error = err.message || 'An error occurred while updating the profile.'
@@ -67,51 +63,46 @@ onMounted(async () => {
   const fetched = await profileStore.getUserProfile()
   Object.assign(profile, {
     ...fetched,
-    isActive: true
+    isActive: true,
   })
   state.isLoading = false
 })
-
 </script>
 
-
-
-
-
 <template>
-
   <div class="container mb-5 mt-3">
     <div class="row justify-content-center">
-
-      <ConnectionTypeSelector :isDatingActive="!!profile.isDatingActive"
-                              :activeTab="activeTab"
-                              @update:selectTab="activeTab = $event"
-                              @update:isDatingActive="(val: boolean) => profile.isDatingActive = val" />
-
+      <ConnectionTypeSelector
+        :isDatingActive="!!profile.isDatingActive"
+        :activeTab="activeTab"
+        @update:selectTab="activeTab = $event"
+        @update:isDatingActive="(val: boolean) => (profile.isDatingActive = val)"
+      />
 
       <div class="tab-content p-3 border border-top-0">
-        <div v-if="activeTab === 'dating'"
-             class="tab-pane active">
+        <div v-if="activeTab === 'dating'" class="tab-pane active">
           <div class="mt-2">
-            <DatingProfileForm :isLoading="isLoading"
-                               :modelValue="profile"
-                               @update:modelValue="val => Object.assign(profile, val)"
-                               @update:isDatingActive="(val: boolean) => profile.isDatingActive = val"
-                               @submit="handleProfileFormSubmit" />
+            <DatingProfileForm
+              :isLoading="isLoading"
+              :modelValue="profile"
+              @update:modelValue="(val) => Object.assign(profile, val)"
+              @update:isDatingActive="(val: boolean) => (profile.isDatingActive = val)"
+              @submit="handleProfileFormSubmit"
+            />
           </div>
         </div>
-        <div v-if="activeTab === 'friend'"
-             class="tab-pane active">
+        <div v-if="activeTab === 'friend'" class="tab-pane active">
           <div class="mt-4">
-            <ProfileForm :isLoading="isLoading"
-                         :modelValue="profile"
-                         @update:modelValue="val => Object.assign(profile, val)"
-                         @submit="handleProfileFormSubmit" />
+            <ProfileForm
+              :isLoading="isLoading"
+              :modelValue="profile"
+              @update:modelValue="(val) => Object.assign(profile, val)"
+              @submit="handleProfileFormSubmit"
+            />
           </div>
         </div>
       </div>
     </div>
     <ErrorComponent :error="state.error" />
   </div>
-
 </template>

--- a/apps/frontend/src/views/Settings.vue
+++ b/apps/frontend/src/views/Settings.vue
@@ -1,18 +1,19 @@
 <script setup lang="ts">
-import { IconSetting2 } from '@/components/icons/DoodleIcons';
-import LoadingComponent from '@/components/LoadingComponent.vue';
-import LogoutButton from '@/components/nav/LogoutButton.vue';
-import { useAuthStore } from '@/store/authStore';
-import { type LoginUser } from '@zod/user.schema';
-import { onMounted, reactive, ref } from 'vue';
+import { IconSetting2 } from '@/components/icons/DoodleIcons'
+import LoadingComponent from '@/components/LoadingComponent.vue'
+import LogoutButton from '@/components/nav/LogoutButton.vue'
+import { useAuthStore } from '@/store/authStore'
+import { type LoginUser } from '@zod/user.schema'
+import { onMounted, reactive, ref } from 'vue'
 import { useColorMode } from 'bootstrap-vue-next'
-import { useLocalStore } from '@/store/localStore';
-
+import { useLocalStore } from '@/store/localStore'
+import { useI18n } from 'vue-i18n'
 
 const authStore = useAuthStore()
 
 const user = reactive({} as LoginUser)
 const isLoading = ref(true)
+const { t } = useI18n()
 
 const mode = useColorMode({
   selector: 'html',
@@ -29,9 +30,8 @@ const changeColor = () => {
   mode.value = mode.value === 'dark' ? 'light' : 'dark'
 }
 
-
 onMounted(async () => {
-  isLoading.value = true;
+  isLoading.value = true
   const { success, user: fetched, error } = await authStore.fetchUser()
 
   if (success) {
@@ -39,23 +39,22 @@ onMounted(async () => {
   } else {
     console.error('Failed to fetch user:', error)
   }
-  isLoading.value = false;
-});
+  isLoading.value = false
+})
 </script>
 
 <template>
-
   <div class="container mt-4">
     <h3 class="mb-4">
       <IconSetting2 class="svg-icon" />
-      Settings
+      {{ t('nav.settings') }}
     </h3>
 
     <LoadingComponent v-if="isLoading" />
 
     <div class="mb-3">
-      <p v-if="user.email">Email: {{ user.email }}</p>
-      <p v-if="user.phonenumber">Phone number: {{ user.phonenumber }}</p>
+      <p v-if="user.email">{{ t('auth.email') }}: {{ user.email }}</p>
+      <p v-if="user.phonenumber">{{ t('settings.phone_number') }}: {{ user.phonenumber }}</p>
     </div>
 
     <div class="mb-3">
@@ -63,12 +62,8 @@ onMounted(async () => {
     </div>
 
     <div class="mb-3">
-
-
-      <button class="btn btn-secondary"
-              @click="changeColor">
-              
-        Toggle night or day
+      <button class="btn btn-secondary" @click="changeColor">
+        {{ t('settings.toggle_theme') }}
       </button>
     </div>
   </div>

--- a/packages/shared/i18n/en.json
+++ b/packages/shared/i18n/en.json
@@ -90,7 +90,13 @@
     "auth_id_input_placeholder": "+12 34567121 or your@email.com",
     "captcha_input_label": "I am a human being",
     "email": "Email",
-    "password": "Password"
+    "password": "Password",
+    "check_your_messages": "Check your messages",
+    "otp_sms_instruction": "We have sent you a little code to your phone number, please enter it below.",
+    "otp_email_instruction": "We have sent you a login link, check your inbox. If you don't see it, please check your spam folder.",
+    "otp_label": "Login code...",
+    "continue": "Continue",
+    "welcome": "Welcome!"
   },
   "nav": {
     "home": "Home",
@@ -121,6 +127,36 @@
         "title": "Error",
         "message": "An error occurred. Please try again."
       }
-    }
+    },
+    "error": {
+      "title": "Error"
+    },
+    "loading": "Loading..."
+  },
+  "errors": {
+    "unknown": "An unknown error occurred, please try again a bit later.",
+    "unexpected": "An unexpected error occurred.",
+    "browser_storage": "Something is off with this browser. Please try again in a different one (or try clearing your browser storage.)",
+    "missing_code": "Something went wrong here with the code. Try again?",
+    "otp_expired": "Oops, this code has probably expired. Try again?",
+    "confirm_email_failed": "Failed to confirm email."
+  },
+  "messaging": {
+    "title": "Messaging",
+    "conversations": "Convos",
+    "recipient_placeholder": "Recipient user id",
+    "message_placeholder": "Type a message",
+    "send_button": "Send",
+    "users": "Users",
+    "send_message": "Send Message"
+  },
+  "settings": {
+    "phone_number": "Phone number",
+    "toggle_theme": "Toggle night or day"
+  },
+  "profile": {
+    "fetch_error": "Failed to fetch profiles",
+    "add_photo": "Add a photo",
+    "update_failed": "Failed to update profile."
   }
 }


### PR DESCRIPTION
## Summary
- add English i18n strings for auth, messaging, and more
- wire up i18n in several vue components
- replace hard coded labels with translation keys

## Testing
- `pnpm -r test:unit` *(fails: Playwright Test did not expect test() to be called here)*

------
https://chatgpt.com/codex/tasks/task_e_6847848e22388331847937507f5260ce