### PR TITLE
Fix WebSocket reconnection after logout

### DIFF
--- a/apps/frontend/src/lib/websocket.ts
+++ b/apps/frontend/src/lib/websocket.ts
@@ -46,8 +46,8 @@ export function connectWebSocket(token: string): void {
 }
 
 export function disconnectWebSocket() {
-  if (socket?.ws.value) {
-    socket.ws.value.close()
+  if (socket) {
+    socket.close()
     socket = null
     console.log('[WS] Disconnected')
   }


### PR DESCRIPTION
## Summary
- fix WebSocket disconnect to avoid reconnect attempts on logout

## Testing
- `scripts/setup-tests.sh` *(fails: database not reachable)*
- `pnpm --filter backend test` *(fails: face detection models missing)*

------
https://chatgpt.com/codex/tasks/task_e_6866c68c2d2483319b1cc02967bdb9b2