### PR TITLE
Protect images with scoped token

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -58,7 +58,8 @@
     "ts-node": "^10.9.2",
     "web-push": "^3.6.7",
     "ws": "^8.18.2",
-    "zod": "^3.24.4"
+    "zod": "^3.24.4",
+    "cookie": "^0.7.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.28.0",

--- a/apps/backend/src/api/index.ts
+++ b/apps/backend/src/api/index.ts
@@ -7,6 +7,7 @@ import captchaRoutes from './routes/captcha.route'
 import messageRoutes from './routes/messaging.route'
 import pushRoutes from './routes/push.routes'
 import imageRoutes from './routes/image.route'
+import imageAuthRoutes from './routes/imageAuth.route'
 import findProfileRoutes from './routes/findProfile.route'
 import appRoutes from './routes/app.route'
 import interactionRoutes from './routes/interaction.route'
@@ -22,6 +23,7 @@ const api: FastifyPluginAsync = async fastify => {
   fastify.register(pushRoutes, { prefix: '/push' })
   fastify.register(imageRoutes, { prefix: '/image' })
   fastify.register(findProfileRoutes, { prefix: '/find' })
+  fastify.register(imageAuthRoutes, { prefix: '/auth' })
   fastify.register(appRoutes, { prefix: '/app' })
 }
 

--- a/apps/backend/src/api/routes/imageAuth.route.ts
+++ b/apps/backend/src/api/routes/imageAuth.route.ts
@@ -1,0 +1,35 @@
+import { FastifyPluginAsync } from 'fastify'
+import { parse as parseCookie, serialize as serializeCookie } from 'cookie'
+import { appConfig } from '@/lib/appconfig'
+import { sendUnauthorizedError } from '../helpers'
+
+const imageAuthRoutes: FastifyPluginAsync = async fastify => {
+  fastify.get('/image-token', { onRequest: [fastify.authenticate] }, async (req, reply) => {
+    const payload = { userId: req.user.userId, profileId: req.user.profileId }
+    const token = fastify.jwt.sign(payload)
+
+    const cookie = serializeCookie('ImageAccessToken', token, {
+      httpOnly: true,
+      secure: true,
+      sameSite: 'strict',
+      path: '/images',
+      domain: appConfig.DOMAIN,
+    })
+    reply.header('Set-Cookie', cookie)
+    return reply.code(200).send({ success: true })
+  })
+
+  fastify.get('/image', async (req, reply) => {
+    const cookies = parseCookie(req.headers.cookie || '')
+    const token = cookies['ImageAccessToken']
+    if (!token) return sendUnauthorizedError(reply)
+    try {
+      fastify.jwt.verify(token)
+      return reply.code(204).send()
+    } catch (err) {
+      return sendUnauthorizedError(reply)
+    }
+  })
+}
+
+export default imageAuthRoutes

--- a/apps/ingress/nginx.conf.template
+++ b/apps/ingress/nginx.conf.template
@@ -101,10 +101,17 @@ http {
     }
 
     location /images/ {
+      auth_request /auth/image;
       alias /var/www/;
       autoindex off;
       try_files $uri =404;
       add_header Cache-Control "public, max-age=31536000, immutable";
+    }
+
+    location = /auth/image {
+      internal;
+      proxy_pass http://backend/api/auth/image;
+      proxy_set_header Cookie $http_cookie;
     }
 
     location /.well-known/acme-challenge/ {


### PR DESCRIPTION
## Summary
- issue and verify ImageAccessToken for /images requests
- register auth route
- secure /images in nginx via auth_request
- add cookie library for backend

## Testing
- `pnpm --filter backend test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68703f6e1ff483319905086aa8ad5d56