### PR TITLE
Add API response types and apply in stores

### DIFF
--- a/apps/backend/src/api/routes/captcha.route.ts
+++ b/apps/backend/src/api/routes/captcha.route.ts
@@ -2,6 +2,7 @@ import { FastifyPluginAsync } from 'fastify'
 import { createChallenge } from 'altcha-lib'
 import { sendError } from '../helpers'
 import { appConfig } from '@shared/config/appconfig'
+import type { CaptchaChallengeResponse } from '@shared/dto/apiResponse.dto'
 
 const captchaRoutes: FastifyPluginAsync = async fastify => {
   fastify.get('/challenge', async (request, reply) => {
@@ -10,7 +11,7 @@ const captchaRoutes: FastifyPluginAsync = async fastify => {
         hmacKey: appConfig.ALTCHA_HMAC_KEY,
         maxNumber: 50_000,
       })
-      return reply.send(challenge)
+      return reply.send<CaptchaChallengeResponse>(challenge)
     } catch (error: any) {
       return sendError(reply, 500, 'Failed to create challenge')
     }

--- a/apps/backend/src/api/routes/city.route.ts
+++ b/apps/backend/src/api/routes/city.route.ts
@@ -1,6 +1,7 @@
 import { FastifyPluginAsync } from 'fastify'
 import { PrismaClient } from '@prisma/client'
 import { CityQuerySchema, CitySchema } from '@zod/city.schema'
+import type { CitySearchResponse } from '@shared/dto/apiResponse.dto'
 
 const prisma = new PrismaClient()
 
@@ -26,7 +27,7 @@ const cityRoutes: FastifyPluginAsync = async fastify => {
 
     // Validate output and send
     const valid = CitySchema.array().parse(cities)
-    return reply.send(valid)
+    return reply.send<CitySearchResponse>(valid)
   })
 }
 

--- a/apps/backend/src/api/routes/messaging.route.ts
+++ b/apps/backend/src/api/routes/messaging.route.ts
@@ -7,6 +7,12 @@ import {
   mapConversationParticipantToSummary,
   mapMessageToMessageInConversation,
 } from '../messaging.mappers'
+import type {
+  MessagesResponse,
+  ConversationsResponse,
+  ConversationResponse,
+  SendMessageResponse,
+} from '@shared/dto/apiResponse.dto'
 
 // Route params for ID lookups
 const IdLookupParamsSchema = z.object({
@@ -50,7 +56,7 @@ const messageRoutes: FastifyPluginAsync = async fastify => {
       // await messageService.markConversationRead(profileId, conversationId)
 
       const messages = raw.map(m => mapMessageToMessageInConversation(m, profileId))
-      return reply.code(200).send({ success: true, messages })
+      return reply.code(200).send<MessagesResponse>({ success: true, messages })
 
     } catch (error) {
       fastify.log.error(error)
@@ -65,7 +71,7 @@ const messageRoutes: FastifyPluginAsync = async fastify => {
     try {
       const raw = await messageService.listConversationsForProfile(profileId)
       const conversations = raw.map(p => mapConversationParticipantToSummary(p, profileId))
-      return reply.code(200).send({ success: true, conversations })
+      return reply.code(200).send<ConversationsResponse>({ success: true, conversations })
     } catch (error) {
       fastify.log.error(error)
       return sendError(reply, 500, 'Failed to fetch conversations')
@@ -87,7 +93,7 @@ const messageRoutes: FastifyPluginAsync = async fastify => {
       const updated = await messageService.getConversationSummary(conversationId, profileId)
       if (!updated) return sendError(reply, 404, 'Conversation not found')
         
-      return reply.code(200).send({ success: true, conversation: mapConversationParticipantToSummary(updated,profileId) })
+      return reply.code(200).send<ConversationResponse>({ success: true, conversation: mapConversationParticipantToSummary(updated, profileId) })
 
     } catch (error) {
       fastify.log.error(error)
@@ -120,7 +126,7 @@ const messageRoutes: FastifyPluginAsync = async fastify => {
     if (!updatedConvo)
       return sendError(reply, 404, 'Conversation not found or could not be created')
 
-    reply.code(200).send({
+    reply.code(200).send<SendMessageResponse>({
       success: true,
       conversation: mapConversationParticipantToSummary(updatedConvo, senderProfileId),
       message: mapMessageToMessageInConversation(message, senderProfileId),

--- a/apps/backend/src/api/routes/tags.route.ts
+++ b/apps/backend/src/api/routes/tags.route.ts
@@ -8,6 +8,7 @@ import {
 import { FastifyPluginAsync } from 'fastify'
 import { sendError } from '../helpers'
 import { TagService } from 'src/services/tag.service'
+import type { TagResponse, TagsResponse } from '@shared/dto/apiResponse.dto'
 
 // debounce duration in milliseconds
 const SEARCH_DEBOUNCE_MS = 300
@@ -26,10 +27,10 @@ const tagsRoutes: FastifyPluginAsync = async fastify => {
       reply.header('Cache-Control', 'no-cache, no-store, must-revalidate')
       reply.header('X-Debounce', SEARCH_DEBOUNCE_MS.toString())
       if (!tags || tags.length === 0) {
-        return reply.code(200).send({ success: true, tags: [] })
+        return reply.code(200).send<TagsResponse>({ success: true, tags: [] })
       }
       const publicTags = tags.map(tag => PublicTagSchema.parse(tag))
-      return reply.code(200).send({ success: true, tags: publicTags })
+      return reply.code(200).send<TagsResponse>({ success: true, tags: publicTags })
     } catch (err) {
       fastify.log.error(err)
       return sendError(reply, 500, 'Failed to search tags')
@@ -59,7 +60,7 @@ const tagsRoutes: FastifyPluginAsync = async fastify => {
           isUserCreated: true, // Mark as user-created
         })
         const tag = PublicTagSchema.parse(created)
-        return reply.code(200).send({ success: true, tag })
+        return reply.code(200).send<TagResponse>({ success: true, tag })
       } catch (err: any) {
         fastify.log.error(err)
         if (err.code === 'P2025') {

--- a/apps/frontend/src/store/authStore.ts
+++ b/apps/frontend/src/store/authStore.ts
@@ -10,6 +10,7 @@ import {
   type AuthIdentifier,
   type SessionData,
 } from '@zod/user.schema'
+import type { OtpLoginResponse, SendLoginLinkResponse, UserMeResponse } from '@shared/dto/apiResponse.dto'
 
 export const useAuthStore = defineStore('auth', {
   state: () => ({
@@ -72,7 +73,7 @@ export const useAuthStore = defineStore('auth', {
         return { success: false, status: 'missing_otp' }
       }
       try {
-        const res = await api.get('/users/otp-login', {
+        const res = await api.get<OtpLoginResponse>('/users/otp-login', {
           params: { userId, otp },
         })
 
@@ -92,7 +93,7 @@ export const useAuthStore = defineStore('auth', {
     async sendLoginLink(authId: AuthIdentifier) {
       // console.log('Sending login link with data:', authId)
       try {
-        const res = await api.post('/users/send-login-link', authId)
+        const res = await api.post<SendLoginLinkResponse>('/users/send-login-link', authId)
         const user = OtpSendReturnSchema.parse(res.data.user)
         // set userId in localStorage for the otplogin to pick up
         localStorage.setItem('uid', user.id)
@@ -106,7 +107,7 @@ export const useAuthStore = defineStore('auth', {
 
     async fetchUser() {
       try {
-        const res = await api.get('/users/me')
+        const res = await api.get<UserMeResponse>('/users/me')
         const user = SettingsUserSchema.parse(res.data.user)
         return { success: true, user, error: null }
       } catch (error: any) {

--- a/apps/frontend/src/store/messageStore.ts
+++ b/apps/frontend/src/store/messageStore.ts
@@ -5,6 +5,12 @@ import { api } from '@/lib/api'
 import { bus } from '@/lib/bus'
 
 import type { ConversationSummary, MessageInConversation } from '@zod/messaging.schema'
+import type {
+  MessagesResponse,
+  ConversationsResponse,
+  ConversationResponse,
+  SendMessageResponse,
+} from '@shared/dto/apiResponse.dto'
 
 
 
@@ -102,7 +108,7 @@ export const useMessageStore = defineStore('message', {
     async fetchMessagesForConversation(conversationId: string): Promise<MessageInConversation[]> {
       try {
         console.log('Fetching messages for conversation:', conversationId)
-        const res = await api.get(`/messages/${conversationId}`)
+        const res = await api.get<MessagesResponse>(`/messages/${conversationId}`)
         console.log('Fetched messages:', res.data)
         if (res.data.success) {
           this.messages = res.data.messages
@@ -117,7 +123,7 @@ export const useMessageStore = defineStore('message', {
 
     async fetchConversations(): Promise<ConversationSummary[]> {
       try {
-        const res = await api.get('/messages/conversations')
+        const res = await api.get<ConversationsResponse>('/messages/conversations')
         if (res.data.success) {
           this.conversations = res.data.conversations
           this.updateUnreadFlag()
@@ -138,7 +144,7 @@ export const useMessageStore = defineStore('message', {
 
     async markAsRead(convoId: string) {
       try {
-        const updateConvo = await api.post(`/messages/conversations/${convoId}/mark-read`)
+        const updateConvo = await api.post<ConversationResponse>(`/messages/conversations/${convoId}/mark-read`)
         if (updateConvo.data.success) {
           const updatedConvo: ConversationSummary = updateConvo.data.conversation
           this.updateConvo(updatedConvo)
@@ -155,7 +161,7 @@ export const useMessageStore = defineStore('message', {
       content: string
     ): Promise<ConversationSummary | null> {
       try {
-        const res = await api.post(`/messages/conversations/${recipientProfileId}`, { content })
+        const res = await api.post<SendMessageResponse>(`/messages/conversations/${recipientProfileId}`, { content })
 
         if (res.data.success) {
           const { conversation, message } = res.data

--- a/apps/frontend/src/store/tagStore.ts
+++ b/apps/frontend/src/store/tagStore.ts
@@ -3,6 +3,7 @@ import { api, axios } from '@/lib/api'
 
 import type { PublicTag, CreateTagInput } from '@zod/tag.schema'
 import type { Tag } from '@zod/generated'
+import type { TagResponse, TagsResponse, ApiError } from '@shared/dto/apiResponse.dto'
 
 interface ServiceError {
   success: false
@@ -25,7 +26,7 @@ export const useTagsStore = defineStore('tags', {
      */
     async fetchAll(): Promise<PublicTag[]> {
       try {
-        const res = await api.get<{ success: true; tags: PublicTag[] }>('/tags')
+        const res = await api.get<TagsResponse>('/tags')
         this.tags = res.data.tags
         return this.tags
       } catch (error: any) {
@@ -39,7 +40,7 @@ export const useTagsStore = defineStore('tags', {
      */
     async searchTags(q: string): Promise<PublicTag[]> {
       try {
-        const res = await api.get<{ success: true; tags: PublicTag[] }>('/tags/search', {
+        const res = await api.get<TagsResponse>('/tags/search', {
           params: { q },
         })
         this.searchResults = res.data.tags
@@ -55,7 +56,7 @@ export const useTagsStore = defineStore('tags', {
      */
     async getTag(id: string): Promise<PublicTag> {
       try {
-        const res = await api.get<{ success: true; tag: PublicTag }>(`/tags/${id}`)
+        const res = await api.get<TagResponse>(`/tags/${id}`)
         this.currentTag = res.data.tag
         return this.currentTag
       } catch (error: any) {
@@ -69,7 +70,7 @@ export const useTagsStore = defineStore('tags', {
      */
     async createTag(input: CreateTagInput): Promise<PublicTag> {
       try {
-        const res = await api.post<{ success: true; tag: PublicTag }>('/tags', input)
+        const res = await api.post<TagResponse>('/tags', input)
         this.tags.push(res.data.tag)
         return res.data.tag
       } catch (error: any) {
@@ -87,7 +88,7 @@ export const useTagsStore = defineStore('tags', {
      */
     async updateTag(id: string, input: Partial<Tag>): Promise<PublicTag> {
       try {
-        const res = await api.patch<{ success: true; tag: PublicTag }>(`/tags/${id}`, input)
+        const res = await api.patch<TagResponse>(`/tags/${id}`, input)
         const idx = this.tags.findIndex(t => t.id === id)
         if (idx !== -1) this.tags.splice(idx, 1, res.data.tag)
         return res.data.tag
@@ -115,7 +116,7 @@ export const useTagsStore = defineStore('tags', {
      */
     async addUserTag(input: CreateTagInput): Promise<PublicTag> {
       try {
-        const res = await api.post<{ success: true; tag: PublicTag }>('/tags/user', input)
+        const res = await api.post<TagResponse>('/tags/user', input)
         return res.data.tag
       } catch (error: any) {
         console.error('Failed to add user tag:', error)

--- a/packages/shared/dto/apiResponse.dto.ts
+++ b/packages/shared/dto/apiResponse.dto.ts
@@ -1,0 +1,39 @@
+export interface ApiError {
+  success: false;
+  message: string;
+  fieldErrors?: Record<string, string[]>;
+}
+
+export type ApiSuccess<T> = { success: true } & T;
+export type ApiResponse<T> = ApiSuccess<T> | ApiError;
+
+// Profile responses
+import type { OwnerProfile, PublicProfile, UpdatedProfileFragment } from '@zod/profile.schema';
+import type { OwnerProfileImage } from '@zod/profileimage.schema';
+import type { PublicTag } from '@zod/tag.schema';
+import type { ConversationSummary, MessageInConversation } from '@zod/messaging.schema';
+import type { SettingsUser, OtpSendReturn } from '@zod/user.schema';
+import type { City } from '@zod/city.schema';
+
+export type GetMyProfileResponse = ApiSuccess<{ profile: OwnerProfile }>;
+export type GetPublicProfileResponse = ApiSuccess<{ profile: PublicProfile }>;
+export type GetProfilesResponse = ApiSuccess<{ profiles: PublicProfile[] }>;
+export type UpdateProfileResponse = ApiSuccess<{ profile: UpdatedProfileFragment }>;
+export type ProfileImagesResponse = ApiSuccess<{ profile: { profileImages: OwnerProfileImage[] } }>;
+
+export type TagsResponse = ApiSuccess<{ tags: PublicTag[] }>;
+export type TagResponse = ApiSuccess<{ tag: PublicTag }>;
+
+export type MessagesResponse = ApiSuccess<{ messages: MessageInConversation[] }>;
+export type ConversationsResponse = ApiSuccess<{ conversations: ConversationSummary[] }>;
+export type ConversationResponse = ApiSuccess<{ conversation: ConversationSummary }>;
+export type SendMessageResponse = ApiSuccess<{ conversation: ConversationSummary; message: MessageInConversation }>;
+
+export type UserMeResponse = ApiSuccess<{ user: SettingsUser }>;
+export type SendLoginLinkResponse = ApiSuccess<{ user: OtpSendReturn; status: string }>;
+export type OtpLoginSuccess = ApiSuccess<{ token: string }>;
+export interface OtpLoginFailure { success: false; status: string }
+export type OtpLoginResponse = OtpLoginSuccess | OtpLoginFailure;
+
+export type CitySearchResponse = City[];
+export type CaptchaChallengeResponse = ApiSuccess<any>; // altcha challenge shape

--- a/packages/shared/index.ts
+++ b/packages/shared/index.ts
@@ -1,6 +1,7 @@
 export * from './dto/user.dto'
 export * from './dto/profile.dto'
 export * from './dto/message.dto'
+export * from './dto/apiResponse.dto'
 export * from './zod/user.schema'
 export * from './zod/profile.schema'
 export * from './zod/profileimage.schema'


### PR DESCRIPTION
## Summary
- create shared API response contracts
- use typed generics in backend routes
- leverage the shared response types in frontend stores for API calls

## Testing
- `pnpm -r test`

------
https://chatgpt.com/codex/tasks/task_e_68495a156f6483319e02a79c7b2e48ec