### PR TITLE
Increase frontend feature test coverage

### DIFF
--- a/apps/frontend/src/features/auth/__tests__/LocaleSelector.spec.ts
+++ b/apps/frontend/src/features/auth/__tests__/LocaleSelector.spec.ts
@@ -1,0 +1,25 @@
+import { mount } from '@vue/test-utils'
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('vue-i18n', () => ({ useI18n: () => ({ t: (k: string) => k }) }))
+vi.mock('@/store/i18nStore', () => ({
+  useI18nStore: () => ({
+    currentLanguage: 'en',
+    getAvailableLocalesWithLabels: () => [
+      { value: 'en', label: 'English' },
+      { value: 'de', label: 'Deutsch' }
+    ]
+  })
+}))
+
+import LocaleSelector from '../components/LocaleSelector.vue'
+
+describe('LocaleSelector', () => {
+  it('emits selected locale when clicked', async () => {
+    const wrapper = mount(LocaleSelector)
+    const link = wrapper.find('a')
+    expect(link.exists()).toBe(true)
+    await link.trigger('click')
+    expect(wrapper.emitted('language:select')).toEqual([[ 'de' ]])
+  })
+})

--- a/apps/frontend/src/features/auth/__tests__/LoginConfirmComponent.spec.ts
+++ b/apps/frontend/src/features/auth/__tests__/LoginConfirmComponent.spec.ts
@@ -1,0 +1,14 @@
+import { mount } from '@vue/test-utils'
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('vue-i18n', () => ({ useI18n: () => ({ t: (k: string) => k }) }))
+vi.mock('@/assets/icons/interface/sun.svg', () => ({ default: { template: '<div />' } }))
+
+import LoginConfirmComponent from '../components/LoginConfirmComponent.vue'
+
+describe('LoginConfirmComponent', () => {
+  it('renders welcome text', () => {
+    const wrapper = mount(LoginConfirmComponent)
+    expect(wrapper.text()).toContain('auth.login_confirm_welcome')
+  })
+})

--- a/apps/frontend/src/features/browse/__tests__/NoAccessCTA.spec.ts
+++ b/apps/frontend/src/features/browse/__tests__/NoAccessCTA.spec.ts
@@ -1,0 +1,25 @@
+import { mount } from '@vue/test-utils'
+import { describe, it, expect } from 'vitest'
+
+const BButton = { template: '<button @click="$emit(\'click\')"><slot /></button>' }
+
+import NoAccessCTA from '../components/NoAccessCTA.vue'
+
+describe('NoAccessCTA', () => {
+  it('emits edit event when button clicked', async () => {
+    const wrapper = mount(NoAccessCTA, {
+      props: { modelValue: 'dating' },
+      global: { stubs: { BButton } }
+    })
+    await wrapper.find('button').trigger('click')
+    expect(wrapper.emitted('edit:profile')).toBeTruthy()
+  })
+
+  it('shows dating scope message', () => {
+    const wrapper = mount(NoAccessCTA, {
+      props: { modelValue: 'dating' },
+      global: { stubs: { BButton } }
+    })
+    expect(wrapper.text()).toContain('dating profile is currently private')
+  })
+})

--- a/apps/frontend/src/features/browse/__tests__/NoResultsCTA.spec.ts
+++ b/apps/frontend/src/features/browse/__tests__/NoResultsCTA.spec.ts
@@ -1,0 +1,19 @@
+import { vi } from "vitest"
+vi.mock("vue-i18n", () => ({ useI18n: () => ({ t: (k: string) => k }) }))
+import { mount } from '@vue/test-utils'
+import { describe, it, expect } from 'vitest'
+
+const ShareDialog = { template: '<div />' }
+const BButton = { template: '<button @click="$emit(\'click\')"><slot /></button>' }
+const BModal = { props: ['show'], template: '<div class="modal" :data-show="show"><slot /></div>' }
+
+import NoResultsCTA from '../components/NoResultsCTA.vue'
+
+describe('NoResultsCTA', () => {
+  it('opens modal when button clicked', async () => {
+    const wrapper = mount(NoResultsCTA, { global: { stubs: { ShareDialog, BButton, BModal } } })
+    expect(wrapper.find('.modal').attributes('data-show')).toBe('false')
+    await wrapper.find('button').trigger('click')
+    expect(wrapper.find('.modal').attributes('data-show')).toBe('true')
+  })
+})

--- a/apps/frontend/src/features/browse/__tests__/SecondaryNav.spec.ts
+++ b/apps/frontend/src/features/browse/__tests__/SecondaryNav.spec.ts
@@ -1,0 +1,34 @@
+import { mount } from '@vue/test-utils'
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('@/assets/icons/interface/setting.svg', () => ({ default: { template: '<div />' } }))
+
+const ScopeViewToggler = {
+  props: ['modelValue'],
+  emits: ['update:modelValue', 'change'],
+  template: `<div data-testid="toggler" @click="$emit('change', 'social')"></div>`
+}
+
+const BButton = { template: '<button @click="$emit(\'click\')"><slot /></button>' }
+
+import SecondaryNav from '../components/SecondaryNav.vue'
+
+describe('SecondaryNav', () => {
+  it('emits scope change via toggler', async () => {
+    const wrapper = mount(SecondaryNav, {
+      props: { modelValue: 'dating' },
+      global: { stubs: { BButton, ScopeViewToggler } }
+    })
+    await wrapper.find('[data-testid="toggler"]').trigger('click')
+    expect(wrapper.emitted('scope:change')).toEqual([[ 'social' ]])
+  })
+
+  it('emits edit event on prefs button', async () => {
+    const wrapper = mount(SecondaryNav, {
+      props: { modelValue: 'dating' },
+      global: { stubs: { BButton, ScopeViewToggler } }
+    })
+    await wrapper.find('button').trigger('click')
+    expect(wrapper.emitted('edit:datingPrefs')).toBeTruthy()
+  })
+})


### PR DESCRIPTION
## Summary
- add unit tests for more frontend components
  - LocaleSelector
  - LoginConfirmComponent
  - browse components NoAccessCTA, NoResultsCTA and SecondaryNav
- keep parity with existing test suite

## Testing
- `pnpm test:unit -- --run`

------
https://chatgpt.com/codex/tasks/task_e_685c8297cdf083318325614a237fe658