### PR TITLE
Add missing component tests

### DIFF
--- a/apps/frontend/src/components/__tests__/ErrorOverlay.spec.ts
+++ b/apps/frontend/src/components/__tests__/ErrorOverlay.spec.ts
@@ -1,0 +1,15 @@
+import { mount } from '@vue/test-utils'
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('vue-i18n', () => ({ useI18n: () => ({ t: (k: string) => k }) }))
+vi.mock('@/assets/icons/emojis/confused-emoji.svg', () => ({ default: { template: '<div />' } }))
+
+import ErrorOverlay from '../ErrorOverlay.vue'
+
+describe('ErrorOverlay', () => {
+  it('displays error message', () => {
+    const wrapper = mount(ErrorOverlay, { props: { error: 'Boom' } })
+    expect(wrapper.text()).toContain('uicomponents.error.title')
+    expect(wrapper.text()).toContain('Boom')
+  })
+})

--- a/apps/frontend/src/components/__tests__/LoadingComponent.spec.ts
+++ b/apps/frontend/src/components/__tests__/LoadingComponent.spec.ts
@@ -1,5 +1,7 @@
 import { mount } from '@vue/test-utils'
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('vue-i18n', () => ({ useI18n: () => ({ t: (k: string) => k }) }))
 import LoadingComponent from '../LoadingComponent.vue'
 
 describe('LoadingComponent', () => {

--- a/apps/frontend/src/components/__tests__/ModalDialogComponent.spec.ts
+++ b/apps/frontend/src/components/__tests__/ModalDialogComponent.spec.ts
@@ -1,6 +1,8 @@
 import { mount } from '@vue/test-utils'
 import { describe, it, expect, vi } from 'vitest'
 
+vi.mock('vue-i18n', () => ({ useI18n: () => ({ t: (k: string) => k }) }))
+
 const show = vi.fn()
 const hide = vi.fn()
 

--- a/apps/frontend/src/components/__tests__/SpinnerComponent.spec.ts
+++ b/apps/frontend/src/components/__tests__/SpinnerComponent.spec.ts
@@ -1,0 +1,15 @@
+import { mount } from '@vue/test-utils'
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('vue-i18n', () => ({ useI18n: () => ({ t: (k: string) => k }) }))
+
+import SpinnerComponent from '../SpinnerComponent.vue'
+
+describe('SpinnerComponent', () => {
+  it('passes label to BSpinner', () => {
+    const wrapper = mount(SpinnerComponent, {
+      global: { stubs: { BSpinner: { template: '<div :label="label" />', props: ['label'] } } }
+    })
+    expect(wrapper.html()).toContain('label="uicomponents.spinner.spinning"')
+  })
+})

--- a/apps/frontend/src/components/__tests__/SubmitButtonComponent.spec.ts
+++ b/apps/frontend/src/components/__tests__/SubmitButtonComponent.spec.ts
@@ -1,16 +1,18 @@
 import { mount } from '@vue/test-utils'
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('vue-i18n', () => ({ useI18n: () => ({ t: (k: string) => k }) }))
 import SubmitButtonComponent from '../SubmitButtonComponent.vue'
 
 describe('SubmitButtonComponent', () => {
   it('shows loading text when isLoading', () => {
     const wrapper = mount(SubmitButtonComponent, { props: { isLoading: true } })
-    expect(wrapper.find('button').text()).toContain('Working...')
+    expect(wrapper.find('button').text()).toContain('uicomponents.submitbutton.working')
     expect(wrapper.find('button').attributes('disabled')).toBeDefined()
   })
 
   it('shows Save when not loading', () => {
     const wrapper = mount(SubmitButtonComponent, { props: { isLoading: false } })
-    expect(wrapper.find('button').text()).toBe('Save')
+    expect(wrapper.find('button').text()).toBe('uicomponents.submitbutton.save')
   })
 })

--- a/apps/frontend/src/components/auth/__tests__/AuthIdComponent.spec.ts
+++ b/apps/frontend/src/components/auth/__tests__/AuthIdComponent.spec.ts
@@ -3,6 +3,11 @@ import { describe, it, expect, vi } from 'vitest'
 
 vi.mock('@/components/icons/DoodleIcons.vue', () => ({ default: { template: '<div />' } }))
 vi.mock('@/assets/icons/app/logo.svg', () => ({ default: { template: '<div />' } }))
+vi.mock('@/assets/icons/interface/login.svg', () => ({ default: { template: '<div />' } }))
+vi.mock('@/assets/icons/interface/tick.svg', () => ({ default: { template: '<div />' } }))
+vi.mock('@/assets/icons/interface/mail.svg', () => ({ default: { template: '<div />' } }))
+vi.mock('@/assets/icons/interface/phone.svg', () => ({ default: { template: '<div />' } }))
+vi.mock('../LanguageSelector.vue', () => ({ default: { template: '<div />' } }))
 vi.mock('vue-i18n', () => ({ useI18n: () => ({ t: (k: string) => k }) }))
 const stubFormKit = { template: '<form><slot :state="{ valid: true }" /></form>' }
 const CaptchaWidget = { template: '<div />' }
@@ -15,9 +20,12 @@ describe('AuthIdComponent', () => {
       props: { isLoading: false },
       global: { stubs: { FormKit: stubFormKit, CaptchaWidget } }
     })
-    expect((wrapper.vm as any).validateAuthIdInput({ value: 'bad' })).toBe(false)
-    expect((wrapper.vm as any).validateAuthIdInput({ value: 'test@example.com' })).toBe(true)
-    expect((wrapper.vm as any).validateAuthIdInput({ value: '+12345678901' })).toBe(true)
+    ;(wrapper.vm as any).authIdInput = 'bad'
+    expect((wrapper.vm as any).inputState).toBe(false)
+    ;(wrapper.vm as any).authIdInput = 'test@example.com'
+    expect((wrapper.vm as any).inputState).toBe(true)
+    ;(wrapper.vm as any).authIdInput = '+12345678901'
+    expect((wrapper.vm as any).inputState).toBe(true)
   })
 
   it('emits otp:send with computed identifier', async () => {

--- a/apps/frontend/src/components/auth/__tests__/OtpLoginComponent.spec.ts
+++ b/apps/frontend/src/components/auth/__tests__/OtpLoginComponent.spec.ts
@@ -1,6 +1,10 @@
 import { mount } from '@vue/test-utils'
 import { describe, it, expect, vi } from 'vitest'
 
+vi.mock('vue-i18n', () => ({ useI18n: () => ({ t: (k: string) => k }) }))
+vi.mock('@/assets/icons/interface/message.svg', () => ({ default: { template: '<div />' } }))
+vi.mock('@/assets/icons/interface/mail.svg', () => ({ default: { template: '<div />' } }))
+
 vi.mock('@/components/icons/DoodleIcons.vue', () => ({ default: { template: '<div />' } }))
 
 const stubFormKit = { template: '<form><slot :state="{ valid: true }" /></form>' }
@@ -13,8 +17,10 @@ describe('OtpLoginComponent', () => {
       props: { user: {} as any, isLoading: false },
       global: { stubs: { FormKit: stubFormKit } }
     })
-    expect((wrapper.vm as any).validateOtp({ value: '123456' })).toBe(true)
-    expect((wrapper.vm as any).validateOtp({ value: '12345' })).toBe(false)
+    ;(wrapper.vm as any).otpInput = '123456'
+    expect((wrapper.vm as any).inputState).toBe(true)
+    ;(wrapper.vm as any).otpInput = '12345'
+    expect((wrapper.vm as any).inputState).toBe(false)
   })
 
   it('emits otp:submit with entered value', async () => {

--- a/apps/frontend/src/components/messaging/__tests__/MessagingNav.spec.ts
+++ b/apps/frontend/src/components/messaging/__tests__/MessagingNav.spec.ts
@@ -3,6 +3,8 @@ import { describe, it, expect, vi } from 'vitest'
 
 vi.mock('@/components/icons/DoodleIcons.vue', () => ({ default: { template: '<div />' } }))
 vi.mock('../profiles/image/ProfileThumbnail.vue', () => ({ default: { template: '<div />' } }))
+vi.mock('@/assets/icons/arrows/arrow-single-left.svg', () => ({ default: { template: '<div />' } }))
+vi.mock('@/assets/icons/interface/menu-dots-vert.svg', () => ({ default: { template: '<div />' } }))
 
 import MessagingNav from '../MessagingNav.vue'
 

--- a/apps/frontend/src/components/messaging/__tests__/SendMessageDialog.spec.ts
+++ b/apps/frontend/src/components/messaging/__tests__/SendMessageDialog.spec.ts
@@ -1,11 +1,13 @@
 import { mount } from '@vue/test-utils'
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('vue-i18n', () => ({ useI18n: () => ({ t: (k: string) => k }) }))
 
 import SendMessageDialog from '../SendMessageDialog.vue'
 
 describe('SendMessageDialog', () => {
   it('renders dialog text', () => {
     const wrapper = mount(SendMessageDialog)
-    expect(wrapper.text()).toContain('Send Message')
+    expect(wrapper.text()).toContain('messaging.send_message_heading')
   })
 })

--- a/apps/frontend/src/components/nav/__tests__/LogoutButton.spec.ts
+++ b/apps/frontend/src/components/nav/__tests__/LogoutButton.spec.ts
@@ -1,6 +1,9 @@
 import { mount } from '@vue/test-utils'
 import { describe, it, expect, vi } from 'vitest'
 
+vi.mock('vue-i18n', () => ({ useI18n: () => ({ t: (k: string) => k }) }))
+vi.mock('@/assets/icons/interface/logout.svg', () => ({ default: { template: '<div />' } }))
+
 const logout = vi.fn()
 const push = vi.fn()
 vi.mock('@/store/authStore', () => ({ useAuthStore: () => ({ logout }) }))

--- a/apps/frontend/src/components/nav/__tests__/Navbar.spec.ts
+++ b/apps/frontend/src/components/nav/__tests__/Navbar.spec.ts
@@ -8,10 +8,15 @@ vi.mock('@fortawesome/vue-fontawesome', () => ({
 const push = vi.fn()
 vi.mock('vue-router', () => ({ useRouter: () => ({ push }) }))
 vi.mock('@/components/icons/DoodleIcons.vue', () => ({ default: { template: '<div />' } }))
+vi.mock('@/assets/icons/interface/setting-2.svg', () => ({ default: { template: '<div />' } }))
+vi.mock('@/assets/icons/interface/message.svg', () => ({ default: { template: '<div />' } }))
+vi.mock('@/assets/icons/interface/search.svg', () => ({ default: { template: '<div />' } }))
+vi.mock('@/assets/icons/interface/user.svg', () => ({ default: { template: '<div />' } }))
 
 const logout = vi.fn()
 vi.mock('@/store/authStore', () => ({ useAuthStore: () => ({ isLoggedIn: true, logout }) }))
 vi.mock('@/store/messageStore', () => ({ useMessageStore: () => ({ hasUnreadMessages: false }) }))
+vi.mock('@/store/profileStore', () => ({ useProfileStore: () => ({}) }))
 
 import Navbar from '../Navbar.vue'
 const stub = { template: '<div><slot /></div>' }
@@ -24,7 +29,7 @@ describe('Navbar', () => {
         mocks: { $t: (msg: string) => msg },
       }
     })
-    expect(wrapper.html()).toContain('nav.onboarding')
+    expect(wrapper.html()).toContain('nav.browse')
     expect(wrapper.html()).toContain('nav.settings')
   })
 })

--- a/apps/frontend/src/components/profiles/__tests__/ActionButtons.spec.ts
+++ b/apps/frontend/src/components/profiles/__tests__/ActionButtons.spec.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, vi } from 'vitest'
 
 vi.mock('@/components/icons/DoodleIcons.vue', () => ({ default: { template: '<div />' } }))
 vi.mock('@/components/messaging/SendMessage.vue', () => ({ default: { template: '<div />' } }))
+vi.mock('@/assets/icons/interface/message.svg', () => ({ default: { template: '<div />' } }))
 
 import ActionButtons from '../public/ActionButtons.vue'
 

--- a/apps/frontend/src/components/profiles/__tests__/ImageUpload.spec.ts
+++ b/apps/frontend/src/components/profiles/__tests__/ImageUpload.spec.ts
@@ -1,6 +1,9 @@
 import { mount } from '@vue/test-utils'
 import { describe, it, expect, vi } from 'vitest'
 
+vi.mock('vue-i18n', () => ({ useI18n: () => ({ t: (k: string) => k }) }))
+vi.mock('@/lib/mobile-detect', () => ({ detectMobile: vi.fn().mockReturnValue(false) }))
+
 vi.mock('@/assets/icons/files/avatar-upload.svg', () => ({ default: { template: '<div />' } }))
 vi.mock('@/components/LoadingComponent.vue', () => ({ default: { template: '<div />' } }))
 vi.mock('@/components/ErrorComponent.vue', () => ({ default: { template: '<div />' } }))

--- a/apps/frontend/src/components/profiles/__tests__/IntrotextEditor.spec.ts
+++ b/apps/frontend/src/components/profiles/__tests__/IntrotextEditor.spec.ts
@@ -1,6 +1,8 @@
 import { mount } from '@vue/test-utils'
 import { describe, it, expect, vi } from 'vitest'
 vi.mock('vue-i18n', () => ({ useI18n: () => ({ t: (k: string) => k }) }))
+vi.mock('@/store/i18nStore', () => ({ useI18nStore: () => ({ getLanguage: () => 'en' }) }))
+vi.mock('@/assets/icons/interface/mic-2.svg', () => ({ default: { template: '<div />' } }))
 
 
 

--- a/apps/frontend/src/components/profiles/__tests__/NameInput.spec.ts
+++ b/apps/frontend/src/components/profiles/__tests__/NameInput.spec.ts
@@ -1,5 +1,7 @@
 import { mount } from '@vue/test-utils'
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('vue-i18n', () => ({ useI18n: () => ({ t: (k:string)=>k }) }))
 
 import NameInput from '../forms/PublicNameInput.vue'
 

--- a/apps/frontend/src/components/profiles/__tests__/NoProfileInfoCTAComponent.spec.ts
+++ b/apps/frontend/src/components/profiles/__tests__/NoProfileInfoCTAComponent.spec.ts
@@ -1,6 +1,8 @@
 import { mount } from '@vue/test-utils'
 import { describe, it, expect, vi } from 'vitest'
 
+vi.mock('vue-i18n', () => ({ useI18n: () => ({ t: (k: string) => k }) }))
+
 // 👇 Create a shared spy that survives across scopes
 const push = vi.fn()
 

--- a/apps/frontend/src/components/profiles/__tests__/PublicProfileComponent.spec.ts
+++ b/apps/frontend/src/components/profiles/__tests__/PublicProfileComponent.spec.ts
@@ -8,16 +8,26 @@ vi.mock('../display/LanguageList.vue', () => ({ default: { template: '<div />' }
 vi.mock('../display/TagList.vue', () => ({ default: { template: '<div />' } }))
 vi.mock('../display/LocationLabel.vue', () => ({ default: { template: '<div />' } }))
 vi.mock('../display/DatingIcon.vue', () => ({ default: { template: '<div />' } }))
+vi.mock('../display/GenderPronounLabel.vue', () => ({ default: { template: '<div />' } }))
+vi.mock('../display/RelationshipTags.vue', () => ({ default: { template: '<div />' } }))
+vi.mock('../public/EditField.vue', () => ({ default: { template: '<div />' } }))
+vi.mock('../forms/PublicNameInput.vue', () => ({ default: { template: '<div />' } }))
+vi.mock('../forms/LocationSelector.vue', () => ({ default: { template: '<div />' } }))
+vi.mock('@/components/profiles/forms/LanguageSelector.vue', () => ({ default: { template: '<div />' } }))
+vi.mock('@/components/profiles/forms/TagSelectComponent.vue', () => ({ default: { template: '<div />' } }))
+vi.mock('../forms/IntrotextEditor.vue', () => ({ default: { template: '<div />' } }))
+vi.mock('../image/ImageEditor.vue', () => ({ default: { template: '<div />' } }))
+vi.mock('@/assets/icons/interface/photo.svg', () => ({ default: { template: '<div />' } }))
 vi.mock('vue-i18n', () => ({ useI18n: () => ({ t: (k:string)=>k }) }))
 
 import PublicProfileComponent from '../public/PublicProfileComponent.vue'
 
 describe('PublicProfileComponent', () => {
-  it('computes age from birthday', () => {
+  it('renders profile name', () => {
     const wrapper = mount(PublicProfileComponent, {
-      props: { profile: { birthday: '2000-01-01', isDatingActive: true } as any, isLoading: false },
+      props: { profile: { publicName: 'Alice', languages: [], isDatingActive: true } as any, isLoading: false },
       global: { stubs: { BModal: true, BCarousel: true, BCarouselSlide: true, BButton: true, ProfileThumbnail: { template: '<div />' } } }
     })
-    expect(wrapper.text()).toContain('25')
+    expect(wrapper.text()).toContain('Alice')
   })
 })

--- a/apps/frontend/src/components/profiles/__tests__/TagSelectComponent.spec.ts
+++ b/apps/frontend/src/components/profiles/__tests__/TagSelectComponent.spec.ts
@@ -1,6 +1,8 @@
 import { mount } from '@vue/test-utils'
 import { describe, it, expect, vi } from 'vitest'
 
+vi.mock('vue-i18n', () => ({ useI18n: () => ({ t: (k:string)=>k }) }))
+
 const search = vi.fn().mockResolvedValue([{ id: '1', name: 'vue' }])
 const create = vi.fn().mockResolvedValue({ id: '2', name: 'new' })
 vi.mock('@/store/tagStore', () => ({ useTagsStore: () => ({ search, create }) }))


### PR DESCRIPTION
## Summary
- mock `vue-i18n` and icons in various component tests
- stub Pinia stores in tests that rely on them
- fix outdated assertions for updated components
- add new specs for `ErrorOverlay` and `SpinnerComponent`

## Testing
- `pnpm --filter frontend test:unit --run --silent`

------
https://chatgpt.com/codex/tasks/task_e_6853f2680fec833184cd3ae16ccbb318