### PR TITLE
Refactor image upload modal management

### DIFF
--- a/apps/frontend/src/features/images/__tests__/ImageUpload.spec.ts
+++ b/apps/frontend/src/features/images/__tests__/ImageUpload.spec.ts
@@ -2,32 +2,18 @@ import { mount } from '@vue/test-utils'
 import { describe, it, expect, vi } from 'vitest'
 
 vi.mock('vue-i18n', () => ({ useI18n: () => ({ t: (k: string) => k }) }))
-vi.mock('@/lib/mobile-detect', () => ({ detectMobile: vi.fn().mockReturnValue(false) }))
 
-vi.mock('@/assets/icons/files/avatar-upload.svg', () => ({ default: { template: '<div />' } }))
-vi.mock('@/features/shared/ui/LoadingComponent.vue', () => ({ default: { template: '<div />' } }))
-vi.mock('@/features/shared/ui/ErrorComponent.vue', () => ({ default: { template: '<div />' } }))
-vi.mock('../components/UploadButton.vue', () => ({ default: { template: '<input />' } }))
-vi.mock('../stores/imageStore', () => ({ useImageStore: () => ({ uploadProfileImage: vi.fn().mockResolvedValue({ success: true }) }) }))
+vi.mock('../components/UploadButton.vue', () => ({ default: { template: '<input @change="$emit(\'file:change\', $event)" />' } }))
 
 import ImageUpload from '../components/ImageUpload.vue'
 
 describe('ImageUpload', () => {
-  it('opens modal and sets preview on file change', async () => {
-    const wrapper = mount(ImageUpload, { global: { stubs: { BModal: true, BButton: { template: '<button></button>' }, FormKit: true } } })
-    const file = new File(['a'], 'a.png', { type: 'image/png' });
-    const orig = window.FileReader;
-    (window as any).FileReader = class {
-      result: string | ArrayBuffer | null = null;
-      onload: any = null;
-      readAsDataURL() {
-        this.result = 'data:';
-        this.onload?.();
-      }
-    };
-    await (wrapper.vm as any).handleFileChange({ target: { files: [file] } } as any)
-    window.FileReader = orig
-    expect((wrapper.vm as any).preview).not.toBeNull()
-    expect((wrapper.vm as any).showModal).toBe(true)
+  it('emits file:change when a file is selected', async () => {
+    const wrapper = mount(ImageUpload, {
+      props: { modalState: 'chooser', preview: null, isLoading: false, error: null },
+      global: { stubs: { BButton: true, BOverlay: true } }
+    })
+    await wrapper.find('input').trigger('change')
+    expect(wrapper.emitted('file:change')).toBeTruthy()
   })
 })

--- a/apps/frontend/src/features/images/components/ImageUpload.vue
+++ b/apps/frontend/src/features/images/components/ImageUpload.vue
@@ -1,130 +1,36 @@
 <script setup lang="ts">
-import { ref, computed, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
-
-import { detectMobile } from '@/lib/mobile-detect'
 
 import ErrorComponent from '@/features/shared/ui/ErrorComponent.vue'
 import UploadButton from './UploadButton.vue'
-import AvatarUploadIcon from '@/assets/icons/files/avatar-upload.svg'
-import { useImageStore } from '@/features/images/stores/imageStore'
 
-const imageStore = useImageStore()
+const props = defineProps<{
+  modalState: 'chooser' | 'preview'
+  preview: string | null
+  isLoading: boolean
+  error: string | null
+}>()
+
+defineEmits<{
+  (e: 'file:change', event: Event): void
+  (e: 'upload'): void
+  (e: 'cancel'): void
+  (e: 'back'): void
+}>()
+
 const { t } = useI18n()
-
-// Upload state
-const selectedFile = ref<File | null>(null)
-const preview = ref<string | null>(null)
-const captionText = ref<string>('')
-
-const isLoading = ref(false)
-const error = ref<string | null>(null)
-const fileInput = ref<HTMLInputElement | null>(null)
-
-// Detect device type
-const isMobile = computed(() => detectMobile())
-
-// Modal state
-type ModalState = 'closed' | 'chooser' | 'preview'
-const modalState = ref<ModalState>('closed')
-
-const showModal = ref(false)
-
-const openModal = () => {
-  modalState.value = isMobile.value ? 'chooser' : 'preview'
-  showModal.value = true
-}
-
-const closeModal = () => {
-  showModal.value = false
-}
-
-const handleUpload = async () => {
-  if (!selectedFile.value) return
-  isLoading.value = true
-  error.value = null
-
-  const res = await imageStore.uploadProfileImage(selectedFile.value, captionText.value)
-  if (!res.success) {
-    error.value = res.message
-    isLoading.value = false
-    return
-  }
-  closeModal()
-}
-
-const handleFileChange = (event: Event) => {
-  const input = event.target as HTMLInputElement
-  const file = input.files?.[0] ?? null
-  selectedFile.value = file
-
-  if (!file) {
-    preview.value = null
-    return
-  }
-
-  const reader = new FileReader()
-  reader.onload = () => {
-    preview.value = typeof reader.result === 'string' ? reader.result : null
-    modalState.value = 'preview'
-    showModal.value = true
-  }
-  reader.readAsDataURL(file)
-}
-
-const backFromPreview = () => {
-  if (isMobile.value) {
-    modalState.value = 'chooser'
-  } else {
-    closeModal()
-  }
-}
-
-function onModalHidden() {
-  modalState.value = 'closed'
-  selectedFile.value = null
-  preview.value = null
-  captionText.value = ''
-  error.value = null
-  isLoading.value = false
-  if (fileInput.value) fileInput.value.value = ''
-}
 </script>
 
 <template>
-  <div class="image-upload h-100">
-    <BButton v-if="isMobile" variant="secondary" class="w-100 h-100" @click="openModal">
-      <AvatarUploadIcon class="svg-icon w-100 h-100" />
-    </BButton>
-    <UploadButton v-else @file:change="handleFileChange" :genericIcon="true" />
-
-    <div v-if="error" class="text-danger mt-2">
-      {{ error }}
-    </div>
-  </div>
-
-  <BModal
-    :show="showModal"
-    centered
-    button-size="sm"
-    :focus="false"
-    :no-close-on-backdrop="true"
-    :no-footer="true"
-    :cancel-title="t('profiles.image_upload.nevermind')"
-    body-class="d-flex flex-column align-items-center justify-content-center"
-    initial-animation
-    fullscreen="md"
-    :title="t('profiles.image_upload.title')"
-    @hidden="onModalHidden"
-  >
+  <div class="image-upload-content">
     <!-- Preview Modal -->
-    <div v-show="modalState === 'preview'" class="preview-container w-100">
-      <ErrorComponent :error="error" v-if="error" />
-      <div v-if="preview && !error" class="mb-3">
-        <BOverlay spinner-type="grow" :show="isLoading">
+    <div v-show="props.modalState === 'preview'" class="preview-container w-100">
+      <ErrorComponent :error="props.error" v-if="props.error" />
+      <div v-if="props.preview && !props.error" class="mb-3">
+        <BOverlay spinner-type="grow" :show="props.isLoading">
           <div class="ratio ratio-4x3 position-relative">
-            <div class="preview-wrapper overflow-hidden" v-show="modalState === 'preview'">
-              <img :src="preview" alt="Preview" class="preview-image" />
+            <div class="preview-wrapper overflow-hidden">
+              <img :src="props.preview" alt="Preview" class="preview-image" />
             </div>
           </div>
         </BOverlay>
@@ -134,15 +40,15 @@ function onModalHidden() {
         <BButton
           variant="primary"
           size="lg"
-          @click.prevent="handleUpload"
+          @click.prevent="$emit('upload')"
           :label="t('profiles.image_upload.looks_good')"
-          :disabled="isLoading || !!error"
+          :disabled="props.isLoading || !!props.error"
         >
           {{ t('profiles.image_upload.looks_good') }}
         </BButton>
         <BButton
           variant="link-secondary"
-          @click.prevent="backFromPreview"
+          @click.prevent="$emit('back')"
           class="link-secondary mt-3"
           size="sm"
         >
@@ -152,27 +58,27 @@ function onModalHidden() {
     </div>
 
     <!-- Mobile: Capture Chooser -->
-    <div v-show="modalState === 'chooser'">
+    <div v-show="props.modalState === 'chooser'">
       <div class="d-flex flex-column align-items-center h-100 justify-content-center">
         <div class="mx-auto d-flex flex-column align-items-center">
           <div class="mb-5 d-flex flex-column align-items-center">
             <div class="col-6">
-              <UploadButton @file:change="handleFileChange" :key="'capture-none'" />
+              <UploadButton @file:change="$emit('file:change', $event)" :key="'capture-none'" />
             </div>
-            <div class="mt-0 form-text text-mute text-centerd">
+            <div class="mt-0 form-text text-mute text-center">
               {{ t('profiles.image_upload.add_from_phone') }}
             </div>
           </div>
           <div class="mb-4 d-flex flex-column align-items-center">
             <div class="col-6">
-              <UploadButton @file:change="handleFileChange" capture="user" :key="'capture-user'" />
+              <UploadButton @file:change="$emit('file:change', $event)" capture="user" :key="'capture-user'" />
             </div>
             <div class="form-text text-muted text-center">{{ t('profiles.image_upload.take_photo') }}</div>
           </div>
           <div>
             <BButton
               variant="link-secondary"
-              @click.prevent="closeModal"
+              @click.prevent="$emit('cancel')"
               class="link-secondary"
               size="sm"
             >
@@ -182,7 +88,7 @@ function onModalHidden() {
         </div>
       </div>
     </div>
-  </BModal>
+  </div>
 </template>
 
 <style scoped lang="scss">
@@ -203,7 +109,7 @@ img {
   display: flex;
   align-items: center;
   justify-content: center;
-  background: rgba(255, 255, 255, 0.5); // semi-transparent layer
+  background: rgba(255, 255, 255, 0.5);
   z-index: 10;
 }
 </style>


### PR DESCRIPTION
## Summary
- lift modal logic out of `ImageUpload.vue`
- manage modal state in `ImageEditor.vue`
- update unit test for new `ImageUpload` API

## Testing
- `pnpm --filter frontend test:unit`

------
https://chatgpt.com/codex/tasks/task_e_6867f7e15de48331ac8ab94c5bd452be