### PR TITLE
Add profile chip list placeholders

### DIFF
--- a/apps/frontend/src/features/app/components/ProfileChipPlaceholder.vue
+++ b/apps/frontend/src/features/app/components/ProfileChipPlaceholder.vue
@@ -1,0 +1,29 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+
+const props = defineProps<{
+  isAnimated?: boolean
+}>()
+
+const animation = computed(() => (props.isAnimated ? 'wave' : undefined))
+</script>
+
+<template>
+  <div class="ph d-flex align-items-center gap-2 p-2 w-100 mb-2">
+    <div class="img" />
+    <BPlaceholder size="lg" :animation="animation" width="75" />
+  </div>
+</template>
+
+<style scoped>
+.img {
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 50%;
+  background-color: var(--bs-secondary);
+  opacity: 0.5;
+}
+.ph {
+  opacity: 0.75;
+}
+</style>

--- a/apps/frontend/src/features/interaction/views/Matches.vue
+++ b/apps/frontend/src/features/interaction/views/Matches.vue
@@ -3,7 +3,7 @@ import { onMounted } from 'vue'
 import MiddleColumn from '@/features/browse/components/MiddleColumn.vue'
 import MatchesList from '../components/MatchesList.vue'
 import IconDate from '@/assets/icons/app/cupid.svg'
-import ConversationPlaceholder from '@/features/messaging/components/ConversationPlaceholder.vue'
+import ProfileChipListPlaceholder from '@/features/publicprofile/components/ProfileChipListPlaceholder.vue'
 import { useDatingInteractions } from '../composables/useDatingInteractions'
 
 const { matches, haveMatches, isLoading, refreshInteractions } = useDatingInteractions()
@@ -26,7 +26,7 @@ onMounted(() => {
         <BPlaceholderWrapper :loading="isLoading">
           <template #loading>
             <div class="col-10 col-md-6 mb-3">
-              <ConversationPlaceholder :isAnimated="true" :howMany="5" />
+              <ProfileChipListPlaceholder :isAnimated="true" :howMany="5" />
             </div>
           </template>
 
@@ -54,7 +54,7 @@ onMounted(() => {
                 </BButton>
               </div>
               <div class="mb-3">
-                <ConversationPlaceholder :howMany="4" />
+                <ProfileChipListPlaceholder :howMany="4" />
               </div>
             </div>
           </div>

--- a/apps/frontend/src/features/publicprofile/components/ProfileChipListPlaceholder.vue
+++ b/apps/frontend/src/features/publicprofile/components/ProfileChipListPlaceholder.vue
@@ -1,0 +1,20 @@
+<script setup lang="ts">
+import ProfileChipPlaceholder from '@/features/app/components/ProfileChipPlaceholder.vue'
+
+const props = withDefaults(
+  defineProps<{
+    howMany?: number
+    isAnimated?: boolean
+  }>(),
+  { howMany: 4 }
+)
+</script>
+
+<template>
+  <div v-for="n in howMany" :key="n" class="w-100">
+    <ProfileChipPlaceholder :isAnimated="isAnimated" />
+  </div>
+</template>
+
+<style scoped>
+</style>


### PR DESCRIPTION
## Summary
- implement `ProfileChipPlaceholder` for repeated use
- implement `ProfileChipListPlaceholder` using the chip component
- show chip list placeholders on matches view

## Testing
- `pnpm --filter frontend lint`
- `cd apps/frontend && pnpm exec vitest run`


------
https://chatgpt.com/codex/tasks/task_e_6863b233f018833180801a47120f33bf