### PR TITLE
Add backend test setup script

### DIFF
--- a/apps/README.md
+++ b/apps/README.md
@@ -7,3 +7,10 @@ The free, open dating application.
 Doodle Icons by Khushmeen
 
 https://khushmeen.com/icons.html
+
+## Running tests
+
+Run `scripts/setup-tests.sh` to install dependencies, initialize the test database,
+and execute the integration tests located in `apps/backend/src/__integration_tests__`.
+If the database isn't reachable, the integration tests are skipped.
+After the initial setup you can run `pnpm --filter backend test` to execute unit tests.

--- a/scripts/setup-tests.sh
+++ b/scripts/setup-tests.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+set -euo pipefail
+
+# Install Node dependencies using pnpm
+pnpm install --frozen-lockfile
+
+# Generate Prisma client for the backend
+pnpm --filter backend exec npx prisma generate
+
+# Start required services for tests
+if command -v docker >/dev/null 2>&1; then
+  docker compose up -d db redis
+fi
+
+# Initialize test database
+DATABASE_URL="${DATABASE_URL:-postgresql://appuser:secret@localhost:5432/app_test}"
+export DATABASE_URL
+db_ready=true
+if pnpm --filter backend exec npx prisma db push; then
+  echo "Database ready"
+else
+  db_ready=false
+  echo "⚠️  Skipping database initialization (database not reachable)"
+fi
+
+# Run integration tests only if the database is available
+if [ "$db_ready" = true ]; then
+  pnpm --filter backend exec vitest run --mode test --config vitest.integration.config.ts
+  echo "✅ Integration tests complete."
+else
+  echo "⚠️  Integration tests skipped" >&2
+fi


### PR DESCRIPTION
## Summary
- create `scripts/setup-tests.sh` to prepare the backend test environment
- document how to run tests in `apps/README.md`
- run integration tests automatically from the setup script (skips if DB unreachable)

## Testing
- `bash scripts/setup-tests.sh` *(fails: Can't reach database server, integration tests skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68631a8dc22c833190aac6cfd4ea1684