### PR TITLE
Implement NotifierService

### DIFF
--- a/apps/backend/src/__tests__/routes/user.route.spec.ts
+++ b/apps/backend/src/__tests__/routes/user.route.spec.ts
@@ -20,7 +20,9 @@ vi.mock('../../services/captcha.service', () => ({
     }
   },
 }))
-vi.mock('../../queues/emailQueue', () => ({ emailQueue: { add: vi.fn() } }))
+vi.mock('../../services/notifier.service', () => ({
+  notifierService: { notifyUser: vi.fn() },
+}))
 vi.mock('@shared/config/appconfig', () => ({
   appConfig: {
     ALTCHA_HMAC_KEY: 'x',
@@ -116,16 +118,14 @@ describe('GET /otp-login', () => {
     const newProfile = { id: 'profile2' }
     mockProfileService.initializeProfiles.mockResolvedValue(newProfile)
     fastify.jwt = { sign: vi.fn().mockReturnValue('jwt-token2') }
-    const emailQueue = (await import('../../queues/emailQueue')).emailQueue
+    const notifier = (await import('../../services/notifier.service')).notifierService
     // @ts-expect-error whatever
-    emailQueue.add.mockClear()
+    notifier.notifyUser.mockClear()
     const req = { query: { userId: 'cmc7t45x400086w39gj30pzn3', otp: '654321' } }
     await handler(req as any, reply as any)
-    expect(emailQueue.add).toHaveBeenCalledWith(
-      'sendWelcomeEmail',
-      { userId: 'user2' },
-      { attempts: 3, backoff: { type: 'exponential', delay: 5000 } }
-    )
+    expect(notifier.notifyUser).toHaveBeenCalledWith('user2', 'welcome', {
+      link: 'http://test/me',
+    })
     expect(mockProfileService.initializeProfiles).toHaveBeenCalledWith('user2')
     expect(reply.statusCode).toBe(200)
     expect(reply.payload.success).toBe(true)
@@ -143,12 +143,12 @@ describe('GET /otp-login', () => {
 
   describe('POST /send-login-link', () => {
     let handler: any
-    let emailQueue: any
+    let notifier: any
 
     beforeEach(async () => {
       handler = fastify.routes['POST /send-login-link']
-      emailQueue = (await import('../../queues/emailQueue')).emailQueue
-      emailQueue.add.mockClear()
+      notifier = (await import('../../services/notifier.service')).notifierService
+      notifier.notifyUser.mockClear()
     })
 
     it('returns 400 if input is invalid', async () => {
@@ -217,11 +217,10 @@ describe('GET /otp-login', () => {
       }
       await handler(req as any, reply as any)
       expect(mockUserService.generateOTP).toHaveBeenCalled()
-      expect(emailQueue.add).toHaveBeenCalledWith(
-        'sendLoginLinkEmail',
-        { userId: 'user3' },
-        { attempts: 3, backoff: { type: 'exponential', delay: 5000 } }
-      )
+      expect(notifier.notifyUser).toHaveBeenCalledWith('user3', 'login_link', {
+        otp: '123456',
+        link: 'http://test/auth/otp?otp=123456',
+      })
       expect(reply.statusCode).toBe(200)
       expect(reply.payload.success).toBe(true)
       expect(reply.payload.status).toBe('register')
@@ -248,11 +247,10 @@ describe('GET /otp-login', () => {
       }
       await handler(req as any, reply as any)
       expect(mockUserService.generateOTP).toHaveBeenCalled()
-      expect(emailQueue.add).toHaveBeenCalledWith(
-        'sendLoginLinkEmail',
-        { userId: 'user4' },
-        { attempts: 3, backoff: { type: 'exponential', delay: 5000 } }
-      )
+      expect(notifier.notifyUser).toHaveBeenCalledWith('user4', 'login_link', {
+        otp: '123456',
+        link: 'http://test/auth/otp?otp=123456',
+      })
       expect(reply.statusCode).toBe(200)
       expect(reply.payload.success).toBe(true)
       expect(reply.payload.status).toBe('login')

--- a/apps/backend/src/__tests__/routes/user.route.spec.ts
+++ b/apps/backend/src/__tests__/routes/user.route.spec.ts
@@ -23,7 +23,7 @@ vi.mock('../../services/captcha.service', () => ({
 vi.mock('../../services/notifier.service', () => ({
   notifierService: { notifyUser: vi.fn() },
 }))
-vi.mock('@shared/config/appconfig', () => ({
+vi.mock('@/lib/appconfig', () => ({
   appConfig: {
     ALTCHA_HMAC_KEY: 'x',
     SMS_API_KEY: 'k',

--- a/apps/backend/src/api/routes/interaction.route.ts
+++ b/apps/backend/src/api/routes/interaction.route.ts
@@ -5,6 +5,8 @@ import type { InteractionEdgeCountResponse, InteractionEdgeResponse, Interaction
 import { InteractionService } from '@/services/interaction.service'
 import { broadcastToProfile } from '@/utils/wsUtils'
 import { WebPushService } from '@/services/webpush.service'
+import { notifierService } from '@/services/notifier.service'
+import { appConfig } from '@/lib/appconfig'
 
 // Route params for ID lookups
 const TargetLookupParamsSchema = z.object({
@@ -57,6 +59,17 @@ const interactionRoutes: FastifyPluginAsync = async fastify => {
         type: likeResult.isMatch ? 'ws:new_match' : 'ws:new_like',
         payload: likeResult.to,
       })
+
+      if (likeResult.isMatch) {
+        await notifierService.notifyProfile(targetId, 'new_match', {
+          name: likeResult.from.profile.publicName,
+          link: `${appConfig.FRONTEND_URL}/matches`,
+        })
+      } else {
+        await notifierService.notifyProfile(targetId, 'new_like', {
+          link: `${appConfig.FRONTEND_URL}/browse/dating`,
+        })
+      }
 
       // webPushService.send(edge)
 

--- a/apps/backend/src/api/routes/messaging.route.ts
+++ b/apps/backend/src/api/routes/messaging.route.ts
@@ -158,19 +158,19 @@ const messageRoutes: FastifyPluginAsync = async fastify => {
       reply.code(200).send(response)
 
       // Broadcast the new message to the recipient's WebSocket connections
-      const ok = broadcastToProfile(fastify, profileId, {
+      const isWsBroadcasted = broadcastToProfile(fastify, profileId, {
         type: 'ws:new_message',
         payload: messageDTO,
       })
 
-      webPushService.send(messageDTO)
-
-      await notifierService.notifyProfile(profileId, 'new_message', {
-        sender: messageDTO.sender.publicName,
-        message: messageDTO.content,
-        link: `${appConfig.FRONTEND_URL}/messages`,
-      })
-
+      if (!isWsBroadcasted) {
+        await notifierService.notifyProfile(profileId, 'new_message', {
+          sender: messageDTO.sender.publicName,
+          message: messageDTO.content,
+          link: `${appConfig.FRONTEND_URL}/inbox`,
+        })
+      // webPushService.send(messageDTO)
+      }
     } catch (error: any) {
       return sendError(reply, 403, error)
     }

--- a/apps/backend/src/api/routes/messaging.route.ts
+++ b/apps/backend/src/api/routes/messaging.route.ts
@@ -19,6 +19,8 @@ import type {
 import { broadcastToProfile } from '@/utils/wsUtils'
 import { SendMessagePayloadSchema } from '@zod/messaging/messaging.dto'
 import { InteractionService } from '../../services/interaction.service'
+import { notifierService } from '@/services/notifier.service'
+import { appConfig } from '@/lib/appconfig'
 
 // Route params for ID lookups
 const IdLookupParamsSchema = z.object({
@@ -162,6 +164,12 @@ const messageRoutes: FastifyPluginAsync = async fastify => {
       })
 
       webPushService.send(messageDTO)
+
+      await notifierService.notifyProfile(profileId, 'new_message', {
+        sender: messageDTO.sender.publicName,
+        message: messageDTO.content,
+        link: `${appConfig.FRONTEND_URL}/messages`,
+      })
 
     } catch (error: any) {
       return sendError(reply, 403, error)

--- a/apps/backend/src/queues/dispatcher.ts
+++ b/apps/backend/src/queues/dispatcher.ts
@@ -1,0 +1,13 @@
+import { emailQueue } from './emailQueue'
+
+export class Dispatcher {
+  async sendEmail(to: string, subject: string, html: string) {
+    await emailQueue.add(
+      'sendEmail',
+      { to, subject, html },
+      { attempts: 3, backoff: { type: 'exponential', delay: 5000 } }
+    )
+  }
+}
+
+export const dispatcher = new Dispatcher()

--- a/apps/backend/src/services/email.service.ts
+++ b/apps/backend/src/services/email.service.ts
@@ -27,23 +27,6 @@ export class EmailService {
     return this.transporter.sendMail(mailOptions)
   }
 
-  async sendConfirmationEmail(to: string, token: string) {
-    const confirmUrl = `${appConfig.FRONTEND_URL}/confirm-email?token=${token}`
-    const html = `
-      <p>Thank you for registering! Please confirm your email by clicking the link below:</p>
-      <a href="${confirmUrl}">${confirmUrl}</a>
-    `
-    return this.sendMail(to, 'Confirm your email address', html)
-  }
-
-  async sendPasswordRecoveryEmail(to: string, token: string) {
-    const confirmUrl = `${appConfig.FRONTEND_URL}/confirm-email?token=${token}`
-    const html = `
-      <p>Thank you for registering! Please confirm your email by clicking the link below:</p>
-      <a href="${confirmUrl}">${confirmUrl}</a>
-    `
-    return this.sendMail(to, 'Confirm your email address', html)
-  }
 }
 
 export const emailService = new EmailService()

--- a/apps/backend/src/services/notifier.service.ts
+++ b/apps/backend/src/services/notifier.service.ts
@@ -1,0 +1,79 @@
+import { prisma } from '@/lib/prisma'
+import { appConfig } from '@/lib/appconfig'
+import i18next from 'i18next'
+import { dispatcher } from '@/queues/dispatcher'
+
+export type NotificationType =
+  | 'login_link'
+  | 'welcome'
+  | 'new_message'
+  | 'new_like'
+  | 'new_match'
+
+export interface NotificationTemplates {
+  login_link: { otp: string; link: string }
+  welcome: { link: string }
+  new_message: { sender: string; message: string; link: string }
+  new_like: { link: string }
+  new_match: { name: string; link: string }
+}
+
+export class NotifierService {
+  private static instance: NotifierService
+
+  public static getInstance(): NotifierService {
+    if (!NotifierService.instance) {
+      NotifierService.instance = new NotifierService()
+    }
+    return NotifierService.instance
+  }
+
+  constructor(private disp = dispatcher) {}
+
+  private templateName(type: NotificationType): string {
+    switch (type) {
+      case 'login_link':
+        return 'loginLink'
+      case 'welcome':
+        return 'welcome'
+      case 'new_message':
+        return 'new_message'
+      case 'new_like':
+        return 'new_like'
+      case 'new_match':
+        return 'new_match'
+    }
+  }
+
+  async notifyUser<T extends NotificationType>(
+    userId: string,
+    type: T,
+    args: NotificationTemplates[T]
+  ): Promise<void> {
+    const user = await prisma.user.findUnique({ where: { id: userId } })
+    if (!user || !user.email) return
+
+    const t = i18next.getFixedT(user.language || 'en')
+    const siteName = appConfig.SITE_NAME || 'OpenCupid'
+    const tmpl = this.templateName(type)
+    const subject = t(`emails.${tmpl}.subject`, { siteName, ...(args as any) })
+    const html = t(`emails.${tmpl}.html`, { siteName, ...(args as any) })
+
+    await this.disp.sendEmail(user.email, subject, html)
+  }
+
+  async notifyProfile<T extends NotificationType>(
+    profileId: string,
+    type: T,
+    args: NotificationTemplates[T]
+  ): Promise<void> {
+    const profile = await prisma.profile.findUnique({
+      where: { id: profileId },
+      include: { user: true },
+    })
+    if (!profile?.user) return
+    await this.notifyUser(profile.user.id, type, args)
+  }
+}
+
+export const notifierService = NotifierService.getInstance()

--- a/apps/backend/src/workers/emailWorker.ts
+++ b/apps/backend/src/workers/emailWorker.ts
@@ -67,6 +67,58 @@ new Worker(
         html: t('emails.welcome.html', { link, siteName }),
       })
     }
+
+    if (job.name === 'sendMessageNotificationEmail') {
+      const { userId, sender } = job.data as { userId: string, sender: string }
+
+      const user = await prisma.user.findUnique({ where: { id: userId } })
+      if (!user) throw new Error('User not found')
+      if (!user.email) throw new Error('Email not found for user')
+
+      const t = i18next.getFixedT(user.language || 'en')
+      const link = `${appConfig.FRONTEND_URL}/messages`
+      await transporter.sendMail({
+        from: appConfig.EMAIL_FROM,
+        to: user.email,
+        subject: t('emails.new_message.subject', { siteName }),
+        html: t('emails.new_message.html', { link, siteName, sender }),
+      })
+    }
+
+    if (job.name === 'sendLikeNotificationEmail') {
+      const { userId } = job.data as { userId: string }
+
+      const user = await prisma.user.findUnique({ where: { id: userId } })
+      if (!user) throw new Error('User not found')
+      if (!user.email) throw new Error('Email not found for user')
+
+      const t = i18next.getFixedT(user.language || 'en')
+      const link = `${appConfig.FRONTEND_URL}/browse/dating`
+      await transporter.sendMail({
+        from: appConfig.EMAIL_FROM,
+        to: user.email,
+        subject: t('emails.new_like.subject', { siteName }),
+        html: t('emails.new_like.html', { link, siteName }),
+      })
+    }
+
+
+    if (job.name === 'sendMatchNotificationEmail') {
+      const { userId, name } = job.data as { userId: string, name: string }
+
+      const user = await prisma.user.findUnique({ where: { id: userId } })
+      if (!user) throw new Error('User not found')
+      if (!user.email) throw new Error('Email not found for user')
+
+      const t = i18next.getFixedT(user.language || 'en')
+      const link = `${appConfig.FRONTEND_URL}/matches`
+      await transporter.sendMail({
+        from: appConfig.EMAIL_FROM,
+        to: user.email,
+        subject: t('emails.new_match.subject', { siteName }),
+        html: t('emails.new_match.html', { link, siteName, name }),
+      })
+    }
   },
   { connection }
 )

--- a/apps/backend/src/workers/emailWorker.ts
+++ b/apps/backend/src/workers/emailWorker.ts
@@ -1,19 +1,14 @@
-// src/workers/emailWorker.ts
 import { Worker } from 'bullmq'
 import IORedis from 'ioredis'
-import { prisma } from '../lib/prisma'
 import nodemailer from 'nodemailer'
 import { appConfig } from '@/lib/appconfig'
-import i18next from 'i18next'
 
 const redisUrl = appConfig.REDIS_URL
 if (!redisUrl) {
   throw new Error('REDIS_URL environment variable is not defined')
 }
 
-const connection = new IORedis(redisUrl, {
-  maxRetriesPerRequest: null,
-})
+const connection = new IORedis(redisUrl, { maxRetriesPerRequest: null })
 
 const transporter = nodemailer.createTransport({
   host: appConfig.SMTP_HOST,
@@ -25,100 +20,21 @@ const transporter = nodemailer.createTransport({
   },
 })
 
-
-
 new Worker(
   'emails',
   async job => {
-    const siteName = appConfig.SITE_NAME || 'OpenCupid'
-
-    if (job.name === 'sendLoginLinkEmail') {
-      const { userId } = job.data as { userId: string }
-
-      const user = await prisma.user.findUnique({ where: { id: userId } })
-      if (!user) throw new Error('User not found')
-
-      const otp = user.loginToken
-      if (!otp || !user.email) throw new Error('OTP or email not found for user')
-
-      const t = i18next.getFixedT(user.language || 'en')
-      const link = `${appConfig.FRONTEND_URL}/auth/otp?otp=${otp}`
-      await transporter.sendMail({
-        from: appConfig.EMAIL_FROM,
-        to: user.email,
-        subject: t('emails.loginLink.subject', { siteName }),
-        html: t('emails.loginLink.html', { otp, link, siteName }),
-      })
+    const { to, subject, html } = job.data as {
+      to: string
+      subject: string
+      html: string
     }
 
-    if (job.name === 'sendWelcomeEmail') {
-      const { userId } = job.data as { userId: string }
-
-      const user = await prisma.user.findUnique({ where: { id: userId } })
-      if (!user) throw new Error('User not found')
-      if (!user.email) throw new Error('Email not found for user')
-
-      const t = i18next.getFixedT(user.language || 'en')
-      const link = `${appConfig.FRONTEND_URL}/me`
-      await transporter.sendMail({
-        from: appConfig.EMAIL_FROM,
-        to: user.email,
-        subject: t('emails.welcome.subject', { siteName }),
-        html: t('emails.welcome.html', { link, siteName }),
-      })
-    }
-
-    if (job.name === 'sendMessageNotificationEmail') {
-      const { userId, sender } = job.data as { userId: string, sender: string }
-
-      const user = await prisma.user.findUnique({ where: { id: userId } })
-      if (!user) throw new Error('User not found')
-      if (!user.email) throw new Error('Email not found for user')
-
-      const t = i18next.getFixedT(user.language || 'en')
-      const link = `${appConfig.FRONTEND_URL}/messages`
-      await transporter.sendMail({
-        from: appConfig.EMAIL_FROM,
-        to: user.email,
-        subject: t('emails.new_message.subject', { siteName }),
-        html: t('emails.new_message.html', { link, siteName, sender }),
-      })
-    }
-
-    if (job.name === 'sendLikeNotificationEmail') {
-      const { userId } = job.data as { userId: string }
-
-      const user = await prisma.user.findUnique({ where: { id: userId } })
-      if (!user) throw new Error('User not found')
-      if (!user.email) throw new Error('Email not found for user')
-
-      const t = i18next.getFixedT(user.language || 'en')
-      const link = `${appConfig.FRONTEND_URL}/browse/dating`
-      await transporter.sendMail({
-        from: appConfig.EMAIL_FROM,
-        to: user.email,
-        subject: t('emails.new_like.subject', { siteName }),
-        html: t('emails.new_like.html', { link, siteName }),
-      })
-    }
-
-
-    if (job.name === 'sendMatchNotificationEmail') {
-      const { userId, name } = job.data as { userId: string, name: string }
-
-      const user = await prisma.user.findUnique({ where: { id: userId } })
-      if (!user) throw new Error('User not found')
-      if (!user.email) throw new Error('Email not found for user')
-
-      const t = i18next.getFixedT(user.language || 'en')
-      const link = `${appConfig.FRONTEND_URL}/matches`
-      await transporter.sendMail({
-        from: appConfig.EMAIL_FROM,
-        to: user.email,
-        subject: t('emails.new_match.subject', { siteName }),
-        html: t('emails.new_match.html', { link, siteName, name }),
-      })
-    }
+    await transporter.sendMail({
+      from: appConfig.EMAIL_FROM,
+      to,
+      subject,
+      html,
+    })
   },
   { connection }
 )

--- a/apps/frontend/src/features/publicprofile/components/ProfileContent.vue
+++ b/apps/frontend/src/features/publicprofile/components/ProfileContent.vue
@@ -29,7 +29,7 @@ const props = defineProps<{
 }>()
 
 const viewerProfile = inject<Ref<OwnerProfile>>('viewerProfile') 
-const viewerLocation = ref(viewerProfile?.value.location)
+const viewerLocation = ref(viewerProfile?.value?.location)
 </script>
 
 <template>

--- a/packages/shared/i18n/api/en.json
+++ b/packages/shared/i18n/api/en.json
@@ -10,6 +10,18 @@
     "welcome": {
       "subject": "[{{siteName}}] Welcome!",
       "html": "<p>Hey there, welcome aboard!</p><a href=\"{{link}}\">Go connect with people</a></p>"
+    },
+    "new_message":{
+      "subject": "[{{siteName}}] You have a new message",
+      "html": "<p>Hey there,</p><p>You have a new message from <strong>{{sender}}</strong>:</p><blockquote>{{message}}</blockquote><p><a href=\"{{link}}\">Click here to read it</a></p>"
+    },
+    "new_like":{
+      "subject": "[{{siteName}}] You have a new like",
+      "html": "<p>Hey there,</p>Someone sent you a ❤️<p><p><a href=\"{{link}}\">Find out who</a></p>"
+    },
+    "new_match":{
+      "subject": "[{{siteName}}] You have a new match!",
+      "html": "<p>Hey there,</p><p>You matched with {{name}}<p><a href=\"{{link}}\">Click here to read it</a></p>"
     }
   }
 }


### PR DESCRIPTION
## Summary
- add NotifierService with typed templates
- add queue Dispatcher for notifications
- simplify emailWorker to only send emails
- send emails via NotifierService from user, interaction and messaging routes
- update unit tests

## Testing
- `pnpm --filter backend lint` *(fails: Cannot find package '@eslint/js')*
- `pnpm --filter backend test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68712e91363883318f4b86636b643f6e