### PR TITLE
Fix lint errors in image tests

### DIFF
--- a/apps/frontend/eslint.config.ts
+++ b/apps/frontend/eslint.config.ts
@@ -16,7 +16,7 @@ export default defineConfigWithVueTs(
     files: ['**/*.{ts,mts,tsx,vue}'],
   },
 
-  globalIgnores(['**/dist/**', '**/dist-ssr/**', '**/coverage/**']),
+  globalIgnores(['**/dist/**', '**/dist-ssr/**', '**/dev-dist/**', '**/coverage/**']),
 
   pluginVue.configs['flat/essential'],
   vueTsConfigs.recommended,

--- a/apps/frontend/src/features/images/__tests__/ImageUpload.spec.ts
+++ b/apps/frontend/src/features/images/__tests__/ImageUpload.spec.ts
@@ -15,9 +15,16 @@ import ImageUpload from '../components/ImageUpload.vue'
 describe('ImageUpload', () => {
   it('opens modal and sets preview on file change', async () => {
     const wrapper = mount(ImageUpload, { global: { stubs: { BModal: true, BButton: { template: '<button></button>' }, FormKit: true } } })
-    const file = new File(['a'], 'a.png', { type: 'image/png' })
-    const orig = window.FileReader
-    ;(window as any).FileReader = class { result: string | ArrayBuffer | null = null; onload: any = null; readAsDataURL() { this.result = 'data:'; this.onload && this.onload(); } }
+    const file = new File(['a'], 'a.png', { type: 'image/png' });
+    const orig = window.FileReader;
+    (window as any).FileReader = class {
+      result: string | ArrayBuffer | null = null;
+      onload: any = null;
+      readAsDataURL() {
+        this.result = 'data:';
+        this.onload?.();
+      }
+    };
     await (wrapper.vm as any).handleFileChange({ target: { files: [file] } } as any)
     window.FileReader = orig
     expect((wrapper.vm as any).preview).not.toBeNull()

--- a/apps/frontend/src/features/images/__tests__/UploadButton.spec.ts
+++ b/apps/frontend/src/features/images/__tests__/UploadButton.spec.ts
@@ -5,7 +5,15 @@ import UploadButton from '../components/UploadButton.vue'
 
 describe('UploadButton', () => {
   it('emits file:change on input', async () => {
-    const wrapper = mount(UploadButton, { global: { stubs: { BFormFile: { template: '<input @change=\"$emit(\'change\',$event)\" />' } } } })
+    const wrapper = mount(UploadButton, {
+      global: {
+        stubs: {
+          BFormFile: {
+            template: '<input @change="$emit(\'change\', $event)" />',
+          },
+        },
+      },
+    })
     await wrapper.find('input').trigger('change')
     expect(wrapper.emitted('file:change')).toBeTruthy()
   })


### PR DESCRIPTION
## Summary
- ignore `dev-dist` in eslint config
- clean up tests for image uploads

## Testing
- `pnpm lint`
- `pnpm -r test:unit`


------
https://chatgpt.com/codex/tasks/task_e_685c55d1e66c8331a9f3f8646388aef4