### PR TITLE
Fix build type declarations

### DIFF
--- a/apps/frontend/src/types/svg.d.ts
+++ b/apps/frontend/src/types/svg.d.ts
@@ -1,0 +1,5 @@
+declare module '*.svg' {
+  import type { FunctionalComponent, SVGAttributes } from 'vue'
+  const src: FunctionalComponent<SVGAttributes>
+  export default src
+}

--- a/apps/frontend/tsconfig.app.json
+++ b/apps/frontend/tsconfig.app.json
@@ -1,7 +1,8 @@
 {
   "extends": "@vue/tsconfig/tsconfig.dom.json",
   "include": [
-    "env.d.ts",
+    "src/types/env.d.ts",
+    "src/types/svg.d.ts",
     "src",
     "src/**/*",
     "src/**/*.vue"

--- a/apps/frontend/tsconfig.vitest.json
+++ b/apps/frontend/tsconfig.vitest.json
@@ -1,6 +1,6 @@
 {
   "extends": "./tsconfig.app.json",
-  "include": ["src/**/__tests__/*", "env.d.ts"],
+  "include": ["src/**/__tests__/*", "src/types/env.d.ts", "src/types/svg.d.ts"],
   "exclude": [],
   "compilerOptions": {
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.vitest.tsbuildinfo",


### PR DESCRIPTION
## Summary
- add svg component type declarations
- include type declaration files in frontend tsconfigs

## Testing
- `pnpm --filter backend generate`
- `cd apps/frontend && pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_684954b1f2cc8331b1ed209e05ed8a0f