### PR TITLE
Refactor profile scopes

### DIFF
--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -72,6 +72,11 @@ enum RelationshipStatus {
   unspecified
 }
 
+enum ProfileScope {
+  social
+  dating
+}
+
 enum UserRole {
   user
   user_dating
@@ -186,8 +191,7 @@ model Profile {
   cityId      String?
   city        City?   @relation(fields: [cityId], references: [id])
 
-  isSocialActive Boolean @default(false)
-  isDatingActive Boolean @default(false)
+  scopes        ProfileScope[] @default([])
   isActive       Boolean @default(false)
   isReported     Boolean @default(false)
   isBlocked      Boolean @default(false)

--- a/apps/backend/src/api/routes/discover.route.ts
+++ b/apps/backend/src/api/routes/discover.route.ts
@@ -15,13 +15,13 @@ const matcherRoutes: FastifyPluginAsync = async fastify => {
 
   fastify.get('/social', { onRequest: [fastify.authenticate] }, async (req, reply) => {
 
-    if (!req.session.hasActiveProfile || !req.session.profile.isSocialActive) return sendForbiddenError(reply)
+    if (!req.session.hasActiveProfile || !req.session.profile.scopes.includes('social')) return sendForbiddenError(reply)
     const myProfileId = req.session.profileId
     const locale = req.session.lang
 
     try {
       const profiles = await matchQueryService.findSocialProfilesFor(myProfileId)
-      const hasDatingPermission = req.session.profile.isDatingActive
+      const hasDatingPermission = req.session.profile.scopes.includes('dating')
       const mappedProfiles = profiles.map(p => mapProfileToPublic(p, hasDatingPermission, locale))
       const response: GetProfilesResponse = { success: true, profiles: mappedProfiles }
       return reply.code(200).send(response)
@@ -34,7 +34,7 @@ const matcherRoutes: FastifyPluginAsync = async fastify => {
 
   fastify.get('/dating', { onRequest: [fastify.authenticate] }, async (req, reply) => {
 
-    if (!req.session.hasActiveProfile || !req.session.profile.isDatingActive) return sendForbiddenError(reply)
+    if (!req.session.hasActiveProfile || !req.session.profile.scopes.includes('dating')) return sendForbiddenError(reply)
     const myProfileId = req.session.profileId
     const locale = req.session.lang
 

--- a/apps/backend/src/services/matchQuery.service.ts
+++ b/apps/backend/src/services/matchQuery.service.ts
@@ -22,7 +22,7 @@ export class MatchQueryService {
     return await prisma.profile.findMany({
       where: {
         isActive: true,
-        isSocialActive: true,
+        scopes: { has: 'social' },
         id: {
           not: profileId,
         },
@@ -38,7 +38,7 @@ export class MatchQueryService {
     const profile = await prisma.profile.findUnique({
       where: { id: profileId },
     })
-    if (!profile || !profile.birthday || !profile.gender || profile.isDatingActive !== true) {
+    if (!profile || !profile.birthday || !profile.gender || !profile.scopes.includes('dating')) {
       return []
     }
 
@@ -47,7 +47,7 @@ export class MatchQueryService {
     const where = {
       id: { not: profile.id },
       ...blocklistWhereClause(profileId),
-      isDatingActive: true,
+      scopes: { has: 'dating' },
       birthday: {
         gte: subtractYears(new Date(), profile.prefAgeMax ?? 99), // oldest acceptable
         lte: subtractYears(new Date(), profile.prefAgeMin ?? 18), // youngest acceptable

--- a/apps/backend/src/services/profile.service.ts
+++ b/apps/backend/src/services/profile.service.ts
@@ -205,11 +205,8 @@ export class ProfileService {
     scopes: UpdateProfileScopePayload,
   ): Promise<DbProfileWithImages | null> {
     const data: Prisma.ProfileUpdateInput = {}
-    if (typeof scopes.isDatingActive === 'boolean') {
-      data.isDatingActive = scopes.isDatingActive
-    }
-    if (typeof scopes.isSocialActive === 'boolean') {
-      data.isSocialActive = scopes.isSocialActive
+    if (Array.isArray(scopes.scopes)) {
+      data.scopes = scopes.scopes as any
     }
 
     try {
@@ -225,8 +222,7 @@ export class ProfileService {
         await tx.user.update({
           where: { id: userId },
           data: {
-            hasActiveProfile:
-              updated.isDatingActive || updated.isSocialActive,
+            hasActiveProfile: Array.isArray(updated.scopes) && updated.scopes.length > 0,
           },
         })
 

--- a/apps/frontend/src/components/profiles/composables/useDatingFields.ts
+++ b/apps/frontend/src/components/profiles/composables/useDatingFields.ts
@@ -12,14 +12,14 @@ export function useDatingFields(profile: Ref<PublicProfileWithContext>, t: (key:
   })
 
   const gender = computed(() => {
-    if (!profile.value.isDatingActive){
+    if (!profile.value.scopes.includes('dating')){
       return ''
     }
     return profile.value.gender
   })
 
   const age = computed(() => {
-    if (!profile.value.isDatingActive || !profile.value.birthday) return null
+    if (!profile.value.scopes.includes('dating') || !profile.value.birthday) return null
     const currentYear = new Date().getFullYear()
     return currentYear - new Date(profile.value.birthday).getFullYear()
   })
@@ -27,19 +27,19 @@ export function useDatingFields(profile: Ref<PublicProfileWithContext>, t: (key:
   const { relationshipStatusLabels, pronounsLabels, hasKidsLabels } = useEnumOptions(t)
 
   const hasKids = computed(() => {
-    if (!profile.value.isDatingActive || profile.value.hasKids === 'unspecified') return ''
+    if (!profile.value.scopes.includes('dating') || profile.value.hasKids === 'unspecified') return ''
     return hasKidsLabels()[profile.value.hasKids!] || profile.value.hasKids
   })
 
   const relationshipStatus = computed(() => {
-    if (!profile.value.isDatingActive) return ''
+    if (!profile.value.scopes.includes('dating')) return ''
     if (!profile.value.relationship || profile.value.relationship === 'unspecified') return ''
 
     return relationshipStatusLabels()[profile.value.relationship] || profile.value.relationship
   })
 
   const pronouns = computed(() => {
-    if (!profile.value.isDatingActive) return ''
+    if (!profile.value.scopes.includes('dating')) return ''
     if (!profile.value.pronouns || profile.value.pronouns === 'unspecified') return ''
 
     return pronounsLabels()[profile.value.pronouns] || profile.value.pronouns

--- a/apps/frontend/src/components/profiles/display/DatingFilter.vue
+++ b/apps/frontend/src/components/profiles/display/DatingFilter.vue
@@ -8,5 +8,5 @@ const props = defineProps<{
 </script>
 
 <template>
-  <slot v-if="props.profile.isDatingActive" />
+  <slot v-if="props.profile.scopes.includes('dating')" />
 </template>

--- a/apps/frontend/src/components/profiles/display/GenderPronounLabel.vue
+++ b/apps/frontend/src/components/profiles/display/GenderPronounLabel.vue
@@ -20,7 +20,7 @@ const { age, gender, pronouns } = useDatingFields(profileRef, t)
 
 <template>
   <div
-    v-if="props.profile.isDatingActive"
+    v-if="props.profile.scopes.includes('dating')"
     class="text-muted dating-field d-flex align-items-center"
   >
     <span class="me-1">{{ age }}</span>

--- a/apps/frontend/src/components/profiles/display/RelationshipTags.vue
+++ b/apps/frontend/src/components/profiles/display/RelationshipTags.vue
@@ -19,7 +19,7 @@ const { relationshipStatus, hasKids } = useDatingFields(profileRef, t)
 
 <template>
   <ul
-    v-if="props.profile.isDatingActive"
+    v-if="props.profile.scopes.includes('dating')"
     class="list-unstyled d-inline-flex flex-wrap align-items-center dating-field"
   >
     <li v-if="props.profile.relationship" class="me-2">

--- a/apps/frontend/src/components/profiles/public/PublicProfileComponent.vue
+++ b/apps/frontend/src/components/profiles/public/PublicProfileComponent.vue
@@ -120,7 +120,7 @@ const emit = defineEmits<{
     </div>
 
     <div class="mb-3">
-      <div class="mb-3 dating-field" v-if="props.profile.isDatingActive">
+      <div class="mb-3 dating-field" v-if="props.profile.scopes.includes('dating')">
         <span class="opacity-25">
           <hr />
         </span>

--- a/apps/frontend/src/features/browse/composables/useFindMatchViewModel.ts
+++ b/apps/frontend/src/features/browse/composables/useFindMatchViewModel.ts
@@ -27,9 +27,9 @@ export function useFindMatchViewModel() {
 
   const haveAccess = computed(() => {
     if (findProfilesStore.currentScope === 'social') {
-      return me.isSocialActive
+      return me.scopes?.includes('social')
     } else if (findProfilesStore.currentScope === 'dating') {
-      return me.isDatingActive
+      return me.scopes?.includes('dating')
     }
     return false
   })

--- a/apps/frontend/src/features/browse/stores/findProfilesStore.ts
+++ b/apps/frontend/src/features/browse/stores/findProfilesStore.ts
@@ -98,10 +98,7 @@ export const useFindProfilesStore = defineStore('findProfiles', {
     async initialize(me: OwnerProfile, defaultScope: ProfileScope | undefined) {
       console.log('Initializing FindMatchViewModel with defaultScope:', defaultScope)
 
-      this.scopes = [
-        ...(me.isSocialActive ? (['social'] as const) : []),
-        ...(me.isDatingActive ? (['dating'] as const) : []),
-      ]
+      this.scopes = [...(me.scopes || [])]
       this.currentScope = defaultScope ?
         defaultScope : this.scopes.length > 0 ? this.scopes[0] : null
 

--- a/apps/frontend/src/features/myprofile/composables/useMyProfile.ts
+++ b/apps/frontend/src/features/myprofile/composables/useMyProfile.ts
@@ -27,7 +27,7 @@ export function useMyProfile(isEditMode: boolean) {
   const profilePreview = computed((): PublicProfileWithContext => {
     return {
       ...publicProfile,
-      isDatingActive: viewState.currentScope === 'dating',
+      scopes: [viewState.currentScope],
     } as PublicProfileWithContext
   })
 
@@ -62,10 +62,10 @@ export function useMyProfile(isEditMode: boolean) {
   }
 
   const updateScopes = async () => {
-    const res = await profileStore.updateProfileScopes({
-      isDatingActive: formData.isDatingActive,
-      isSocialActive: formData.isSocialActive,
-    })
+    const scopes: ProfileScope[] = []
+    if (formData.isDatingActive) scopes.push('dating')
+    if (formData.isSocialActive) scopes.push('social')
+    const res = await profileStore.updateProfileScopes({ scopes })
   }
 
   const updateProfile = async () => {

--- a/apps/frontend/src/features/myprofile/views/MyProfile.vue
+++ b/apps/frontend/src/features/myprofile/views/MyProfile.vue
@@ -37,22 +37,30 @@ const isDatingWizardActive = ref(false)
 
 const toggleDating = async () => {
   // If dating is not onboarded, show the wizard
-  if (!isDatingOnboarded.value && !formData.isDatingActive) {
+  if (!isDatingOnboarded.value && !formData.scopes.includes('dating')) {
     isDatingWizardActive.value = true
     return
   }
-  formData.isDatingActive = !formData.isDatingActive
+  if (formData.scopes.includes('dating')) {
+    formData.scopes = formData.scopes.filter(s => s !== 'dating')
+  } else {
+    formData.scopes.push('dating')
+  }
   await updateScopes()
 }
 
 const toggleSocial = async () => {
-  formData.isSocialActive = !formData.isSocialActive
+  if (formData.scopes.includes('social')) {
+    formData.scopes = formData.scopes.filter(s => s !== 'social')
+  } else {
+    formData.scopes.push('social')
+  }
   await updateScopes()
 }
 
 const handleFinishEdit = async () => {
   const res = await updateProfile()
-  formData.isDatingActive = true
+  if (!formData.scopes.includes('dating')) formData.scopes.push('dating')
   await updateScopes()
   if (res.success) {
     isDatingWizardActive.value = false
@@ -86,14 +94,14 @@ provide('isOwner', true)
                 <span
                   class="btn-social-toggle px-4 py-1 rounded-4 me-2"
                   @click="toggleSocial"
-                  :class="{ active: formData.isSocialActive }"
+                  :class="{ active: formData.scopes.includes('social') }"
                 >
                   <IconSocialize class="svg-icon-lg" />
                 </span>
                 <span
                   class="btn-dating-toggle px-4 py-1 rounded-4"
                   @click="toggleDating"
-                  :class="{ active: formData.isDatingActive }"
+                  :class="{ active: formData.scopes.includes('dating') }"
                 >
                   <IconDate class="svg-icon-lg" />
                 </span>

--- a/apps/frontend/src/features/onboarding/components/DatingWizard.vue
+++ b/apps/frontend/src/features/onboarding/components/DatingWizard.vue
@@ -19,8 +19,7 @@ defineEmits<{
 
 const formData = defineModel<EditFieldProfileFormWithImages>({
   default: () => ({
-    isDatingActive: false,
-    isSocialActive: false,
+    scopes: [],
     birthday: null,
     genderPronouns: null,
     relationshipStatus: null,

--- a/apps/frontend/src/features/onboarding/components/GoalsSelector.vue
+++ b/apps/frontend/src/features/onboarding/components/GoalsSelector.vue
@@ -5,25 +5,29 @@ import { useI18n } from 'vue-i18n'
 
 const { t } = useI18n()
 
+import type { ProfileScope } from '@zod/profile/profile.dto'
+
 type FormData = {
-  isSocialActive: boolean
-  isDatingActive: boolean
+  scopes: ProfileScope[]
 }
 
 // Replace props/emits/watch with defineModel
 const model = defineModel<FormData>({
   default: () => ({
-    isSocialActive: false,
-    isDatingActive: false,
+    scopes: [],
   }),
 })
 
 const toggleSocial = () => {
-  model.value.isSocialActive = !model.value.isSocialActive
+  const scopes = new Set(model.value.scopes)
+  scopes.has('social') ? scopes.delete('social') : scopes.add('social')
+  model.value.scopes = Array.from(scopes)
 }
 
 const toggleDating = () => {
-  model.value.isDatingActive = !model.value.isDatingActive
+  const scopes = new Set(model.value.scopes)
+  scopes.has('dating') ? scopes.delete('dating') : scopes.add('dating')
+  model.value.scopes = Array.from(scopes)
 }
 </script>
 
@@ -31,7 +35,7 @@ const toggleDating = () => {
   <div class="d-flex gap-2 flex-row justify-content-between w-100">
     <div
       class="card btn-social-toggle"
-      :class="{ active: model.isSocialActive }"
+      :class="{ active: model.scopes.includes('social') }"
       @click="toggleSocial"
     >
       <div class="m-4">
@@ -45,7 +49,7 @@ const toggleDating = () => {
           <input
             type="checkbox"
             class="form-check-input"
-            :checked="model.isSocialActive"
+            :checked="model.scopes.includes('social')"
             value="true"
           />
         </div>
@@ -54,7 +58,7 @@ const toggleDating = () => {
 
     <div
       class="card btn-dating-toggle"
-      :class="{ active: model.isDatingActive }"
+      :class="{ active: model.scopes.includes('dating') }"
       @click="toggleDating"
     >
       <div class="m-4">
@@ -68,7 +72,7 @@ const toggleDating = () => {
           <input
             type="checkbox"
             class="form-check-input"
-            :checked="model.isDatingActive"
+            :checked="model.scopes.includes('dating')"
             value="true"
           />
         </div>

--- a/apps/frontend/src/features/onboarding/components/OnboardWizard.vue
+++ b/apps/frontend/src/features/onboarding/components/OnboardWizard.vue
@@ -33,7 +33,7 @@ const { current, isLast, isFirst, goToNext, goToPrevious, goTo, isCurrent } =
 
 const handleNext = () => {
   if (current.value.flags === 'stage_one_end') {
-    if (!formData.value.isDatingActive) {
+    if (!formData.value.scopes.includes('dating')) {
       goTo('confirm')
       emit('finished')
       return

--- a/apps/frontend/src/features/onboarding/composables/useWizardSteps.ts
+++ b/apps/frontend/src/features/onboarding/composables/useWizardSteps.ts
@@ -20,9 +20,7 @@ const imageStore = useImageStore()
       flags: '',
     },
     looking_for: {
-      state: computed(() =>
-        [formData.isDatingActive, formData.isSocialActive].some(t => t) ? true : false
-      ),
+      state: computed(() => formData.scopes.length > 0),
       flags: '',
     },
     interests: {

--- a/apps/frontend/src/features/onboarding/views/Onboarding.vue
+++ b/apps/frontend/src/features/onboarding/views/Onboarding.vue
@@ -37,8 +37,7 @@ const formData = reactive({
   introDating: '',
   introSocialLocalized: {} as Record<string, string>,
   introDatingLocalized: {} as Record<string, string>,
-  isDatingActive: false,
-  isSocialActive: true,
+  scopes: ['social'],
 } as EditProfileForm)
 
 const error = ref('')

--- a/packages/shared/zod/profile/profile.dto.ts
+++ b/packages/shared/zod/profile/profile.dto.ts
@@ -13,29 +13,14 @@ import { PublicProfileImageSchema } from "./profileimage.dto";
 import { LocationSchema } from "@zod/dto/location.dto";
 import { baseFields, socialFields, datingFields, ownerFields } from "./profile.fields";
 
-const PublicScalarsSchema = ProfileSchema.pick({
-  ...baseFields,
-  ...socialFields,
-}).extend({
-  isDatingActive: z.literal(false)
-})
-
-const PublicDatingScalarsSchema = ProfileSchema.pick({
+export const PublicProfileSchema = ProfileSchema.pick({
   ...baseFields,
   ...socialFields,
   ...datingFields,
+  scopes: true,
 }).extend({
-  isDatingActive: z.literal(true)
-})
-
-export const ProfileUnionSchema = z.discriminatedUnion('isDatingActive', [
-  // when isDatingActive = false, use the base
-  PublicScalarsSchema,
-  // when isDatingActive = true, require the dating picks
-  PublicDatingScalarsSchema,
-])
-
-export const PublicProfileSchema = ProfileUnionSchema.and(
+  scopes: z.array(z.enum(['social', 'dating'])).default([]),
+}).and(
   z.object({
     location: LocationSchema,
     profileImages: z.array(PublicProfileImageSchema).default([]),
@@ -46,7 +31,7 @@ export const PublicProfileSchema = ProfileUnionSchema.and(
 );
 export type PublicProfile = z.infer<typeof PublicProfileSchema>;
 
-export const PublicProfileWithContextSchema = ProfileUnionSchema.and(
+export const PublicProfileWithContextSchema = PublicProfileSchema.and(
   z.object({
     location: LocationSchema,
     profileImages: z.array(PublicProfileImageSchema).default([]),
@@ -85,8 +70,7 @@ export type OwnerOrPublicProfile = OwnerProfile | PublicProfileWithContext
 export const editableFields = {
   ...socialFields,
   ...datingFields,
-  isDatingActive: true,
-  isSocialActive: true,
+  scopes: true,
 
 } as const;
 
@@ -125,8 +109,7 @@ export type ProfileScope = z.infer<typeof ProfileScopeSchema>
 
 
 export const UpdateProfileScopeSchemaPayload = z.object({
-  isDatingActive: z.boolean(),
-  isSocialActive: z.boolean(),
+  scopes: z.array(ProfileScopeSchema),
 }).partial()
 
 export type UpdateProfileScopePayload = z.infer<typeof UpdateProfileScopeSchemaPayload>

--- a/packages/shared/zod/profile/profile.fields.ts
+++ b/packages/shared/zod/profile/profile.fields.ts
@@ -20,7 +20,6 @@ export const datingFields = {
 
 
 export const ownerFields = {
-  isDatingActive: true,
-  isSocialActive: true,
+  scopes: true,
   isOnboarded: true,
 } as const;

--- a/packages/shared/zod/user/user.types.ts
+++ b/packages/shared/zod/user/user.types.ts
@@ -5,8 +5,7 @@ import { AuthIdentifierSchema, JwtPayloadSchema } from "./user.dto"
 
 export const SessionProfileSchema = ProfileSchema.pick({
   id: true,
-  isDatingActive: true,
-  isSocialActive: true,
+  scopes: true,
 })
 export type SessionProfile = z.infer<typeof SessionProfileSchema>
 


### PR DESCRIPTION
## Summary
- replace `isSocialActive`/`isDatingActive` with `scopes` enum field in prisma schema
- adjust backend services and routes to work with the scopes array
- refactor several frontend components to use `scopes`
- update shared zod types for the new field

## Testing
- `pnpm --filter backend generate`
- `pnpm --filter backend test` *(fails: MatchQueryService tests)*
- `pnpm --filter frontend test:unit` *(fails: DatingFilter and GoalsSelector tests)*

------
https://chatgpt.com/codex/tasks/task_e_685ec904af708331bb05a1782ca482e7