### PR TITLE
Fix plugin typings in vite config

### DIFF
--- a/apps/frontend/vite.config.ts
+++ b/apps/frontend/vite.config.ts
@@ -61,7 +61,8 @@ export default defineConfig(({ mode }: ConfigEnv): UserConfig => {
     optimizeDeps: {
       include: ['qrcode']
     },
-    plugins: [
+    plugins: (() => {
+      const plugins: PluginOption[] = [
       {
         name: 'exclude-tests-from-build',
         resolveId(source) {
@@ -84,14 +85,14 @@ export default defineConfig(({ mode }: ConfigEnv): UserConfig => {
           emitFile: true,
           filename: "stats.html",
           template: 'sunburst'
-        }) as PluginOption]
+        }) as unknown as PluginOption]
         : [visualizer({
           open: false,
           gzipSize: true,
           emitFile: true,
           filename: "stats.html",
           template: 'sunburst'
-        }) as PluginOption]),
+        }) as unknown as PluginOption]),
       vueJsx(),
       vueDevTools(),
       svgLoader(),
@@ -135,10 +136,13 @@ export default defineConfig(({ mode }: ConfigEnv): UserConfig => {
       //     maximumFileSizeToCacheInBytes: 5 * 1024 * 1024, // 5MB
       //   },
       //   devOptions: {
-      //     enabled: true, 
+      //     enabled: true,
       //   },
       // })
-    ],
+      ]
+
+      return plugins
+    })(),
     css: {
       preprocessorOptions: {
         scss: {


### PR DESCRIPTION
## Summary
- fix plugin list types in Vite config for the frontend app

## Testing
- `pnpm --filter ./apps/frontend run type-check` *(fails: Namespace 'Prisma' has no exported member ...)*
- `pnpm --filter ./apps/frontend build` *(fails: Namespace 'Prisma' has no exported member ...)*

------
https://chatgpt.com/codex/tasks/task_e_686da882ea7c83319a958410a9785ff6