### PR TITLE
Update pnpm to 10.12.3

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 10.12.1
+          version: 10.12.3
 
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
         with:
-          version: 10.12.1
+          version: 10.12.3
           run_install: false
       - uses: actions/setup-node@v4
         with:

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -99,5 +99,5 @@
     "vue-i18n-extract": "^2.0.7",
     "vue-tsc": "^2.2.8"
   },
-  "packageManager": "pnpm@10.12.1"
+  "packageManager": "pnpm@10.12.3"
 }

--- a/package.json
+++ b/package.json
@@ -26,5 +26,5 @@
   "dependencies": {
     "zod": "^3.24.4"
   },
-  "packageManager": "pnpm@10.12.1"
+  "packageManager": "pnpm@10.12.3"
 }

--- a/packages/shared/config/package.json
+++ b/packages/shared/config/package.json
@@ -9,7 +9,7 @@
   "keywords": [],
   "author": "",
   "license": "ISC",
-  "packageManager": "pnpm@10.12.1",
+  "packageManager": "pnpm@10.12.3",
   "dependencies": {
     "dotenv": "^16.5.0",
     "dotenv-expand": "^12.0.2",


### PR DESCRIPTION
## Summary
- bump pnpm to `10.12.3` in package manifests
- update pnpm version in CI workflows

## Testing
- `pnpm install --frozen-lockfile`
- `pnpm lint`
- `pnpm --filter backend exec vitest run --mode test` *(fails: @prisma/client did not initialize yet)*
- `pnpm --filter frontend exec vitest run`

------
https://chatgpt.com/codex/tasks/task_e_685c83c5deb0833186e782db9778ab7a