### PR TITLE
Add backend service tests

### DIFF
--- a/apps/backend/src/__tests__/api/helpers.spec.ts
+++ b/apps/backend/src/__tests__/api/helpers.spec.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
+vi.mock('@shared/config/appconfig', () => ({ appConfig: { TYPEAHEAD_DEBOUNCE_MS: 300 } }))
 import {
   sendError,
   sendForbiddenError,

--- a/apps/backend/src/__tests__/routes/tags.route.spec.ts
+++ b/apps/backend/src/__tests__/routes/tags.route.spec.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
+vi.mock('@shared/config/appconfig', () => ({ appConfig: { TYPEAHEAD_DEBOUNCE_MS: 300 } }))
 import tagsRoutes from '../../api/routes/tags.route'
 import { MockFastify, MockReply } from '../../test-utils/fastify'
 

--- a/apps/backend/src/__tests__/services/city.service.spec.ts
+++ b/apps/backend/src/__tests__/services/city.service.spec.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { createMockPrisma } from '../../test-utils/prisma'
+
+let service: any
+let mockPrisma: any
+
+beforeEach(async () => {
+  vi.resetModules()
+  mockPrisma = createMockPrisma()
+  vi.doMock('../../lib/prisma', () => ({ prisma: mockPrisma }))
+  const module = await import('../../services/city.service')
+  ;(module.CityService as any).instance = undefined
+  service = module.CityService.getInstance()
+})
+
+describe('CityService.search', () => {
+  it('queries prisma with correct params', async () => {
+    mockPrisma.city.findMany.mockResolvedValue([{ id: 'c1', name: 'Test', country: 'US' }])
+    const res = await service.search('US', 'Tes')
+    expect(mockPrisma.city.findMany).toHaveBeenCalledWith({
+      where: {
+        name: { contains: 'Tes', mode: 'insensitive' },
+        country: { startsWith: 'US', mode: 'insensitive' },
+        isDeleted: false,
+        isApproved: true,
+        isHidden: false,
+      },
+      take: 20,
+      orderBy: { name: 'asc' },
+    })
+    expect(res[0].name).toBe('Test')
+  })
+})
+
+describe('CityService.create', () => {
+  it('creates city with defaults', async () => {
+    mockPrisma.city.create.mockResolvedValue({ id: 'c2', name: 'Foo', country: 'US' })
+    const res = await service.create({ name: 'Foo', country: 'US', createdBy: 'u1' })
+    expect(mockPrisma.city.create).toHaveBeenCalledWith({
+      data: {
+        name: 'Foo',
+        country: 'US',
+        createdBy: 'u1',
+        isApproved: true,
+        isUserCreated: false,
+      },
+    })
+    expect(res.id).toBe('c2')
+  })
+})

--- a/apps/backend/src/__tests__/services/messaging.service.spec.ts
+++ b/apps/backend/src/__tests__/services/messaging.service.spec.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+let service: any
+let mockPrisma: any
+
+beforeEach(async () => {
+  mockPrisma = {}
+  vi.doMock('../../lib/prisma', () => ({ prisma: mockPrisma }))
+  const module = await import('../../services/messaging.service')
+  ;(module.MessageService as any).instance = undefined
+  service = module.MessageService.getInstance()
+})
+
+describe('MessageService.sortProfilePair', () => {
+  it('sorts profiles lexicographically', () => {
+    const [a, b] = service.sortProfilePair('b', 'a')
+    expect(a).toBe('a')
+    expect(b).toBe('b')
+  })
+})
+
+describe('MessageService.canSendMessageInConversation', () => {
+  it('allows when no conversation', () => {
+    expect(service.canSendMessageInConversation(null, 'p1')).toBe(true)
+  })
+
+  it('allows when accepted', () => {
+    const convo: any = { status: 'ACCEPTED', profileAId: 'p1' }
+    expect(service.canSendMessageInConversation(convo, 'p1')).toBe(true)
+  })
+
+  it('allows when initiated by other user', () => {
+    const convo: any = { status: 'INITIATED', profileAId: 'other' }
+    expect(service.canSendMessageInConversation(convo, 'p1')).toBe(true)
+  })
+
+  it('rejects when initiated by sender', () => {
+    const convo: any = { status: 'INITIATED', profileAId: 'p1' }
+    expect(service.canSendMessageInConversation(convo, 'p1')).toBe(false)
+  })
+
+  it('rejects when blocked', () => {
+    const convo: any = { status: 'BLOCKED', profileAId: 'x' }
+    expect(service.canSendMessageInConversation(convo, 'p1')).toBe(false)
+  })
+})
+

--- a/apps/backend/src/test-utils/prisma.ts
+++ b/apps/backend/src/test-utils/prisma.ts
@@ -49,6 +49,12 @@ export function createMockPrisma() {
       create: vi.fn(),
       update: vi.fn(),
     },
+    city: {
+      findMany: vi.fn(),
+      findFirst: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
+    },
     $transaction: vi.fn(fn => fn(this)),
   }
 }


### PR DESCRIPTION
## Summary
- extend prisma mock with city helpers
- mock config in helpers and tag routes tests
- test CityService search and create
- test MessageService helper methods

## Testing
- `pnpm --filter backend exec vitest run --config vitest.config.ts`

------
https://chatgpt.com/codex/tasks/task_e_684f0813a2408331a0404e83133dda93