### PR TITLE
Fix duplicate apiResponse imports

### DIFF
--- a/apps/backend/src/api/routes/captcha.route.ts
+++ b/apps/backend/src/api/routes/captcha.route.ts
@@ -2,7 +2,7 @@ import { FastifyPluginAsync } from 'fastify'
 import { createChallenge } from 'altcha-lib'
 import { sendError } from '../helpers'
 import { appConfig } from '@/lib/appconfig'
-import type { CaptchaChallengeResponse } from '@shared/dto/apiResponse.dto'
+import type { CaptchaChallengeResponse } from '@zod/apiResponse.dto'
 
 const captchaRoutes: FastifyPluginAsync = async fastify => {
   fastify.get('/challenge', async (request, reply) => {

--- a/apps/backend/src/api/routes/city.route.ts
+++ b/apps/backend/src/api/routes/city.route.ts
@@ -9,7 +9,7 @@ import {
 import { FastifyPluginAsync } from 'fastify'
 import { sendError, addDebounceHeaders } from '../helpers'
 import { CityService } from 'src/services/city.service'
-import type { CityResponse, CitiesResponse } from '@shared/dto/apiResponse.dto'
+import type { CityResponse, CitiesResponse } from '@zod/apiResponse.dto'
 
 
 

--- a/apps/backend/src/api/routes/messaging.route.ts
+++ b/apps/backend/src/api/routes/messaging.route.ts
@@ -15,7 +15,7 @@ import type {
   ConversationsResponse,
   ConversationResponse,
   SendMessageResponse,
-} from '@shared/dto/apiResponse.dto'
+} from '@zod/apiResponse.dto'
 import { broadcastToProfile } from '@/utils/wsUtils'
 import { SendMessagePayloadSchema } from '@zod/messaging/messaging.dto'
 

--- a/apps/backend/src/api/routes/tags.route.ts
+++ b/apps/backend/src/api/routes/tags.route.ts
@@ -8,7 +8,7 @@ import {
 import { FastifyPluginAsync } from 'fastify'
 import { sendError, addDebounceHeaders, rateLimitConfig } from '../helpers'
 import { TagService } from 'src/services/tag.service'
-import type { TagResponse, TagsResponse } from '@shared/dto/apiResponse.dto'
+import type { TagResponse, TagsResponse } from '@zod/apiResponse.dto'
 import { DbTagToPublicTagTransform } from '../mappers/tag.mappers'
 
 const tagsRoutes: FastifyPluginAsync = async fastify => {

--- a/apps/backend/src/api/routes/user.route.ts
+++ b/apps/backend/src/api/routes/user.route.ts
@@ -10,7 +10,7 @@ import { CaptchaService } from '@/services/captcha.service'
 import { appConfig } from '@/lib/appconfig'
 
 import { AuthIdentifierCaptchaInput, AuthIdentifierCaptchaInputSchema, OtpLoginInputSchema, OtpSendReturn } from '@zod/user/user.dto'
-import type { OtpLoginResponse, SendLoginLinkResponse, UserMeResponse } from '@shared/dto/apiResponse.dto'
+import type { OtpLoginResponse, SendLoginLinkResponse, UserMeResponse } from '@zod/apiResponse.dto'
 import { AuthIdentifier, JwtPayload } from '@zod/user/user.types'
 import { User } from '@zod/generated'
 

--- a/apps/backend/src/services/profile.service.ts
+++ b/apps/backend/src/services/profile.service.ts
@@ -1,4 +1,3 @@
-import cuid from 'cuid'
 import { prisma } from '@/lib/prisma'
 import { Prisma } from '@prisma/client'
 

--- a/apps/frontend/src/features/app/stores/appStore.ts
+++ b/apps/frontend/src/features/app/stores/appStore.ts
@@ -1,7 +1,7 @@
 import { defineStore } from 'pinia'
 import { api } from '@/lib/api'
 import { LocationSchema, type LocationDTO } from '@zod/dto/location.dto'
-import type { LocationResponse } from '@shared/dto/apiResponse.dto'
+import type { LocationResponse } from '@zod/apiResponse.dto'
 import { storeSuccess, storeError, type StoreResponse } from '@/store/helpers'
 
 export const useAppStore = defineStore('app', {

--- a/apps/frontend/src/features/auth/stores/authStore.ts
+++ b/apps/frontend/src/features/auth/stores/authStore.ts
@@ -12,7 +12,7 @@ import {
 
 import type { AuthIdentifier, JwtPayload, SessionData } from '@zod/user/user.types'
 
-import type { ApiError, ApiSuccess, OtpLoginResponse, SendLoginLinkResponse, UserMeResponse } from '@shared/dto/apiResponse.dto'
+import type { ApiError, ApiSuccess, OtpLoginResponse, SendLoginLinkResponse, UserMeResponse } from '@zod/apiResponse.dto'
 import { AuthErrorCodes } from '@zod/user/auth.dto'
 
 type SuccessResponse<T> = { success: true } & T

--- a/apps/frontend/src/features/browse/stores/findProfileStore.ts
+++ b/apps/frontend/src/features/browse/stores/findProfileStore.ts
@@ -8,7 +8,7 @@ import {
 } from '@zod/profile/profile.dto'
 import type {
   GetProfilesResponse,
-} from '@shared/dto/apiResponse.dto'
+} from '@zod/apiResponse.dto'
 import {
   storeSuccess,
   storeError,

--- a/apps/frontend/src/features/images/stores/imageStore.ts
+++ b/apps/frontend/src/features/images/stores/imageStore.ts
@@ -1,7 +1,7 @@
 import z from 'zod'
 import { defineStore } from 'pinia'
 import { api, axios } from '@/lib/api'
-import type { ApiError, ApiSuccess } from '@shared/dto/apiResponse.dto'
+import type { ApiError, ApiSuccess } from '@zod/apiResponse.dto'
 import { type ImageApiResponse, ImageApiResponseSchema, type OwnerProfileImage, type ProfileImagePosition } from '@zod/profile/profileimage.dto'
 import { bus } from '@/lib/bus'
 

--- a/apps/frontend/src/features/messaging/stores/messageStore.ts
+++ b/apps/frontend/src/features/messaging/stores/messageStore.ts
@@ -14,7 +14,7 @@ import type {
   ConversationsResponse,
   ConversationResponse,
   SendMessageResponse,
-} from '@shared/dto/apiResponse.dto'
+} from '@zod/apiResponse.dto'
 import { storeError, type StoreError, type StoreResponse, storeSuccess } from '@/store/helpers'
 
 

--- a/apps/frontend/src/features/myprofile/stores/ownerProfileStore.ts
+++ b/apps/frontend/src/features/myprofile/stores/ownerProfileStore.ts
@@ -19,7 +19,7 @@ import type {
   GetPublicProfileResponse,
   UpdateDatingPreferencesResponse,
   UpdateProfileResponse,
-} from '@shared/dto/apiResponse.dto'
+} from '@zod/apiResponse.dto'
 import {
   storeSuccess,
   storeError,
@@ -33,19 +33,19 @@ import { type DatingPreferencesDTO, DatingPreferencesDTOSchema } from '@zod/matc
 export type PublicProfileResponse = StoreResponse<PublicProfileWithContext> | StoreError
 
 interface ProfileStoreState {
-  profile: OwnerProfile | null // Current user's profile
-  datingPrefs: DatingPreferencesDTO | null, // Current user's dating preferences  
-  scopes: ProfileScope[], // Available scopes based on user profile
-  isLoading: boolean // Loading state
-  error: StoreError | null // Error state
+  profile: OwnerProfile | null
+  datingPrefs: DatingPreferencesDTO | null,
+  scopes: ProfileScope[],
+  isLoading: boolean
+  error: StoreError | null
 }
 
 export const useOwnerProfileStore = defineStore('ownerProfile', {
   state: (): ProfileStoreState => ({
-    profile: null as OwnerProfile | null,// Current user's profile
-    datingPrefs: null, // Current user's dating preferences  
-    scopes: [], // Available scopes based on user profile
-    isLoading: false, // Loading state
+    profile: null as OwnerProfile | null,
+    datingPrefs: null,
+    scopes: [],
+    isLoading: false,
     error: null
   }),
 

--- a/apps/frontend/src/router/index.ts
+++ b/apps/frontend/src/router/index.ts
@@ -8,7 +8,6 @@ import MessagingView from '@/features/messaging/views/Messaging.vue'
 import UserHome from '@/views/UserHome.vue'
 import Settings from '@/features/settings/views/Settings.vue'
 import MyProfile from '@/features/myprofile/views/MyProfile.vue'
-import PublicProfile from '@/features/publicprofile/views/PublicProfile.vue'
 import BrowseProfiles from '@/features/browse/views/BrowseProfiles.vue'
 import OnboardingView from '@/features/onboarding/views/Onboarding.vue'
 

--- a/apps/frontend/src/store/cityStore.ts
+++ b/apps/frontend/src/store/cityStore.ts
@@ -1,6 +1,6 @@
 // import { createEntityStore } from './entityStore'
 // import type { PublicCity, CreateCityInput } from '@zod/dto/city.dto'
-// import type { CityResponse, CitiesResponse } from '@shared/dto/apiResponse.dto'
+// import type { CityResponse, CitiesResponse } from '@zod/apiResponse.dto'
 
 // export const useCitiesStore = createEntityStore<PublicCity, CreateCityInput>({
 //   name: 'cities',
@@ -21,7 +21,7 @@ import { api, axios } from '@/lib/api'
 
 import type { PublicCity, CreateCityPayload } from '@zod/dto/city.dto'
 import type { City } from '@zod/generated'
-import type { CityResponse, CitiesResponse, ApiError } from '@shared/dto/apiResponse.dto'
+import type { CityResponse, CitiesResponse, ApiError } from '@zod/apiResponse.dto'
 
 interface ServiceError {
   success: false

--- a/apps/frontend/src/store/helpers.ts
+++ b/apps/frontend/src/store/helpers.ts
@@ -1,4 +1,4 @@
-import { type ApiError } from '@shared/dto/apiResponse.dto'
+import { type ApiError } from '@zod/apiResponse.dto'
 import { AxiosError } from 'axios'
 import { ZodError } from 'zod'
 import { useToast } from 'vue-toastification'

--- a/apps/frontend/src/store/tagStore.ts
+++ b/apps/frontend/src/store/tagStore.ts
@@ -1,6 +1,6 @@
 // import { createEntityStore } from './entityStore'
 // import type { PublicTag, CreateTagInput } from '@zod/dto/tag.dto'
-// import type { TagResponse, TagsResponse } from '@shared/dto/apiResponse.dto'
+// import type { TagResponse, TagsResponse } from '@zod/apiResponse.dto'
 
 // export const useTagsStore = createEntityStore<PublicTag, CreateTagInput>({
 //   name: 'tags',
@@ -21,7 +21,7 @@ import { api, axios } from '@/lib/api'
 
 import type { PublicTag, CreateTagInput, CreateTagPayload } from '@zod/tag/tag.dto'
 import type { Tag } from '@zod/generated'
-import type { TagResponse, TagsResponse, ApiError } from '@shared/dto/apiResponse.dto'
+import type { TagResponse, TagsResponse, ApiError } from '@zod/apiResponse.dto'
 
 interface ServiceError {
   success: false


### PR DESCRIPTION
Replace all instances of the duplicate `apiResponse` imports from `@shared/dto/apiResponse.dto` to `@zod/apiResponse.dto` for consistency.