### PR TITLE
Fix CI with Postgres service

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,17 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:15
+        env:
+          POSTGRES_DB: app_test
+          POSTGRES_USER: appuser
+          POSTGRES_PASSWORD: secret
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd="pg_isready" --health-interval=10s --health-timeout=5s --health-retries=5
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
@@ -23,6 +34,10 @@ jobs:
         run: pnpm install --frozen-lockfile
       - name: Generate Prisma
         run: pnpm --filter backend exec npx prisma generate
+      - name: Initialize test database
+        run: pnpm --filter backend exec npx prisma db push
+        env:
+          DATABASE_URL: postgresql://appuser:secret@localhost:5432/app_test
       - name: Build frontend
         run: pnpm --filter frontend exec pnpm build
       - name: Backend tests


### PR DESCRIPTION
## Summary
- spin up Postgres in the CI workflow
- initialize database schema before running tests

## Testing
- `pnpm --filter backend exec vitest run` *(fails: Cannot find module '../package.json')*

------
https://chatgpt.com/codex/tasks/task_e_685acd3829988331ba0b8ccbf7410374