### PR TITLE
Prepare localization in frontend

### DIFF
--- a/apps/frontend/src/features/app/components/LikeReceivedToast.vue
+++ b/apps/frontend/src/features/app/components/LikeReceivedToast.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
 import ProfileImage from '@/features/images/components/ProfileImage.vue'
 import { type InteractionEdge } from '@zod/interaction/interaction.dto'
-// import { useI18n } from 'vue-i18n';
-// const { t } = useI18n()
+import { useI18n } from 'vue-i18n'
+
+const { t } = useI18n()
 
 defineEmits<{
   (e: 'closeToast'): void
@@ -15,7 +16,8 @@ defineProps<{
 
 <template>
   <div class="d-flex align-items-center clickable">
-    <span> You have received a new like!</span>
+    <!-- You have received a new like! -->
+    <span>{{ t('matches.like_received_toast') }}</span>
   </div>
 </template>
 

--- a/apps/frontend/src/features/browse/components/SocialFilterDisplay.vue
+++ b/apps/frontend/src/features/browse/components/SocialFilterDisplay.vue
@@ -5,6 +5,7 @@ import LocationLabel from '@/features/shared/profiledisplay/LocationLabel.vue'
 import TagList from '@/features/shared/profiledisplay/TagList.vue'
 import IconSetting from '@/assets/icons/interface/setting.svg'
 import IconSearch from '@/assets/icons/interface/search.svg'
+import { useI18n } from 'vue-i18n'
 
 const socialFilter = defineModel<SocialMatchFilterDTO | null>({
   default: null,
@@ -17,6 +18,8 @@ const props = defineProps<{
 defineEmits<{
   (event: 'prefs:toggle'): void
 }>()
+
+const { t } = useI18n()
 </script>
 
 <template>
@@ -36,7 +39,8 @@ defineEmits<{
           :showCountryLabel="true"
           :showCountryIcon="false"
         />
-        <span v-if="!socialFilter?.location.country">Anywhere</span>
+        <!-- Anywhere -->
+        <span v-if="!socialFilter?.location.country">{{ t('browse.filter.anywhere') }}</span>
       </span>
 
       <TagList v-if="socialFilter?.tags.length" :tags="socialFilter.tags" />

--- a/apps/frontend/src/features/browse/components/SocialFilterForm.vue
+++ b/apps/frontend/src/features/browse/components/SocialFilterForm.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { ref } from 'vue'
+import { useI18n } from 'vue-i18n'
 
 import TagSelectComponent from '@/features/shared/profileform/TagSelectComponent.vue'
 import CountrySelector from '@/features/shared/profileform/CountrySelector.vue'
@@ -13,6 +14,8 @@ import { type LocationDTO } from '@zod/dto/location.dto'
 const model = defineModel<SocialMatchFilterDTO>({
   default: () => SocialMatchFilterDTOSchema.parse({}),
 })
+
+const { t } = useI18n()
 
 const props = defineProps<{
   viewerProfile: OwnerProfile | null
@@ -39,12 +42,13 @@ const toggleDisabled = () => {
 
 <template>
   <div class="d-flex flex-column justify-content-center h-100">
-    <h5 class="text-center mb-4">I 'm looking for connections...</h5>
+    <!-- I'm looking for connections... -->
+    <h5 class="text-center mb-4">{{ t('browse.filter.title') }}</h5>
     <div class="mb-2">
       <div class="d-flex flex-row">
         <div class="flex-grow-1">
           <BFormCheckbox v-model="locationDisabled" @change="toggleDisabled"
-            >Anywhere</BFormCheckbox
+            >{{ t('browse.filter.anywhere') }}</BFormCheckbox
           >
         </div>
         <div class="text-end">
@@ -69,11 +73,12 @@ const toggleDisabled = () => {
     </fieldset>
 
     <div>
-      <label>Interested in...</label>
+      <!-- Interested in... -->
+      <label>{{ t('browse.filter.interests_label') }}</label>
       <TagSelectComponent
         v-model="model.tags"
-        label="Select interests"
-        placeholder="Interested in"
+        :label="t('browse.filter.select_interests')"
+        :placeholder="t('browse.filter.interests_placeholder')"
         :taggable="false"
       />
     </div>

--- a/apps/frontend/src/features/interaction/components/LikesAndMatchesBanner.vue
+++ b/apps/frontend/src/features/interaction/components/LikesAndMatchesBanner.vue
@@ -1,8 +1,10 @@
 <script setup lang="ts">
 import IconHeart from '@/assets/icons/interface/heart.svg'
 import { useInteractionsViewModel } from '../composables/useInteractionsViewModel'
+import { useI18n } from 'vue-i18n'
 
 const { receivedLikesCount, haveReceivedLikes, haveNewMatches, newMatchesCount } = useInteractionsViewModel()
+const { tc, t } = useI18n()
 </script>
 
 <template>
@@ -14,11 +16,21 @@ const { receivedLikesCount, haveReceivedLikes, haveNewMatches, newMatchesCount }
   >
     <div class="">
       <span class="text-dating"><IconHeart class="svg-icon" /></span>
-      You have
-      <span v-if="haveReceivedLikes">{{ receivedLikesCount }} likes</span>
-      <span v-if="haveNewMatches && haveReceivedLikes"> and </span>
-      <span v-if="haveNewMatches">{{ newMatchesCount }} new matches</span>
-      <span>!</span>
+      <!-- You have X likes and X new matches! -->
+      <span>
+        {{
+          [
+            haveReceivedLikes
+              ? tc('matches.received_likes', receivedLikesCount, { count: receivedLikesCount })
+              : null,
+            haveNewMatches
+              ? t('matches.new_matches', { count: newMatchesCount })
+              : null,
+          ]
+            .filter(Boolean)
+            .join(' ')
+        }}
+      </span>
       <!-- <BButton
         variant="link-primary"
         class="stretched-link p-0 ms-1"

--- a/apps/frontend/src/features/interaction/components/ReceivedLikesBanner.vue
+++ b/apps/frontend/src/features/interaction/components/ReceivedLikesBanner.vue
@@ -1,8 +1,10 @@
 <script setup lang="ts">
 import IconHeart from '@/assets/icons/interface/heart.svg'
 import { useInteractionsViewModel } from '../composables/useInteractionsViewModel'
+import { useI18n } from 'vue-i18n'
 
 const { receivedLikesCount, haveReceivedLikes, haveMatches, matches } = useInteractionsViewModel()
+const { tc } = useI18n()
 </script>
 
 <template>
@@ -14,7 +16,8 @@ const { receivedLikesCount, haveReceivedLikes, haveMatches, matches } = useInter
   >
     <div class="">
       <span class="text-dating"><IconHeart class="svg-icon" /></span>
-      You have      <span v-if="haveReceivedLikes">{{ receivedLikesCount }} likes.</span>
+      <!-- You have {{ receivedLikesCount }} likes. -->
+      <span>{{ tc('matches.received_likes', receivedLikesCount, { count: receivedLikesCount }) }}</span>
 
 
       <!-- <BButton

--- a/apps/frontend/src/features/interaction/components/ReceivedLikesCount.vue
+++ b/apps/frontend/src/features/interaction/components/ReceivedLikesCount.vue
@@ -1,8 +1,10 @@
 <script setup lang="ts">
 import IconHeart from '@/assets/icons/interface/heart.svg'
 import { useInteractionsViewModel } from '../composables/useInteractionsViewModel'
+import { useI18n } from 'vue-i18n'
 
 const { receivedLikesCount, haveReceivedLikes, haveMatches, matches } = useInteractionsViewModel()
+const { tc } = useI18n()
 </script>
 
 <template>
@@ -13,8 +15,8 @@ const { receivedLikesCount, haveReceivedLikes, haveMatches, matches } = useInter
   >
     <div class="">
       <span class="text-dating"><IconHeart class="svg-icon" /></span>
-      You have
-      {{ receivedLikesCount }} likes!
+      <!-- You have {{ receivedLikesCount }} likes! -->
+      <span>{{ tc('matches.received_likes', receivedLikesCount, { count: receivedLikesCount }) }}</span>
       <!-- <BButton
         variant="link-primary"
         class="stretched-link p-0 ms-1"

--- a/packages/shared/i18n/en.json
+++ b/packages/shared/i18n/en.json
@@ -75,7 +75,17 @@
     "profile": "Profile",
     "browse": "Browse",
     "inbox": "Inbox",
-    "settings": "Settings"
+    "settings": "Settings",
+    "matches": "Matches"
+  },
+  "browse": {
+    "filter": {
+      "title": "I'm looking for connections...",
+      "anywhere": "Anywhere",
+      "interests_label": "Interested in...",
+      "select_interests": "Select interests",
+      "interests_placeholder": "Interested in"
+    }
   },
   "authentication": {
     "login": "Login",
@@ -114,11 +124,18 @@
       "dictate": "Dictate",
       "intro_placeholder": "Tell a bit about yourself",
       "intro_who_placeholder": "Who would you like to meet?"
-    }
+    },
+    "relationship_unspecified_label": "I'd rather not say",
+    "haskids_unspecified_label": "I'd rather not say"
+  },
+  "profile": {
+    "pronouns": "Pronouns"
   },
   "matches":{
     "received_likes": "You have no likes.|You have 1 like.|You have {count} likes!",
     "received_likes_cta": "Who|Find out who sent it.|Find out who sent them.",
+    "like_received_toast": "You have received a new like!",
+    "new_matches": "{count} new matches",
     "no_match_no_sent_like": "There's gotta be someone you like out there?  ",
     "no_match_no_sent_like_cta": "Start lookin'",
     "no_match_have_sent_like": "They will surely like you back.",
@@ -133,6 +150,7 @@
     "send_message_to_user": "Send a message to {name}",
     "unknown_sender": "Someone",
     "message_input_hint": "Press Enter to send",
+    "loading_conversation": "Loading conversation...",
     "send_failed": "Oops, this didn't work. Please try again.",
     "message_sent_success": "Message sent successfully!",
     "my_turn": "My turn",
@@ -176,29 +194,11 @@
       "retry": "Retry",
       "cancel": "Cancel"
     },
-    "submitbutton": {
-      "working": "Working...",
-      "submit": "Submit",
-      "save": "Save"
-    },
     "loading": {
       "loading": "Loading..."
     },
     "spinner": {
       "spinning": "Spinning"
-    },
-    "modal": {
-      "close": "Close"
-    },
-    "toast": {
-      "success": {
-        "title": "Success",
-        "message": "Your action was successful."
-      },
-      "error": {
-        "title": "Error",
-        "message": "An error occurred. Please try again."
-      }
     }
   },
   "emails": {


### PR DESCRIPTION
## Summary
- enable i18n usage for several frontend components
- extract texts into `packages/shared/i18n/en.json`
- clean up unused entries in language catalog

## Testing
- `pnpm --filter frontend exec vitest run`
- `pnpm lint` *(fails: network unreachable while fetching)*

------
https://chatgpt.com/codex/tasks/task_e_686a6c2246048331b169c4173e6b368b