### PR TITLE
Fix location type mismatch in SocialFilter

### DIFF
--- a/apps/frontend/src/features/browse/components/SocialFilterDisplay.vue
+++ b/apps/frontend/src/features/browse/components/SocialFilterDisplay.vue
@@ -18,7 +18,7 @@ const interestlist = computed(() => {
   <div v-if="socialFilter?.location && viewerLocation" >
     {{
       relativeLocationLabel({
-        location: socialFilter?.location,
+        location: socialFilter?.location ?? null,
         viewerLocation: viewerLocation,
         showCity: true,
         showCountryLabel: true,

--- a/apps/frontend/src/features/shared/composables/useLocationLabel.ts
+++ b/apps/frontend/src/features/shared/composables/useLocationLabel.ts
@@ -1,8 +1,8 @@
-import type { LocationDTO } from '@zod/dto/location.dto'
+import type { LocationDTO, LocationPayload } from '@zod/dto/location.dto'
 import { useCountries } from './useCountries'
 
 interface UseLocationLabelOptions {
-  location: LocationDTO | null
+  location: LocationDTO | LocationPayload | null
   viewerLocation: LocationDTO | null
   showCity?: boolean
   showCountryLabel?: boolean
@@ -24,8 +24,8 @@ export function relativeLocationLabel({
 
   const parts: string[] = []
 
-  if (showCityName) parts.push(location.cityName)
-  if (showCountry && showCountryLabel) {
+  if (showCityName && location.cityName) parts.push(location.cityName)
+  if (showCountry && showCountryLabel && location.country) {
     const countryName = countryCodeToName(location.country)
     if (countryName) parts.push(countryName)
   }


### PR DESCRIPTION
## Summary
- fix SocialFilterDisplay location type
- expand `relativeLocationLabel` to accept payload and guard nulls

## Testing
- `pnpm --filter frontend run lint`
- `pnpm --filter frontend run type-check` *(fails: no exported member errors)*

------
https://chatgpt.com/codex/tasks/task_e_68692cbdc84c8331a4d25fe47e410995