### PR TITLE
Increase backend test coverage

### DIFF
--- a/apps/backend/src/__tests__/api/helpers.spec.ts
+++ b/apps/backend/src/__tests__/api/helpers.spec.ts
@@ -5,6 +5,7 @@ import {
   sendForbiddenError,
   sendUnauthorizedError,
   getUserRoles,
+  addDebounceHeaders,
 } from '../../api/helpers'
 import { MockReply } from '../../test-utils/fastify'
 
@@ -37,5 +38,14 @@ describe('getUserRoles', () => {
   it('returns roles from session', () => {
     const req: any = { session: { roles: ['admin'] } }
     expect(getUserRoles(req)).toEqual(['admin'])
+  })
+})
+
+describe('addDebounceHeaders', () => {
+  it('sets cache control and debounce headers', () => {
+    const rep = new MockReply()
+    addDebounceHeaders(rep as any)
+    expect(rep.headers['Cache-Control']).toBe('no-cache, no-store, must-revalidate')
+    expect(rep.headers['X-Debounce']).toBe('300')
   })
 })

--- a/apps/backend/src/__tests__/api/mappers.spec.ts
+++ b/apps/backend/src/__tests__/api/mappers.spec.ts
@@ -1,5 +1,5 @@
 import { vi, describe, it, expect } from 'vitest'
-import { mapProfileImagesToOwner } from '../../api/mappers'
+import { mapProfileImagesToOwner, mapToLocalizedUpserts } from '../../api/mappers'
 vi.mock('@shared/config/appconfig', () => ({ appConfig: { IMAGE_URL_BASE: 'http://img' } }))
 
 const image: any = {
@@ -25,5 +25,14 @@ describe('mappers', () => {
     const res = mapProfileImagesToOwner([image])
     expect(res[0]).toHaveProperty('url')
     expect(res[0].url).toMatch('http://img/path/to/img')
+  })
+
+  it('creates upsert payloads from localized data', () => {
+    const upserts = mapToLocalizedUpserts('p1', {
+      introSocialLocalized: { en: 'hi', fr: 'salut' },
+      introDatingLocalized: { en: 'hey' },
+    })
+    expect(upserts).toContainEqual({ locale: 'en', updates: { introSocial: 'hi', introDating: 'hey' } })
+    expect(upserts).toContainEqual({ locale: 'fr', updates: { introSocial: 'salut' } })
   })
 })

--- a/apps/backend/src/__tests__/api/messaging.mappers.spec.ts
+++ b/apps/backend/src/__tests__/api/messaging.mappers.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest'
-import { mapMessageDTO, mapMessageForMessageList } from '../../api/messaging.mappers'
+import { mapMessageDTO, mapMessageForMessageList, mapConversationParticipantToSummary } from '../../api/messaging.mappers'
 vi.mock('@shared/config/appconfig', () => ({ appConfig: { IMAGE_URL_BASE: 'http://img' } }))
 
 const msg: any = {
@@ -10,9 +10,39 @@ const msg: any = {
   createdAt: new Date(),
 }
 
+const participant: any = {
+  id: 'cp1',
+  profileId: 'p1',
+  conversationId: 'c1',
+  lastReadAt: null,
+  isMuted: false,
+  isArchived: false,
+  conversation: {
+    id: 'c1',
+    updatedAt: new Date(),
+    createdAt: new Date(),
+    participants: [
+      { profileId: 'p1', profile: { id: 'p1', publicName: 'Me', profileImages: [] } },
+      { profileId: 'p2', profile: { id: 'p2', publicName: 'Them', profileImages: [] } },
+    ],
+    messages: [msg],
+  },
+}
+
 describe('messaging mappers', () => {
   it('marks message as mine', () => {
     const m = mapMessageForMessageList(msg, 'p1')
     expect(m.isMine).toBe(true)
+  })
+
+  it('maps participant to conversation summary', () => {
+    const summary = mapConversationParticipantToSummary(participant, 'p1')
+    expect(summary.partnerProfile.publicName).toBe('Them')
+    expect(summary.lastMessage?.isMine).toBe(true)
+  })
+
+  it('maps message dto with sender profile', () => {
+    const dto = mapMessageDTO(msg, participant)
+    expect(dto.sender.publicName).toBe('Me')
   })
 })

--- a/apps/backend/src/__tests__/services/city.service.spec.ts
+++ b/apps/backend/src/__tests__/services/city.service.spec.ts
@@ -48,3 +48,14 @@ describe('CityService.create', () => {
     expect(res.id).toBe('c2')
   })
 })
+
+describe('CityService.update', () => {
+  it('slugifies name when updating', async () => {
+    mockPrisma.city.update.mockResolvedValue({ id: 'c2', name: 'New City', slug: 'new-city' })
+    await service.update('c2', { name: 'New City' } as any)
+    expect(mockPrisma.city.update).toHaveBeenCalledWith({
+      where: { id: 'c2' },
+      data: { name: 'New City', slug: 'new-city' },
+    })
+  })
+})

--- a/apps/backend/src/__tests__/services/tag.service.spec.ts
+++ b/apps/backend/src/__tests__/services/tag.service.spec.ts
@@ -27,4 +27,13 @@ describe('TagService', () => {
     expect(tag.slug).toBe('bar')
     expect(mockPrisma.tag.create).toHaveBeenCalled()
   })
+
+  it('updates slug when name provided', async () => {
+    mockPrisma.tag.update.mockResolvedValue({ id: 't1', name: 'New', slug: 'new' })
+    await service.update('t1', { name: 'New' } as any)
+    expect(mockPrisma.tag.update).toHaveBeenCalledWith({
+      where: { id: 't1' },
+      data: { name: 'New', slug: 'new' },
+    })
+  })
 })

--- a/apps/backend/src/__tests__/services/user.service.spec.ts
+++ b/apps/backend/src/__tests__/services/user.service.spec.ts
@@ -64,3 +64,26 @@ describe('UserService.otpLogin', () => {
     expect(mockPrisma.user.update).toHaveBeenCalled()
   })
 })
+
+describe('UserService.setUserOTP', () => {
+  it('updates existing user', async () => {
+    const user = { id: 'u1', isRegistrationConfirmed: true }
+    mockPrisma.user.findUnique.mockResolvedValue(user)
+    const res = await service.setUserOTP({ email: 'a@a.com' }, '123', 'en')
+    expect(res.user).toBe(user)
+    expect(res.isNewUser).toBe(false)
+    expect(mockPrisma.user.update).toHaveBeenCalledWith({
+      where: { id: 'u1' },
+      data: { loginToken: '123', loginTokenExp: expect.any(Date) },
+    })
+  })
+
+  it('creates new user when missing', async () => {
+    mockPrisma.user.findUnique.mockResolvedValue(null)
+    mockPrisma.user.create.mockResolvedValue({ id: 'new' })
+    const res = await service.setUserOTP({ phonenumber: '+1' }, '999', 'en')
+    expect(res.isNewUser).toBe(true)
+    expect(mockPrisma.user.create).toHaveBeenCalled()
+    expect(res.user.id).toBe('new')
+  })
+})


### PR DESCRIPTION
## Summary
- extend api helper tests to check debounce headers
- exercise localized upsert mapping
- validate conversation summary and message mapping
- add more user service logic tests
- test update methods for city and tag services

## Testing
- `pnpm test --run --silent`

------
https://chatgpt.com/codex/tasks/task_e_68541a8b66c88331827c026393b6d818