### PR TITLE
Add reprocess images script

### DIFF
--- a/apps/backend/scripts/reprocess-images.js
+++ b/apps/backend/scripts/reprocess-images.js
@@ -1,0 +1,39 @@
+import 'dotenv/config'
+import path from 'path'
+import fs from 'fs'
+import { PrismaClient } from '@prisma/client'
+import { ImageService } from '../src/services/image.service'
+import { getImageRoot } from '../src/lib/media'
+
+const prisma = new PrismaClient()
+const imageService = ImageService.getInstance()
+
+async function main() {
+  const images = await prisma.profileImage.findMany()
+
+  for (const img of images) {
+    const basePath = path.join(getImageRoot(), img.storagePath)
+    const originalFile = `${basePath}-original.jpg`
+    const outputDir = path.dirname(basePath)
+    const baseName = path.basename(basePath)
+
+    if (!fs.existsSync(originalFile)) {
+      console.warn(`⚠️  Original file not found for ${img.id}: ${originalFile}`)
+      continue
+    }
+
+    try {
+      console.log(`Reprocessing ${img.id}`)
+      await imageService.processImage(originalFile, outputDir, baseName)
+      console.log(`✔ Reprocessed ${img.id}`)
+    } catch (err) {
+      console.error(`❌ Failed to reprocess image ${img.id}:`, err)
+    }
+  }
+}
+
+main()
+  .catch(err => {
+    console.error(err)
+  })
+  .finally(() => prisma.$disconnect())

--- a/apps/backend/src/__tests__/services/image.generateVariants.spec.ts
+++ b/apps/backend/src/__tests__/services/image.generateVariants.spec.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest'
+import { ImageService } from '../../services/image.service'
+import { FaceDetectionService } from '../../services/face-detection.service'
+import path from 'path'
+import fs from 'fs'
+import sharp from 'sharp'
+
+const imageService = ImageService.getInstance()
+const faceService = FaceDetectionService.getInstance()
+let outputDir: string
+let inputDir: string
+
+beforeAll(async () => {
+  process.env.FACEAPI_ENABLED = 'true'
+  vi.spyOn(faceService, 'autoCrop').mockImplementation(async (input, output) => {
+    // simple center crop to simulate face detection success
+    const img = sharp(input)
+    const { width, height } = await img.metadata()
+    if (!width || !height) return false
+    const size = Math.min(width, height) / 2
+    await img
+      .extract({ left: Math.floor((width - size) / 2), top: Math.floor((height - size) / 2), width: Math.floor(size), height: Math.floor(size) })
+      .jpeg({ quality: 90 })
+      .toFile(output)
+    return true
+  })
+  outputDir = '/tmp/test-generate-variants'
+  inputDir = '/tmp/test-generate-variants-input'
+  fs.mkdirSync(outputDir, { recursive: true })
+  fs.mkdirSync(inputDir, { recursive: true })
+
+  await Promise.all([
+    sharp({ create: { width: 100, height: 100, channels: 3, background: 'white' } })
+      .png()
+      .toFile(path.join(inputDir, 'blank.png')),
+    sharp({ create: { width: 300, height: 600, channels: 3, background: 'red' } })
+      .jpeg({ quality: 90 })
+      .toFile(path.join(inputDir, 'tall.jpg')),
+    sharp({ create: { width: 600, height: 300, channels: 3, background: 'blue' } })
+      .jpeg({ quality: 90 })
+      .toFile(path.join(inputDir, 'wide.jpg')),
+    sharp({ create: { width: 200, height: 200, channels: 3, background: 'green' } })
+      .jpeg({ quality: 90 })
+      .toFile(path.join(inputDir, 'face.jpg')),
+  ])
+})
+
+afterAll(() => {
+  vi.restoreAllMocks()
+  if (fs.existsSync(outputDir)) {
+    fs.rmSync(outputDir, { recursive: true, force: true })
+  }
+  if (fs.existsSync(inputDir)) {
+    fs.rmSync(inputDir, { recursive: true, force: true })
+  }
+})
+
+const cases = ['blank.png', 'tall.jpg', 'wide.jpg', 'face.jpg']
+
+describe('ImageService.generateVariants', () => {
+  for (const file of cases) {
+    it(`generates variants for ${file}`, async () => {
+      const inputPath = path.join(inputDir, file)
+      const baseName = path.parse(file).name
+      const res = await imageService.generateVariants(inputPath, outputDir, baseName)
+
+      expect(res.width).toBeGreaterThan(0)
+      expect(res.height).toBeGreaterThan(0)
+
+      expect(res.variants.thumb).toBeDefined()
+      expect(res.variants.card).toBeDefined()
+      expect(res.variants.full).toBeDefined()
+      expect(res.variants.original).toBeUndefined()
+
+      for (const variant of ['thumb', 'card', 'full']) {
+        expect(fs.existsSync(res.variants[variant])).toBe(true)
+      }
+
+      if (file === 'face.jpg') {
+        expect(res.variants.face).toBeDefined()
+        if (res.variants.face) {
+          expect(fs.existsSync(res.variants.face)).toBe(true)
+        }
+      }
+    })
+  }
+})


### PR DESCRIPTION
## Summary
- add a script to regenerate profile image variants
- refactor `ImageService` so image variant generation can be reused
- include new test cases for variant generation using generated images
- remove image fixture files

## Testing
- `pnpm run ci:test`


------
https://chatgpt.com/codex/tasks/task_e_6874364d14e0833181808f9c567db7cd