### PR TITLE
Add missing unit tests for features

### DIFF
--- a/apps/frontend/src/features/datinginteraction/__tests__/InteractionButtons.spec.ts
+++ b/apps/frontend/src/features/datinginteraction/__tests__/InteractionButtons.spec.ts
@@ -1,0 +1,41 @@
+import { mount } from '@vue/test-utils'
+import { describe, it, expect, vi } from 'vitest'
+import InteractionButtons from '../components/InteractionButtons.vue'
+
+vi.mock('@/assets/icons/interface/heart.svg', () => ({ default: { template: '<div />' } }))
+vi.mock('@/assets/icons/interface/cross.svg', () => ({ default: { template: '<div />' } }))
+vi.mock('@/assets/icons/interface/message.svg', () => ({ default: { template: '<div />' } }))
+
+const BButton = {
+  template: `<button @click="$emit('click')" :disabled="disabled"><slot /></button>`,
+  props: ['disabled']
+}
+
+describe('InteractionButtons', () => {
+  it('emits events when buttons clicked', async () => {
+    const wrapper = mount(InteractionButtons, {
+      props: { canLike: true, canPass: true },
+      global: { stubs: { BButton } }
+    })
+
+    const buttons = wrapper.findAll('button')
+    await buttons[0].trigger('click')
+    await buttons[1].trigger('click')
+    await buttons[2].trigger('click')
+
+    expect(wrapper.emitted('pass')).toBeTruthy()
+    expect(wrapper.emitted('message')).toBeTruthy()
+    expect(wrapper.emitted('like')).toBeTruthy()
+  })
+
+  it('disables like and pass buttons based on props', () => {
+    const wrapper = mount(InteractionButtons, {
+      props: { canLike: false, canPass: false },
+      global: { stubs: { BButton } }
+    })
+
+    const buttons = wrapper.findAll('button')
+    expect(buttons[0].attributes('disabled')).toBeDefined()
+    expect(buttons[2].attributes('disabled')).toBeDefined()
+  })
+})

--- a/apps/frontend/src/features/images/__tests__/ProfileImage.spec.ts
+++ b/apps/frontend/src/features/images/__tests__/ProfileImage.spec.ts
@@ -1,0 +1,29 @@
+import { mount } from '@vue/test-utils'
+import { describe, it, expect } from 'vitest'
+import ProfileImage from '../components/ProfileImage.vue'
+
+const ImageTag = {
+  props: ['image', 'className'],
+  template: '<div class="image-tag">{{ image.url }}</div>'
+}
+
+describe('ProfileImage', () => {
+  it('renders first image from profile', () => {
+    const profile = { profileImages: [{ url: '/one.jpg' }] }
+    const wrapper = mount(ProfileImage, {
+      props: { profile },
+      global: { stubs: { ImageTag } }
+    })
+    expect(wrapper.find('.image-tag').text()).toContain('/one.jpg')
+  })
+
+  it('updates when profile prop changes', async () => {
+    const profile = { profileImages: [{ url: '/one.jpg' }] }
+    const wrapper = mount(ProfileImage, {
+      props: { profile },
+      global: { stubs: { ImageTag } }
+    })
+    await wrapper.setProps({ profile: { profileImages: [{ url: '/two.jpg' }] } })
+    expect(wrapper.find('.image-tag').text()).toContain('/two.jpg')
+  })
+})


### PR DESCRIPTION
## Summary
- add `InteractionButtons` tests
- cover `ProfileImage` component

## Testing
- `pnpm test:unit -- --run`

------
https://chatgpt.com/codex/tasks/task_e_68606d1ed29c8331828855fa15249478