### PR TITLE
Add cursor-based browsing

### DIFF
--- a/apps/frontend/src/features/browse/composables/useFindMatchViewModel.ts
+++ b/apps/frontend/src/features/browse/composables/useFindMatchViewModel.ts
@@ -84,20 +84,7 @@ export function useFindMatchViewModel() {
   }
 
   const fetchResults = async () => {
-    switch (currentScope.value) {
-      case 'social': {
-        await findProfileStore.findSocial()
-        break
-      }
-      case 'dating': {
-        await findProfileStore.findDating()
-        break
-      }
-      default: {
-        console.warn('No valid scope selected, cannot fetch results')
-        return
-      }
-    }
+    await findProfileStore.browseProfiles()
   }
 
   watch(currentScope, (newScope) => {
@@ -186,6 +173,8 @@ export function useFindMatchViewModel() {
     navigateToScope,
     openProfile,
     profileList: computed(() => findProfileStore.profileList),
+    nextCursor: toRef(findProfileStore, 'nextCursor'),
+    loadMore: findProfileStore.browseProfiles,
     isInitialized: computed(() => isInitialized.value),
   }
 

--- a/packages/shared/zod/apiResponse.dto.ts
+++ b/packages/shared/zod/apiResponse.dto.ts
@@ -34,6 +34,7 @@ export type UpdateDatingPreferencesResponse = ApiSuccess<{ prefs: DatingPreferen
 export type GetMyProfileResponse = ApiSuccess<{ profile: OwnerProfile }>
 export type GetPublicProfileResponse = ApiSuccess<{ profile: PublicProfileWithContext }>
 export type GetProfilesResponse = ApiSuccess<{ profiles: PublicProfileWithContext[] }>
+export type BrowseProfilesResponse = ApiSuccess<{ profiles: PublicProfileWithContext[]; nextCursor: string | null }>
 export type UpdateProfileResponse = ApiSuccess<{ profile: OwnerProfile }>
 
 export type TagsResponse = ApiSuccess<{ tags: PublicTag[] }>


### PR DESCRIPTION
## Summary
- add BrowseProfilesResponse type
- implement browseProfiles with cursor pagination in profile service
- expose /profiles/browse route
- support pagination in frontend store and view model
- implement infinite scroll in BrowseProfiles view

## Testing
- `pnpm --filter backend run lint`
- `pnpm --filter frontend run lint`


------
https://chatgpt.com/codex/tasks/task_e_686a2e8c12248331a6bd4ecf41a62aec