### PR TITLE
Increase backend test coverage

### DIFF
--- a/apps/backend/src/__tests__/routes/city.route.spec.ts
+++ b/apps/backend/src/__tests__/routes/city.route.spec.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+vi.mock('@shared/config/appconfig', () => ({ appConfig: { TYPEAHEAD_DEBOUNCE_MS: 300 } }))
+import citiesRoutes from '../../api/routes/city.route'
+import { MockFastify, MockReply } from '../../test-utils/fastify'
+
+let fastify: MockFastify
+let reply: MockReply
+let mockCityService: any
+
+vi.mock('../../services/city.service', () => ({
+  CityService: { getInstance: () => mockCityService },
+}))
+
+beforeEach(async () => {
+  fastify = new MockFastify()
+  reply = new MockReply()
+  mockCityService = { search: vi.fn(), findById: vi.fn(), create: vi.fn() }
+  await citiesRoutes(fastify as any, {})
+})
+
+describe('GET /search', () => {
+  it('returns mapped cities and sets debounce headers', async () => {
+    const handler = fastify.routes['GET /search']
+    mockCityService.search.mockResolvedValue([{ id: 'ckcity1234567890abcd123456', name: 'Test', country: 'US' }])
+    await handler({ query: { q: 'Te', country: 'US' }, user: { userId: 'u1' } } as any, reply as any)
+    expect(reply.headers['X-Debounce']).toBe('300')
+    expect(reply.payload.success).toBe(true)
+    expect(reply.payload.cities[0].name).toBe('Test')
+  })
+
+  it('returns empty list when no cities found', async () => {
+    const handler = fastify.routes['GET /search']
+    mockCityService.search.mockResolvedValue([])
+    await handler({ query: { q: 'zz', country: 'US' }, user: { userId: 'u1' } } as any, reply as any)
+    expect(reply.payload.success).toBe(true)
+    expect(reply.payload.cities).toEqual([])
+  })
+})
+
+describe('POST /', () => {
+  it('creates city for user', async () => {
+    const handler = fastify.routes['POST /']
+    mockCityService.create.mockResolvedValue({ id: 'ckcity234567890abcd123457', name: 'Foo', country: 'US' })
+    await handler({ user: { userId: 'u1' }, body: { name: 'Foo', country: 'US' } } as any, reply as any)
+    expect(mockCityService.create).toHaveBeenCalledWith({ name: 'Foo', country: 'US', createdBy: 'u1', isUserCreated: true })
+    expect(reply.payload.success).toBe(true)
+  })
+})

--- a/apps/backend/src/__tests__/routes/push.route.spec.ts
+++ b/apps/backend/src/__tests__/routes/push.route.spec.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import pushRoutes from '../../api/routes/push.routes'
+import { MockFastify, MockReply } from '../../test-utils/fastify'
+
+let fastify: MockFastify
+let reply: MockReply
+let upsert: any
+
+beforeEach(async () => {
+  fastify = new MockFastify()
+  reply = new MockReply()
+  upsert = vi.fn()
+  fastify.prisma = { pushSubscription: { upsert } } as any
+  await pushRoutes(fastify as any, {})
+})
+
+describe('POST /subscription', () => {
+  it('stores subscription and returns result', async () => {
+    const handler = fastify.routes['POST /subscription']
+    upsert.mockResolvedValue({ id: 'sub1' })
+    await handler({
+      body: { endpoint: 'e', keys: { p256dh: 'p', auth: 'a' } },
+      headers: { 'user-agent': 'UA' },
+      user: { userId: 'u1' }
+    } as any, reply as any)
+    expect(upsert).toHaveBeenCalledWith({
+      where: { endpoint: 'e' },
+      update: { endpoint: 'e', p256dh: 'p', auth: 'a', userId: 'u1', lastSeen: expect.any(Date) },
+      create: { endpoint: 'e', p256dh: 'p', auth: 'a', userId: 'u1', deviceInfo: 'UA' }
+    })
+    expect(reply.statusCode).toBe(200)
+    expect(reply.payload.success).toBe(true)
+    expect(reply.payload.updated.id).toBe('sub1')
+  })
+})

--- a/apps/backend/src/__tests__/services/city.service.spec.ts
+++ b/apps/backend/src/__tests__/services/city.service.spec.ts
@@ -59,3 +59,13 @@ describe('CityService.update', () => {
     })
   })
 })
+
+describe('CityService.remove', () => {
+  it('soft deletes the city', async () => {
+    await service.remove('c3')
+    expect(mockPrisma.city.update).toHaveBeenCalledWith({
+      where: { id: 'c3' },
+      data: { isDeleted: true },
+    })
+  })
+})

--- a/apps/backend/src/__tests__/services/messaging.service.spec.ts
+++ b/apps/backend/src/__tests__/services/messaging.service.spec.ts
@@ -83,3 +83,15 @@ describe('MessageService.markConversationRead', () => {
     })
   })
 })
+
+describe('MessageService.listConversationsForProfile', () => {
+  it('queries prisma with correct filters', async () => {
+    mockPrisma.conversationParticipant.findMany.mockResolvedValue([])
+    await service.listConversationsForProfile('p1')
+    const args = mockPrisma.conversationParticipant.findMany.mock.calls[0][0]
+    expect(args.where.profileId).toBe('p1')
+    expect(args.orderBy).toEqual({ conversation: { updatedAt: 'desc' } })
+    // ensure blocklist filters applied
+    expect(args.where.conversation.participants.some.profile.blockedProfiles.none.id).toBe('p1')
+  })
+})


### PR DESCRIPTION
## Summary
- cover city routes with basic GET/POST tests
- add push subscription route tests
- extend city service tests for remove
- extend messaging service tests for conversation listing

## Testing
- `pnpm --filter backend test`

------
https://chatgpt.com/codex/tasks/task_e_68606d686d4c8331b25c2f3e4c7d3138