### PR TITLE
Update pnpm to 10.12.4

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 10.12.3
+          version: 10.12.4
 
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
         with:
-          version: 10.12.3
+          version: 10.12.4
           run_install: false
       - uses: actions/setup-node@v4
         with:

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -101,5 +101,5 @@
     "vue-i18n-extract": "^2.0.7",
     "vue-tsc": "^2.2.8"
   },
-  "packageManager": "pnpm@10.12.3"
+  "packageManager": "pnpm@10.12.4"
 }

--- a/package.json
+++ b/package.json
@@ -26,5 +26,5 @@
   "dependencies": {
     "zod": "^3.24.4"
   },
-  "packageManager": "pnpm@10.12.3"
+  "packageManager": "pnpm@10.12.4"
 }


### PR DESCRIPTION
## Summary
- update pnpm version references in root and frontend package.json files
- update CI workflows to use pnpm 10.12.4

## Testing
- `pnpm lint`
- `pnpm --filter backend exec vitest run --mode test`
- `pnpm --filter frontend exec vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68606d32d4ec8331a7ceee2f043c6905