### PR TITLE
Fix vitest config mismatch

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -66,7 +66,7 @@
     "@types/all-the-cities": "^3.1.3",
     "@types/bcrypt": "^5.0.2",
     "@types/mime-types": "^2.1.4",
-    "@types/node": "^18.19.100",
+    "@types/node": "^22.16.1",
     "@types/nodemailer": "^6.4.17",
     "@types/otp-generator": "^4.0.2",
     "@types/web-push": "^3.6.4",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "translate": "npx json-autotranslate -i packages/shared/i18n/ --directory-structure ngx-translate -d --type key-based -m i18next -s deepl-free -c ${DEEPL_API_KEY},less,1000"
   },
   "dependencies": {
-    "@types/node": "^24.0.11",
+    "@types/node": "^22.16.1",
     "rollup": "^4.44.2",
     "zod": "^3.24.4"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@types/node':
-        specifier: ^24.0.11
-        version: 24.0.11
+        specifier: ^22.16.1
+        version: 22.16.2
       rollup:
         specifier: ^4.44.2
         version: 4.44.2
@@ -137,7 +137,7 @@ importers:
         version: 1.6.6
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@types/node@18.19.116)(typescript@5.8.3)
+        version: 10.9.2(@types/node@22.16.2)(typescript@5.8.3)
       web-push:
         specifier: ^3.6.7
         version: 3.6.7
@@ -164,8 +164,8 @@ importers:
         specifier: ^2.1.4
         version: 2.1.4
       '@types/node':
-        specifier: ^18.19.100
-        version: 18.19.116
+        specifier: ^22.16.1
+        version: 22.16.2
       '@types/nodemailer':
         specifier: ^6.4.17
         version: 6.4.17
@@ -180,7 +180,7 @@ importers:
         version: 8.18.1
       '@vitest/coverage-v8':
         specifier: ^3.2.4
-        version: 3.2.4(vitest@3.2.4(@types/node@18.19.116)(jiti@2.4.2)(jsdom@26.1.0(canvas@3.1.2))(sass-embedded@1.89.2)(sass@1.89.2)(terser@5.43.1))
+        version: 3.2.4(vitest@3.2.4(@types/node@22.16.2)(jiti@2.4.2)(jsdom@26.1.0(canvas@3.1.2))(sass-embedded@1.89.2)(sass@1.89.2)(terser@5.43.1))
       all-the-cities:
         specifier: ^3.1.0
         version: 3.1.0
@@ -210,7 +210,7 @@ importers:
         version: 0.8.13(prisma@6.11.1(typescript@5.8.3))
       ts-node-dev:
         specifier: ^2.0.0
-        version: 2.0.0(@types/node@18.19.116)(typescript@5.8.3)
+        version: 2.0.0(@types/node@22.16.2)(typescript@5.8.3)
       tsc-watch:
         specifier: ^6.2.1
         version: 6.3.1(typescript@5.8.3)
@@ -228,13 +228,13 @@ importers:
         version: 8.36.0(eslint@9.30.1(jiti@2.4.2))(typescript@5.8.3)
       vite:
         specifier: ^6.3.5
-        version: 6.3.5(@types/node@18.19.116)(jiti@2.4.2)(sass-embedded@1.89.2)(sass@1.89.2)(terser@5.43.1)
+        version: 6.3.5(@types/node@22.16.2)(jiti@2.4.2)(sass-embedded@1.89.2)(sass@1.89.2)(terser@5.43.1)
       vite-tsconfig-paths:
         specifier: ^5.0.0
-        version: 5.1.4(typescript@5.8.3)(vite@6.3.5(@types/node@18.19.116)(jiti@2.4.2)(sass-embedded@1.89.2)(sass@1.89.2)(terser@5.43.1))
+        version: 5.1.4(typescript@5.8.3)(vite@6.3.5(@types/node@22.16.2)(jiti@2.4.2)(sass-embedded@1.89.2)(sass@1.89.2)(terser@5.43.1))
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/node@18.19.116)(jiti@2.4.2)(jsdom@26.1.0(canvas@3.1.2))(sass-embedded@1.89.2)(sass@1.89.2)(terser@5.43.1)
+        version: 3.2.4(@types/node@22.16.2)(jiti@2.4.2)(jsdom@26.1.0(canvas@3.1.2))(sass-embedded@1.89.2)(sass@1.89.2)(terser@5.43.1)
       wscat:
         specifier: ^6.1.0
         version: 6.1.0
@@ -1760,14 +1760,8 @@ packages:
   '@types/node-fetch@2.6.12':
     resolution: {integrity: sha512-8nneRWKCg3rMtF69nLQJnOYUcbafYeFSjqkw3jCRLsqkWFlHaoQrr5mXmofFGOx3DKn7UfmBMyov8ySvLRVldA==}
 
-  '@types/node@18.19.116':
-    resolution: {integrity: sha512-1SHF5oSE6UfsnhB1QtPTB8bhKI/ZL57kIesbl0+/Nj8jW1C4Pjc+E+7sMq0Np6lu1zhjOKmoqPsK+RUsmok7nQ==}
-
   '@types/node@22.16.2':
     resolution: {integrity: sha512-Cdqa/eJTvt4fC4wmq1Mcc0CPUjp/Qy2FGqLza3z3pKymsI969TcZ54diNJv8UYUgeWxyb8FSbCkhdR6WqmUFhA==}
-
-  '@types/node@24.0.11':
-    resolution: {integrity: sha512-CJV8eqrYnwQJGMrvcRhQmZfpyniDavB+7nAZYJc6w99hFYJyFN3INV1/2W3QfQrqM36WTLrijJ1fxxvGBmCSxA==}
 
   '@types/nodemailer@6.4.17':
     resolution: {integrity: sha512-I9CCaIp6DTldEg7vyUTZi8+9Vo0hi1/T8gv3C89yk1rSAAzoKQ8H8ki/jBYJSFoH/BisgLP8tkZMlQ91CIquww==}
@@ -5822,14 +5816,8 @@ packages:
   ufo@1.6.1:
     resolution: {integrity: sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==}
 
-  undici-types@5.26.5:
-    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
-
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
-
-  undici-types@7.8.0:
-    resolution: {integrity: sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==}
 
   unicorn-magic@0.1.0:
     resolution: {integrity: sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==}
@@ -7531,7 +7519,7 @@ snapshots:
 
   '@types/bcrypt@5.0.2':
     dependencies:
-      '@types/node': 18.19.116
+      '@types/node': 22.16.2
 
   '@types/bootstrap@5.2.10':
     dependencies:
@@ -7540,7 +7528,7 @@ snapshots:
   '@types/browser-sync@2.29.0':
     dependencies:
       '@types/micromatch': 2.3.35
-      '@types/node': 24.0.11
+      '@types/node': 22.16.2
       '@types/serve-static': 1.15.8
       chokidar: 3.6.0
 
@@ -7552,11 +7540,11 @@ snapshots:
 
   '@types/cors@2.8.19':
     dependencies:
-      '@types/node': 24.0.11
+      '@types/node': 22.16.2
 
   '@types/cross-spawn@6.0.2':
     dependencies:
-      '@types/node': 24.0.11
+      '@types/node': 22.16.2
 
   '@types/debug@4.1.8':
     dependencies:
@@ -7572,7 +7560,7 @@ snapshots:
 
   '@types/jsdom@21.1.7':
     dependencies:
-      '@types/node': 24.0.11
+      '@types/node': 22.16.2
       '@types/tough-cookie': 4.0.5
       parse5: 7.3.0
 
@@ -7594,24 +7582,16 @@ snapshots:
 
   '@types/node-fetch@2.6.12':
     dependencies:
-      '@types/node': 24.0.11
+      '@types/node': 22.16.2
       form-data: 4.0.3
-
-  '@types/node@18.19.116':
-    dependencies:
-      undici-types: 5.26.5
 
   '@types/node@22.16.2':
     dependencies:
       undici-types: 6.21.0
 
-  '@types/node@24.0.11':
-    dependencies:
-      undici-types: 7.8.0
-
   '@types/nodemailer@6.4.17':
     dependencies:
-      '@types/node': 18.19.116
+      '@types/node': 22.16.2
 
   '@types/normalize-package-data@2.4.4': {}
 
@@ -7625,12 +7605,12 @@ snapshots:
 
   '@types/qrcode@1.5.5':
     dependencies:
-      '@types/node': 24.0.11
+      '@types/node': 22.16.2
 
   '@types/request@2.48.12':
     dependencies:
       '@types/caseless': 0.12.5
-      '@types/node': 24.0.11
+      '@types/node': 22.16.2
       '@types/tough-cookie': 4.0.5
       form-data: 2.5.3
 
@@ -7641,12 +7621,12 @@ snapshots:
   '@types/send@0.17.5':
     dependencies:
       '@types/mime': 1.3.5
-      '@types/node': 24.0.11
+      '@types/node': 22.16.2
 
   '@types/serve-static@1.15.8':
     dependencies:
       '@types/http-errors': 2.0.5
-      '@types/node': 24.0.11
+      '@types/node': 22.16.2
       '@types/send': 0.17.5
 
   '@types/strip-bom@3.0.0': {}
@@ -7661,11 +7641,11 @@ snapshots:
 
   '@types/web-push@3.6.4':
     dependencies:
-      '@types/node': 18.19.116
+      '@types/node': 22.16.2
 
   '@types/ws@8.18.1':
     dependencies:
-      '@types/node': 18.19.116
+      '@types/node': 22.16.2
 
   '@typescript-eslint/eslint-plugin@8.36.0(@typescript-eslint/parser@8.36.0(eslint@9.30.1(jiti@2.4.2))(typescript@5.8.3))(eslint@9.30.1(jiti@2.4.2))(typescript@5.8.3)':
     dependencies:
@@ -7776,25 +7756,6 @@ snapshots:
       vite: 6.3.5(@types/node@22.16.2)(jiti@2.4.2)(sass-embedded@1.89.2)(sass@1.89.2)(terser@5.43.1)
       vue: 3.5.17(typescript@5.8.3)
 
-  '@vitest/coverage-v8@3.2.4(vitest@3.2.4(@types/node@18.19.116)(jiti@2.4.2)(jsdom@26.1.0(canvas@3.1.2))(sass-embedded@1.89.2)(sass@1.89.2)(terser@5.43.1))':
-    dependencies:
-      '@ampproject/remapping': 2.3.0
-      '@bcoe/v8-coverage': 1.0.2
-      ast-v8-to-istanbul: 0.3.3
-      debug: 4.4.1
-      istanbul-lib-coverage: 3.2.2
-      istanbul-lib-report: 3.0.1
-      istanbul-lib-source-maps: 5.0.6
-      istanbul-reports: 3.1.7
-      magic-string: 0.30.17
-      magicast: 0.3.5
-      std-env: 3.9.0
-      test-exclude: 7.0.1
-      tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/node@18.19.116)(jiti@2.4.2)(jsdom@26.1.0(canvas@3.1.2))(sass-embedded@1.89.2)(sass@1.89.2)(terser@5.43.1)
-    transitivePeerDependencies:
-      - supports-color
-
   '@vitest/coverage-v8@3.2.4(vitest@3.2.4(@types/node@22.16.2)(jiti@2.4.2)(jsdom@26.1.0(canvas@3.1.2))(sass-embedded@1.89.2)(sass@1.89.2)(terser@5.43.1))':
     dependencies:
       '@ampproject/remapping': 2.3.0
@@ -7831,14 +7792,6 @@ snapshots:
       '@vitest/utils': 3.2.4
       chai: 5.2.1
       tinyrainbow: 2.0.0
-
-  '@vitest/mocker@3.2.4(vite@6.3.5(@types/node@18.19.116)(jiti@2.4.2)(sass-embedded@1.89.2)(sass@1.89.2)(terser@5.43.1))':
-    dependencies:
-      '@vitest/spy': 3.2.4
-      estree-walker: 3.0.3
-      magic-string: 0.30.17
-    optionalDependencies:
-      vite: 6.3.5(@types/node@18.19.116)(jiti@2.4.2)(sass-embedded@1.89.2)(sass@1.89.2)(terser@5.43.1)
 
   '@vitest/mocker@3.2.4(vite@6.3.5(@types/node@22.16.2)(jiti@2.4.2)(sass-embedded@1.89.2)(sass@1.89.2)(terser@5.43.1))':
     dependencies:
@@ -8783,7 +8736,7 @@ snapshots:
 
   deepl-node@1.19.0:
     dependencies:
-      '@types/node': 18.19.116
+      '@types/node': 22.16.2
       adm-zip: 0.5.16
       axios: 1.10.0
       form-data: 3.0.3
@@ -8978,7 +8931,7 @@ snapshots:
   engine.io@6.6.4:
     dependencies:
       '@types/cors': 2.8.19
-      '@types/node': 24.0.11
+      '@types/node': 22.16.2
       accepts: 1.3.8
       base64id: 2.0.0
       cookie: 0.7.2
@@ -10885,7 +10838,7 @@ snapshots:
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
       '@protobufjs/utf8': 1.1.0
-      '@types/node': 24.0.11
+      '@types/node': 22.16.2
       long: 5.3.2
 
   protocol-buffers-schema@3.6.0: {}
@@ -11839,7 +11792,7 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
-  ts-node-dev@2.0.0(@types/node@18.19.116)(typescript@5.8.3):
+  ts-node-dev@2.0.0(@types/node@22.16.2)(typescript@5.8.3):
     dependencies:
       chokidar: 3.6.0
       dynamic-dedupe: 0.3.0
@@ -11849,7 +11802,7 @@ snapshots:
       rimraf: 2.7.1
       source-map-support: 0.5.21
       tree-kill: 1.2.2
-      ts-node: 10.9.2(@types/node@18.19.116)(typescript@5.8.3)
+      ts-node: 10.9.2(@types/node@22.16.2)(typescript@5.8.3)
       tsconfig: 7.0.0
       typescript: 5.8.3
     transitivePeerDependencies:
@@ -11857,14 +11810,14 @@ snapshots:
       - '@swc/wasm'
       - '@types/node'
 
-  ts-node@10.9.2(@types/node@18.19.116)(typescript@5.8.3):
+  ts-node@10.9.2(@types/node@22.16.2)(typescript@5.8.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.11
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
-      '@types/node': 18.19.116
+      '@types/node': 22.16.2
       acorn: 8.15.0
       acorn-walk: 8.3.4
       arg: 4.1.3
@@ -12014,11 +11967,7 @@ snapshots:
 
   ufo@1.6.1: {}
 
-  undici-types@5.26.5: {}
-
   undici-types@6.21.0: {}
-
-  undici-types@7.8.0: {}
 
   unicorn-magic@0.1.0: {}
 
@@ -12115,27 +12064,6 @@ snapshots:
     dependencies:
       vite: 6.3.5(@types/node@22.16.2)(jiti@2.4.2)(sass-embedded@1.89.2)(sass@1.89.2)(terser@5.43.1)
 
-  vite-node@3.2.4(@types/node@18.19.116)(jiti@2.4.2)(sass-embedded@1.89.2)(sass@1.89.2)(terser@5.43.1):
-    dependencies:
-      cac: 6.7.14
-      debug: 4.4.1
-      es-module-lexer: 1.7.0
-      pathe: 2.0.3
-      vite: 6.3.5(@types/node@18.19.116)(jiti@2.4.2)(sass-embedded@1.89.2)(sass@1.89.2)(terser@5.43.1)
-    transitivePeerDependencies:
-      - '@types/node'
-      - jiti
-      - less
-      - lightningcss
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - yaml
-
   vite-node@3.2.4(@types/node@22.16.2)(jiti@2.4.2)(sass-embedded@1.89.2)(sass@1.89.2)(terser@5.43.1):
     dependencies:
       cac: 6.7.14
@@ -12221,32 +12149,16 @@ snapshots:
       svgo: 3.3.2
       vue: 3.5.17(typescript@5.8.3)
 
-  vite-tsconfig-paths@5.1.4(typescript@5.8.3)(vite@6.3.5(@types/node@18.19.116)(jiti@2.4.2)(sass-embedded@1.89.2)(sass@1.89.2)(terser@5.43.1)):
+  vite-tsconfig-paths@5.1.4(typescript@5.8.3)(vite@6.3.5(@types/node@22.16.2)(jiti@2.4.2)(sass-embedded@1.89.2)(sass@1.89.2)(terser@5.43.1)):
     dependencies:
       debug: 4.4.1
       globrex: 0.1.2
       tsconfck: 3.1.6(typescript@5.8.3)
     optionalDependencies:
-      vite: 6.3.5(@types/node@18.19.116)(jiti@2.4.2)(sass-embedded@1.89.2)(sass@1.89.2)(terser@5.43.1)
+      vite: 6.3.5(@types/node@22.16.2)(jiti@2.4.2)(sass-embedded@1.89.2)(sass@1.89.2)(terser@5.43.1)
     transitivePeerDependencies:
       - supports-color
       - typescript
-
-  vite@6.3.5(@types/node@18.19.116)(jiti@2.4.2)(sass-embedded@1.89.2)(sass@1.89.2)(terser@5.43.1):
-    dependencies:
-      esbuild: 0.25.6
-      fdir: 6.4.6(picomatch@4.0.2)
-      picomatch: 4.0.2
-      postcss: 8.5.6
-      rollup: 4.44.2
-      tinyglobby: 0.2.14
-    optionalDependencies:
-      '@types/node': 18.19.116
-      fsevents: 2.3.3
-      jiti: 2.4.2
-      sass: 1.89.2
-      sass-embedded: 1.89.2
-      terser: 5.43.1
 
   vite@6.3.5(@types/node@22.16.2)(jiti@2.4.2)(sass-embedded@1.89.2)(sass@1.89.2)(terser@5.43.1):
     dependencies:
@@ -12263,48 +12175,6 @@ snapshots:
       sass: 1.89.2
       sass-embedded: 1.89.2
       terser: 5.43.1
-
-  vitest@3.2.4(@types/node@18.19.116)(jiti@2.4.2)(jsdom@26.1.0(canvas@3.1.2))(sass-embedded@1.89.2)(sass@1.89.2)(terser@5.43.1):
-    dependencies:
-      '@types/chai': 5.2.2
-      '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@6.3.5(@types/node@18.19.116)(jiti@2.4.2)(sass-embedded@1.89.2)(sass@1.89.2)(terser@5.43.1))
-      '@vitest/pretty-format': 3.2.4
-      '@vitest/runner': 3.2.4
-      '@vitest/snapshot': 3.2.4
-      '@vitest/spy': 3.2.4
-      '@vitest/utils': 3.2.4
-      chai: 5.2.1
-      debug: 4.4.1
-      expect-type: 1.2.2
-      magic-string: 0.30.17
-      pathe: 2.0.3
-      picomatch: 4.0.2
-      std-env: 3.9.0
-      tinybench: 2.9.0
-      tinyexec: 0.3.2
-      tinyglobby: 0.2.14
-      tinypool: 1.1.1
-      tinyrainbow: 2.0.0
-      vite: 6.3.5(@types/node@18.19.116)(jiti@2.4.2)(sass-embedded@1.89.2)(sass@1.89.2)(terser@5.43.1)
-      vite-node: 3.2.4(@types/node@18.19.116)(jiti@2.4.2)(sass-embedded@1.89.2)(sass@1.89.2)(terser@5.43.1)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@types/node': 18.19.116
-      jsdom: 26.1.0(canvas@3.1.2)
-    transitivePeerDependencies:
-      - jiti
-      - less
-      - lightningcss
-      - msw
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - yaml
 
   vitest@3.2.4(@types/node@22.16.2)(jiti@2.4.2)(jsdom@26.1.0(canvas@3.1.2))(sass-embedded@1.89.2)(sass@1.89.2)(terser@5.43.1):
     dependencies:


### PR DESCRIPTION
## Summary
- unify `@types/node` versions across workspace

## Testing
- `pnpm --filter frontend exec -- vitest run`
- `pnpm --filter backend exec -- vitest run`


------
https://chatgpt.com/codex/tasks/task_e_686e4f3e9cac8331bf6f040d2e2cbec9