### PR TITLE
Reduce large flag icon CSS

### DIFF
--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -39,6 +39,7 @@
     "bootstrap": "^5.3.7",
     "bootstrap-vue-next": "^0.30.4",
     "find-up": "^7.0.0",
+    "flag-icons": "^7.5.0",
     "i18n-iso-countries": "^7.14.0",
     "luxon": "^3.6.1",
     "mitt": "^3.0.1",
@@ -53,10 +54,8 @@
     "vue-multiselect": "github:peterzen/vue-multiselect",
     "vue-router": "^4.5.1",
     "vue-toastification": "2.0.0-rc.5",
-    "vue3-flag-icons": "^0.0.3",
     "workbox-precaching": "^7.3.0",
-    "workbox-window": "^7.3.0",
-    "flag-icons": "^7.5.0"
+    "workbox-window": "^7.3.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.30.1",

--- a/apps/frontend/src/features/shared/profiledisplay/LocationLabel.vue
+++ b/apps/frontend/src/features/shared/profiledisplay/LocationLabel.vue
@@ -51,12 +51,12 @@ const countryCode = computed(() => {
       <span v-if="showCountryLabel">
         {{ countryName }}
       </span>
-      <span v-if="showCountryIcon" class="flag-icon" @click="$event.stopPropagation()">
+      <span v-if="showCountryIcon" @click="$event.stopPropagation()">
         <BTooltip :delay="100" placement="top" :title="countryName">
           <template #target>
             <CountryFlag 
               :code="countryCode"
-              size="36"
+              size="32"
               circle
               :title="countryName"
             />

--- a/apps/frontend/src/features/shared/ui/CountryFlag.vue
+++ b/apps/frontend/src/features/shared/ui/CountryFlag.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import FlagIcon, { type CountryCode } from 'vue3-flag-icons'
 import 'flag-icons/css/flag-icons.min.css'
 
 defineProps<{
@@ -9,11 +8,20 @@ defineProps<{
 }>()
 </script>
 <template>
-  <FlagIcon
-    :code="code as CountryCode"
-    circle
-    v-if="code"
-    :title="title ?? ''"
-    v-bind:size="size"
-  />
+  <div
+    class="fis flag-icon"
+    :class="`fi-${code?.toLowerCase()}`"
+    :title="title"
+    :style="{ width: size + 'px', height: size + 'px' }"
+  ></div>
 </template>
+<style>
+.flag-icon {
+  width: 100%;
+  height: 100%;
+  background-size: contain;
+  background-position: 50%;
+  background-repeat: no-repeat;
+  border-radius: 50%;
+}
+</style>

--- a/apps/frontend/vite.config.ts
+++ b/apps/frontend/vite.config.ts
@@ -38,20 +38,9 @@ export default defineConfig(({ mode }: ConfigEnv): UserConfig => {
             if (id.includes('assets/icons')) {
               return 'icons'
             }
-            if (id.includes('vue3-flag-icons')) {
+            if (id.includes('flag-icons')) {
               return 'flags'
             }
-            // output: {
-            //   manualChunks(id) {
-            //     if (id.includes('features/auth')) {
-            //       return 'auth'
-            //     }
-            //     if (id.includes('assets/icons')) {
-            //       return 'icons'
-            //     }
-            //   }
-            // }
-
           }
         }
       }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -358,9 +358,6 @@ importers:
       vue-toastification:
         specifier: 2.0.0-rc.5
         version: 2.0.0-rc.5(vue@3.5.17(typescript@5.8.3))
-      vue3-flag-icons:
-        specifier: ^0.0.3
-        version: 0.0.3(vue@3.5.17(typescript@5.8.3))
       workbox-precaching:
         specifier: ^7.3.0
         version: 7.3.0
@@ -6199,11 +6196,6 @@ packages:
     hasBin: true
     peerDependencies:
       typescript: '>=5.0.0'
-
-  vue3-flag-icons@0.0.3:
-    resolution: {integrity: sha512-DtRMzdn6iFTwdOazJLMIZNMcJmNzgTOfZY88y9kfPJ6o3gJFkIJJKsBaUmynv0/rkOIX8sHnmwx3f4GgtKjy5A==}
-    peerDependencies:
-      vue: ^3.3.4
 
   vue@3.5.17:
     resolution: {integrity: sha512-LbHV3xPN9BeljML+Xctq4lbz2lVHCR6DtbpTf5XIO6gugpXUN49j2QQPcMj086r9+AkJ0FfUT8xjulKKBkkr9g==}
@@ -12508,11 +12500,6 @@ snapshots:
       '@volar/typescript': 2.4.15
       '@vue/language-core': 2.2.12(typescript@5.8.3)
       typescript: 5.8.3
-
-  vue3-flag-icons@0.0.3(vue@3.5.17(typescript@5.8.3)):
-    dependencies:
-      flag-icons: 7.5.0
-      vue: 3.5.17(typescript@5.8.3)
 
   vue@3.5.17(typescript@5.8.3):
     dependencies:


### PR DESCRIPTION
## Summary
- cut down `vue3-flag-icons` style bloat
- import `flag-icons` css instead
- declare `flag-icons` as a dependency

## Testing
- `pnpm build` *(fails: Could not load @intlify/unplugin-vue-i18n/messages)*

------
https://chatgpt.com/codex/tasks/task_e_687013430ba48331b975b4a196c1b625