### PR TITLE
Fix frontend linter path

### DIFF
--- a/apps/frontend/eslint.config.js
+++ b/apps/frontend/eslint.config.js
@@ -6,7 +6,7 @@ import { defineConfig } from "eslint/config";
 
 
 export default defineConfig([
-  { ignores: ["dist/**", "node_modules/**"] },
+  { ignores: ["dist/**", "dev-dist/**", "node_modules/**"] },
   { files: ["**/*.{js,mjs,cjs,ts,mts,cts,vue}"], plugins: { js }, extends: ["js/recommended"] },
   { files: ["**/*.{js,mjs,cjs,ts,mts,cts,vue}"], languageOptions: { globals: globals.browser } },
   tseslint.configs.recommended,


### PR DESCRIPTION
## Summary
- ensure ESLint ignores `dev-dist` in the frontend workspace

## Testing
- `cd apps/frontend && pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_685c5969d4f48331be153e3f0742ac42