### PR TITLE
Add localized emails

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -39,6 +39,8 @@
     "dotenv": "^16.5.0",
     "fastify": "^5.3.3",
     "fastify-plugin": "^4.5.1",
+    "i18next": "^25.2.1",
+    "i18next-fs-backend": "^2.6.0",
     "ioredis": "^5.6.1",
     "nodemailer": "^7.0.3",
     "otp-generator": "^4.0.1",

--- a/packages/shared/i18n/en.json
+++ b/packages/shared/i18n/en.json
@@ -183,5 +183,15 @@
         "message": "An error occurred. Please try again."
       }
     }
+  },
+  "emails": {
+    "loginLink": {
+      "subject": "Your login link",
+      "html": "<p>Hey there, welcome aboard!</p><h1>{{otp}}</h1><p>Please click this link to jump right in: <a href=\"{{link}}\">Confirm Email</a></p>"
+    },
+    "welcome": {
+      "subject": "Welcome to OpenCupid!",
+      "html": "<p>Hey there, welcome aboard!</p><a href=\"{{link}}\">Go connect with people</a></p>"
+    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,6 +75,12 @@ importers:
       fastify-plugin:
         specifier: ^4.5.1
         version: 4.5.1
+      i18next:
+        specifier: ^25.2.1
+        version: 25.2.1(typescript@5.8.3)
+      i18next-fs-backend:
+        specifier: ^2.6.0
+        version: 2.6.0
       ioredis:
         specifier: ^5.6.1
         version: 5.6.1
@@ -4055,6 +4061,17 @@ packages:
   i18n-iso-countries@7.14.0:
     resolution: {integrity: sha512-nXHJZYtNrfsi1UQbyRqm3Gou431elgLjKl//CYlnBGt5aTWdRPH1PiS2T/p/n8Q8LnqYqzQJik3Q7mkwvLokeg==}
     engines: {node: '>= 12'}
+
+  i18next-fs-backend@2.6.0:
+    resolution: {integrity: sha512-3ZlhNoF9yxnM8pa8bWp5120/Ob6t4lVl1l/tbLmkml/ei3ud8IWySCHt2lrY5xWRlSU5D9IV2sm5bEbGuTqwTw==}
+
+  i18next@25.2.1:
+    resolution: {integrity: sha512-+UoXK5wh+VlE1Zy5p6MjcvctHXAhRwQKCxiJD8noKZzIXmnAX8gdHX5fLPA3MEVxEN4vbZkQFy8N0LyD9tUqPw==}
+    peerDependencies:
+      typescript: ^5
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   iconv-lite@0.4.24:
     resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
@@ -11127,6 +11144,14 @@ snapshots:
   i18n-iso-countries@7.14.0:
     dependencies:
       diacritics: 1.3.0
+
+  i18next-fs-backend@2.6.0: {}
+
+  i18next@25.2.1(typescript@5.8.3):
+    dependencies:
+      '@babel/runtime': 7.27.6
+    optionalDependencies:
+      typescript: 5.8.3
 
   iconv-lite@0.4.24:
     dependencies:


### PR DESCRIPTION
## Summary
- support sending localized emails
- add translations for email content
- include i18next and filesystem backend for translations

## Testing
- `pnpm --filter backend exec vitest run  --mode test`


------
https://chatgpt.com/codex/tasks/task_e_685c91ec132c8331a31f1c4b8bc068bb