### PR TITLE
Fix failing tests and add coverage

### DIFF
--- a/apps/backend/src/__tests__/routes/tags.route.spec.ts
+++ b/apps/backend/src/__tests__/routes/tags.route.spec.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import tagsRoutes from '../../api/routes/tags.route'
+import { MockFastify, MockReply } from '../../test-utils/fastify'
+
+let fastify: MockFastify
+let reply: MockReply
+let mockTagService: any
+
+vi.mock('../../services/tag.service', () => ({
+  TagService: { getInstance: () => mockTagService },
+}))
+
+beforeEach(async () => {
+  fastify = new MockFastify()
+  reply = new MockReply()
+  mockTagService = { search: vi.fn(), create: vi.fn() }
+  await tagsRoutes(fastify as any)
+})
+
+describe('GET /search', () => {
+  it('returns mapped tags', async () => {
+    const handler = fastify.routes['GET /search']
+    mockTagService.search.mockResolvedValue([{ id: 'ck1234567890abcd12345678', name: 'Test', slug: 'test', createdBy: 'u1' }])
+    await handler({ query: { q: 'te' }, user: { userId: 'u1' } } as any, reply as any)
+    expect(reply.payload.success).toBe(true)
+    expect(reply.payload.tags[0].name).toBe('Test')
+  })
+})
+
+describe('POST /user', () => {
+  it('creates tag for user', async () => {
+    const handler = fastify.routes['POST /user']
+    mockTagService.create.mockResolvedValue({ id: 'ck1234567890abcd12345679', name: 'Foo', slug: 'foo' })
+    await handler({ user: { userId: 'u1' }, body: { name: 'Foo' } } as any, reply as any)
+    expect(reply.payload.success).toBe(true)
+    expect(mockTagService.create).toHaveBeenCalled()
+  })
+})

--- a/apps/backend/src/__tests__/services/tag.service.spec.ts
+++ b/apps/backend/src/__tests__/services/tag.service.spec.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { createMockPrisma } from '../../test-utils/prisma'
+
+let service: any
+let mockPrisma: any
+
+beforeEach(async () => {
+  vi.resetModules()
+  mockPrisma = createMockPrisma()
+  vi.doMock('../../lib/prisma', () => ({ prisma: mockPrisma }))
+  const module = await import('../../services/tag.service')
+  ;(module.TagService as any).instance = undefined
+  service = module.TagService.getInstance()
+})
+
+describe('TagService', () => {
+  it('searches tags', async () => {
+    mockPrisma.tag.findMany.mockResolvedValue([{ id: 'cksearchtagid1234567890', name: 'foo', slug: 'foo' }])
+    const result = await service.search('foo')
+    expect(mockPrisma.tag.findMany).toHaveBeenCalled()
+    expect(result[0].name).toBe('foo')
+  })
+
+  it('creates a tag', async () => {
+    mockPrisma.tag.create.mockResolvedValue({ id: 'ck1234567890abcd12345670', name: 'Bar', slug: 'bar' })
+    const tag = await service.create({ name: 'Bar', createdBy: 'u1' })
+    expect(tag.slug).toBe('bar')
+    expect(mockPrisma.tag.create).toHaveBeenCalled()
+  })
+})

--- a/apps/backend/src/test-utils/fastify.ts
+++ b/apps/backend/src/test-utils/fastify.ts
@@ -9,17 +9,17 @@ export class MockFastify {
   public log = { error: () => {}, warn: () => {}, info: () => {} }
   public authenticate = (_req: any, _reply: any) => {}
 
-  get(path: string, handler: RouteHandler) {
-    this.routes[`GET ${path}`] = handler
+  get(path: string, opts: any | RouteHandler, handler?: RouteHandler) {
+    this.routes[`GET ${path}`] = (typeof opts === 'function' ? opts : handler) as RouteHandler
   }
-  post(path: string, handler: RouteHandler) {
-    this.routes[`POST ${path}`] = handler
+  post(path: string, opts: any | RouteHandler, handler?: RouteHandler) {
+    this.routes[`POST ${path}`] = (typeof opts === 'function' ? opts : handler) as RouteHandler
   }
-  patch(path: string, handler: RouteHandler) {
-    this.routes[`PATCH ${path}`] = handler
+  patch(path: string, opts: any | RouteHandler, handler?: RouteHandler) {
+    this.routes[`PATCH ${path}`] = (typeof opts === 'function' ? opts : handler) as RouteHandler
   }
-  delete(path: string, handler: RouteHandler) {
-    this.routes[`DELETE ${path}`] = handler
+  delete(path: string, opts: any | RouteHandler, handler?: RouteHandler) {
+    this.routes[`DELETE ${path}`] = (typeof opts === 'function' ? opts : handler) as RouteHandler
   }
   register(_plugin: any, _opts?: any) {
     // no-op for tests
@@ -29,12 +29,17 @@ export class MockFastify {
 export class MockReply {
   statusCode = 200
   payload: any
+  headers: Record<string, string> = {}
   code(status: number) {
     this.statusCode = status
     return this
   }
   send(payload: any) {
     this.payload = payload
+    return this
+  }
+  header(name: string, value: string) {
+    this.headers[name] = value
     return this
   }
 }

--- a/apps/backend/src/test-utils/prisma.ts
+++ b/apps/backend/src/test-utils/prisma.ts
@@ -43,6 +43,12 @@ export function createMockPrisma() {
       findMany: vi.fn(),
       create: vi.fn(),
     },
+    tag: {
+      findMany: vi.fn(),
+      findFirst: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
+    },
     $transaction: vi.fn(fn => fn(this)),
   }
 }

--- a/apps/backend/src/test-utils/redis.ts
+++ b/apps/backend/src/test-utils/redis.ts
@@ -2,20 +2,21 @@ export class MockRedis {
   hashes: Record<string, Record<string, string>> = {}
   sets: Record<string, Set<string>> = {}
   multi() {
+    const self = this
     return {
       hset(key: string, ...args: any[]) {
-        this.hset(key, ...args)
+        self.hset(key, ...args)
         return this
       },
       expire(_key: string, _ttl: number) {
         return this
       },
       sadd(key: string, ...vals: string[]) {
-        this.sadd(key, ...vals)
+        self.sadd(key, ...vals)
         return this
       },
       del(key: string) {
-        this.del(key)
+        self.del(key)
         return this
       },
       exec() {

--- a/apps/frontend/src/components/nav/__tests__/Navbar.spec.ts
+++ b/apps/frontend/src/components/nav/__tests__/Navbar.spec.ts
@@ -2,6 +2,9 @@ import { mount } from '@vue/test-utils'
 import { describe, it, expect, vi } from 'vitest'
 
 vi.mock('vue-i18n', () => ({ useI18n: () => ({ t: (k: string) => k }) }))
+vi.mock('@fortawesome/vue-fontawesome', () => ({
+  FontAwesomeIcon: { template: '<div />' },
+}))
 const push = vi.fn()
 vi.mock('vue-router', () => ({ useRouter: () => ({ push }) }))
 vi.mock('@/components/icons/DoodleIcons', () => ({
@@ -14,6 +17,7 @@ vi.mock('@/components/icons/DoodleIcons', () => ({
 
 const logout = vi.fn()
 vi.mock('@/store/authStore', () => ({ useAuthStore: () => ({ isLoggedIn: true, logout }) }))
+vi.mock('@/store/messageStore', () => ({ useMessageStore: () => ({ hasUnreadMessages: false }) }))
 
 import Navbar from '../Navbar.vue'
 const stub = { template: '<div><slot /></div>' }
@@ -21,7 +25,10 @@ const stub = { template: '<div><slot /></div>' }
 describe('Navbar', () => {
   it('renders when logged in', () => {
     const wrapper = mount(Navbar, {
-      global: { stubs: { BNavbar: stub, BNavItem: stub, BNavbarNav: stub } }
+      global: {
+        stubs: { BNavbar: stub, BNavItem: stub, BNavbarNav: stub, FontAwesomeIcon: stub },
+        mocks: { $t: (msg: string) => msg },
+      }
     })
     expect(wrapper.html()).toContain('nav.onboarding')
     expect(wrapper.html()).toContain('nav.settings')

--- a/apps/frontend/src/setupTests.ts
+++ b/apps/frontend/src/setupTests.ts
@@ -1,0 +1,7 @@
+(globalThis as any).__APP_CONFIG__ = {
+  API_BASE_URL: 'http://localhost',
+  WS_BASE_URL: 'ws://localhost',
+  IMAGE_URL_BASE: 'http://localhost/images',
+  FRONTEND_URL: 'http://localhost',
+  NODE_ENV: 'test',
+}

--- a/apps/frontend/vitest.config.ts
+++ b/apps/frontend/vitest.config.ts
@@ -14,6 +14,7 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
     globals: true,
+    setupFiles: ['./src/setupTests.ts'],
     include: ['src/**/__tests__/**/*.{spec,test}.ts'],
     exclude: ['e2e/**']
   }


### PR DESCRIPTION
## Summary
- fix MockRedis multi wrapper to avoid stack overflow
- support options in MockFastify route helpers and add headers to replies
- add unit test setup for frontend
- mock i18n and FontAwesome in Navbar tests
- add TagService and tags route tests

## Testing
- `pnpm exec vitest run` in apps/backend
- `pnpm exec vitest run` in apps/frontend

------
https://chatgpt.com/codex/tasks/task_e_684a2fd9dc548331b8677b600f7fa00b