### PR TITLE
Add Vue component unit tests

### DIFF
--- a/apps/frontend/src/components/__tests__/AppNotifier.spec.ts
+++ b/apps/frontend/src/components/__tests__/AppNotifier.spec.ts
@@ -1,0 +1,42 @@
+import { mount } from '@vue/test-utils'
+import { describe, it, expect, vi } from 'vitest'
+
+const listeners: Record<string, any> = {}
+const bus = {
+  on: vi.fn((event: string, cb: any) => { listeners[event] = cb }),
+  off: vi.fn(),
+  emit(event: string, payload: any) { listeners[event]?.(payload) }
+}
+vi.mock('@/lib/bus', () => ({ bus }))
+
+const push = vi.fn()
+vi.mock('vue-router', () => ({ useRouter: () => ({ push }) }))
+
+const toast = vi.fn()
+vi.mock('vue-toastification', () => ({ useToast: () => toast }))
+vi.mock('@/components/messaging/MessageReceivedToast.vue', () => ({ default: 'MsgToast' }))
+
+import AppNotifier from '../AppNotifier.vue'
+
+describe('AppNotifier', () => {
+  it('shows toast when message received and handles click', () => {
+    mount(AppNotifier)
+    const message = { id: '1', conversationId: '42' } as any
+    bus.emit('message:received', { message })
+
+    expect(toast).toHaveBeenCalled()
+    const [opts, cfg] = toast.mock.calls[0]
+    expect(opts.component).toBe('MsgToast')
+    expect(opts.props.toastId).toBe('1')
+    const close = vi.fn()
+    cfg.onClick(close)
+    expect(push).toHaveBeenCalledWith({ name: 'Messaging', params: { conversationId: '42' }, force: true })
+    expect(close).toHaveBeenCalled()
+  })
+
+  it('cleans up listener on unmount', () => {
+    const wrapper = mount(AppNotifier)
+    wrapper.unmount()
+    expect(bus.off).toHaveBeenCalled()
+  })
+})

--- a/apps/frontend/src/components/settings/__tests__/LanguageSelectorDropdown.spec.ts
+++ b/apps/frontend/src/components/settings/__tests__/LanguageSelectorDropdown.spec.ts
@@ -1,0 +1,53 @@
+import { mount } from '@vue/test-utils'
+import { describe, it, expect, vi } from 'vitest'
+import { ref, defineComponent } from 'vue'
+
+const store = {
+  currentLanguage: ref('en'),
+  getAvailableLocalesWithLabels: () => [
+    { value: 'en', label: 'English' },
+    { value: 'de', label: 'Deutsch' }
+  ]
+}
+vi.mock('@/store/i18nStore', () => ({ useI18nStore: () => store }))
+vi.mock('@/store/i18nStore.ts', () => ({ useI18nStore: () => store }))
+vi.mock('vue-i18n', () => ({ useI18n: () => ({ t: (k:string) => k }) }))
+
+import LanguageSelectorDropdown from '../LanguageSelectorDropdown.vue'
+
+const SelectStub = defineComponent({
+  props: ['modelValue'],
+  emits: ['update:modelValue'],
+  template:'<select :value="modelValue" @change="onChange($event)"><slot /></select>',
+  setup(_, { emit }) {
+    const onChange = (e: Event) => {
+      const val = (e.target as HTMLSelectElement).value
+      emit('update:modelValue', val)
+      changed.value = val
+    }
+    const changed = ref('')
+    return { onChange, changed }
+  }
+})
+const stubs = {
+  BFormSelect: SelectStub,
+  BFormSelectOption: defineComponent({ props:['value'], template:'<option :value="value"><slot /></option>' })
+}
+
+describe('LanguageSelectorDropdown', () => {
+  it('renders provided locales', () => {
+    const wrapper = mount(LanguageSelectorDropdown, { global: { stubs } })
+    const options = wrapper.findAll('option')
+    expect(options).toHaveLength(2)
+    expect(options[0].text()).toBe('English')
+  })
+
+  it('updates currentLanguage on change', async () => {
+    const wrapper = mount(LanguageSelectorDropdown, { global: { stubs } })
+    const select = wrapper.find('select')
+    select.element.value = 'de'
+    await select.trigger('change')
+    await wrapper.vm.$nextTick()
+    expect(wrapper.findComponent(SelectStub).vm.changed).toBe('de')
+  })
+})

--- a/apps/frontend/src/components/settings/__tests__/PushPermissions.spec.ts
+++ b/apps/frontend/src/components/settings/__tests__/PushPermissions.spec.ts
@@ -1,0 +1,40 @@
+import { mount } from '@vue/test-utils'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('vue-i18n', () => ({ useI18n: () => ({ t: (k:string) => k }) }))
+const post = vi.fn().mockResolvedValue({})
+vi.mock('@/lib/api', () => ({ api: { post } }))
+
+import PushPermissions from '../PushPermissions.vue'
+
+const stubs = { BButton: { template:'<button @click="$emit(\'click\')"><slot /></button>' } }
+
+beforeEach(() => {
+  post.mockClear()
+})
+
+describe('PushPermissions', () => {
+  it('requests permission when clicked', async () => {
+    ;(global as any).Notification = { requestPermission: vi.fn().mockResolvedValue('denied') }
+    const wrapper = mount(PushPermissions, { global: { stubs } })
+    await wrapper.find('button').trigger('click')
+    expect((Notification as any).requestPermission).toHaveBeenCalled()
+    delete (global as any).Notification
+  })
+
+  it('subscribes and posts when granted', async () => {
+    const subscribe = vi.fn().mockResolvedValue('sub')
+    ;(global as any).Notification = { requestPermission: vi.fn().mockResolvedValue('granted') }
+    ;(global as any).navigator = {
+      serviceWorker: { ready: Promise.resolve({ pushManager: { subscribe } }) }
+    }
+    ;(global as any).__APP_CONFIG__.VAPID_PUBLIC_KEY = 'AAAAA'
+    const wrapper = mount(PushPermissions, { global: { stubs } })
+    await wrapper.find('button').trigger('click')
+    await Promise.resolve()
+    expect(subscribe).toHaveBeenCalled()
+    expect(post).toHaveBeenCalledWith('/push/subscription', 'sub')
+    delete (global as any).Notification
+    delete (global as any).navigator
+  })
+})


### PR DESCRIPTION
## Summary
- add AppNotifier tests for bus and toast handling
- test settings components for language selection and push permissions

## Testing
- `CI=1 pnpm --filter frontend exec vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6855f69863e88331a135b443c8aac3ff