### PR TITLE
feat: add jitsi video call support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -74,3 +74,4 @@ CERTBOT_ETCDIR=/srv/certbot
 
 # Name of the site
 SITE_NAME=OpenCupid
+JITSI_DOMAIN=meet.jit.si

--- a/apps/backend/prisma/migrations/20250715000000_add_meeting_model/migration.sql
+++ b/apps/backend/prisma/migrations/20250715000000_add_meeting_model/migration.sql
@@ -1,0 +1,13 @@
+-- CreateTable
+CREATE TABLE "Meeting" (
+    "id" TEXT NOT NULL,
+    "room" TEXT NOT NULL,
+    "createdById" TEXT NOT NULL,
+    "targetProfileId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "endedAt" TIMESTAMP(3),
+    CONSTRAINT "Meeting_pkey" PRIMARY KEY ("id"),
+    CONSTRAINT "Meeting_room_key" UNIQUE ("room"),
+    CONSTRAINT "Meeting_createdById_fkey" FOREIGN KEY ("createdById") REFERENCES "Profile"("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "Meeting_targetProfileId_fkey" FOREIGN KEY ("targetProfileId") REFERENCES "Profile"("id") ON DELETE CASCADE ON UPDATE CASCADE
+);

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -229,6 +229,9 @@ model Profile {
   likesSent     LikedProfile[] @relation("LikesSent")
   likesReceived LikedProfile[] @relation("LikesReceived")
 
+  meetingsCreated  Meeting[] @relation("MeetingsCreated")
+  meetingsReceived Meeting[] @relation("MeetingsTarget")
+
   hiddenProfiles HiddenProfile[] @relation("HiddenProfiles")
   hiddenBy       HiddenProfile[] @relation("HiddenBy")
 }
@@ -356,6 +359,17 @@ model SocialMatchFilter {
   radius    Int?    @default(50) // in km
   tags      Tag[]
   city      City?   @relation(fields: [cityId], references: [id])
+}
+
+model Meeting {
+  id             String   @id @default(cuid())
+  room           String   @unique
+  createdBy      Profile  @relation("MeetingsCreated", fields: [createdById], references: [id])
+  createdById    String
+  targetProfile  Profile  @relation("MeetingsTarget", fields: [targetProfileId], references: [id])
+  targetProfileId String
+  createdAt      DateTime @default(now())
+  endedAt        DateTime?
 }
 
 model PushSubscription {

--- a/apps/backend/src/__tests__/routes/meetings.route.spec.ts
+++ b/apps/backend/src/__tests__/routes/meetings.route.spec.ts
@@ -1,0 +1,33 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import meetingRoutes from '../../api/routes/meetings.route'
+import { MockFastify, MockReply } from '../../test-utils/fastify'
+
+let fastify: MockFastify
+let reply: MockReply
+
+beforeEach(async () => {
+  fastify = new MockFastify()
+  reply = new MockReply()
+  fastify.prisma.meeting = {
+    create: vi.fn().mockResolvedValue({ id: '1', room: 'r', createdById: 'a', targetProfileId: 'b', createdAt: new Date() }),
+    findFirst: vi.fn().mockResolvedValue({ id: '1', room: 'r', createdById: 'a', targetProfileId: 'b', createdAt: new Date() }),
+    update: vi.fn().mockResolvedValue({ id: '1', room: 'r', createdById: 'a', targetProfileId: 'b', createdAt: new Date(), endedAt: new Date() }),
+  }
+  await meetingRoutes(fastify as any, {})
+})
+
+describe('meeting routes', () => {
+  it('creates meeting', async () => {
+    const handler = fastify.routes['POST /']
+    await handler({ session: { profileId: 'a' }, body: { room: 'r', targetProfileId: 'ck00000000000000000000001' } } as any, reply as any)
+    expect(reply.statusCode).toBe(200)
+    expect(fastify.prisma.meeting.create).toHaveBeenCalled()
+  })
+
+  it('fetches latest', async () => {
+    const handler = fastify.routes['GET /latest']
+    await handler({ session: { profileId: 'a' }, query: { withProfileId: 'ck00000000000000000000001' } } as any, reply as any)
+    expect(reply.statusCode).toBe(200)
+    expect(fastify.prisma.meeting.findFirst).toHaveBeenCalled()
+  })
+})

--- a/apps/backend/src/api/index.ts
+++ b/apps/backend/src/api/index.ts
@@ -10,6 +10,7 @@ import imageRoutes from './routes/image.route'
 import findProfileRoutes from './routes/findProfile.route'
 import appRoutes from './routes/app.route'
 import interactionRoutes from './routes/interaction.route'
+import meetingRoutes from './routes/meetings.route'
 
 const api: FastifyPluginAsync = async fastify => {
   fastify.register(userRoutes, { prefix: '/users' })
@@ -23,6 +24,7 @@ const api: FastifyPluginAsync = async fastify => {
   fastify.register(imageRoutes, { prefix: '/image' })
   fastify.register(findProfileRoutes, { prefix: '/find' })
   fastify.register(appRoutes, { prefix: '/app' })
+  fastify.register(meetingRoutes, { prefix: '/meetings' })
 }
 
 export default api

--- a/apps/backend/src/api/routes/meetings.route.ts
+++ b/apps/backend/src/api/routes/meetings.route.ts
@@ -1,0 +1,78 @@
+import { FastifyPluginAsync } from 'fastify'
+import z from 'zod'
+import { sendError } from '../helpers'
+
+const createBody = z.object({
+  room: z.string(),
+  targetProfileId: z.string().cuid(),
+})
+
+const latestQuery = z.object({
+  withProfileId: z.string().cuid(),
+})
+
+const idParams = z.object({
+  id: z.string().cuid(),
+})
+
+const meetingRoutes: FastifyPluginAsync = async fastify => {
+  fastify.post('/', { onRequest: [fastify.authenticate] }, async (req, reply) => {
+    const profileId = req.session.profileId
+    if (!profileId) return sendError(reply, 401, 'Profile not found.')
+    const body = createBody.safeParse(req.body)
+    if (!body.success) return sendError(reply, 400, 'Invalid payload')
+    try {
+      const meeting = await fastify.prisma.meeting.create({
+        data: {
+          room: body.data.room,
+          createdById: profileId,
+          targetProfileId: body.data.targetProfileId,
+        },
+      })
+      return reply.code(200).send({ success: true, meeting })
+    } catch (err) {
+      fastify.log.error(err)
+      return sendError(reply, 500, 'Failed to create meeting')
+    }
+  })
+
+  fastify.get('/latest', { onRequest: [fastify.authenticate] }, async (req, reply) => {
+    const profileId = req.session.profileId
+    if (!profileId) return sendError(reply, 401, 'Profile not found.')
+    const query = latestQuery.safeParse(req.query)
+    if (!query.success) return sendError(reply, 400, 'Invalid query')
+    try {
+      const meeting = await fastify.prisma.meeting.findFirst({
+        where: {
+          endedAt: null,
+          OR: [
+            { createdById: profileId, targetProfileId: query.data.withProfileId },
+            { createdById: query.data.withProfileId, targetProfileId: profileId },
+          ],
+        },
+        orderBy: { createdAt: 'desc' },
+      })
+      return reply.code(200).send({ success: true, meeting: meeting ?? null })
+    } catch (err) {
+      fastify.log.error(err)
+      return sendError(reply, 500, 'Failed to fetch meeting')
+    }
+  })
+
+  fastify.post('/:id/end', { onRequest: [fastify.authenticate] }, async (req, reply) => {
+    const params = idParams.safeParse(req.params)
+    if (!params.success) return sendError(reply, 400, 'Invalid meeting id')
+    try {
+      const meeting = await fastify.prisma.meeting.update({
+        where: { id: params.data.id },
+        data: { endedAt: new Date() },
+      })
+      return reply.code(200).send({ success: true, meeting })
+    } catch (err) {
+      fastify.log.error(err)
+      return sendError(reply, 500, 'Failed to end meeting')
+    }
+  })
+}
+
+export default meetingRoutes

--- a/apps/backend/src/lib/appconfig.ts
+++ b/apps/backend/src/lib/appconfig.ts
@@ -59,6 +59,8 @@ export const configSchema = z.object({
   DOMAIN: z.string().default('example.org'),
 
   SITE_NAME: z.string().default('OpenCupid'),
+
+  JITSI_DOMAIN: z.string().default('meet.jit.si'),
 })
 
 if (!['production', 'staging'].includes(process.env.NODE_ENV!)) {

--- a/apps/frontend/index.html
+++ b/apps/frontend/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1, interactive-widget=resizes-visual">
+    <meta http-equiv="Content-Security-Policy" content="frame-src 'self' https://meet.jit.si; connect-src 'self' https://meet.jit.si; media-src 'self' https://meet.jit.si">
     <!--meta-head-->
 
     <link rel="icon" type="image/png" href="/assets/favicon-96x96.png" sizes="96x96" />

--- a/apps/frontend/src/features/jitsi/components/JitsiModalBVN.vue
+++ b/apps/frontend/src/features/jitsi/components/JitsiModalBVN.vue
@@ -1,0 +1,26 @@
+<script setup lang="ts">
+import { computed, watch } from 'vue'
+import { BModal } from 'bootstrap-vue-next'
+import { useJitsiStore } from '../stores/jitsi'
+
+const model = defineModel<boolean>({ default: false })
+const store = useJitsiStore()
+const room = computed(() => store.currentMeeting?.room)
+
+watch(model, value => {
+  if (!value && store.currentMeeting) {
+    store.endMeeting(store.currentMeeting.id)
+  }
+})
+</script>
+
+<template>
+  <BModal v-model="model" size="xl" hide-footer no-close-on-backdrop no-close-on-esc title="Video call">
+    <iframe
+      v-if="room"
+      :src="`https://meet.jit.si/${room}`"
+      allow="camera; microphone; fullscreen"
+      style="width: 100%; height: 80vh; border: 0"
+    />
+  </BModal>
+</template>

--- a/apps/frontend/src/features/jitsi/components/JoinCallButton.vue
+++ b/apps/frontend/src/features/jitsi/components/JoinCallButton.vue
@@ -1,0 +1,28 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import IconVideo from '@/assets/icons/interface/video-camera.svg'
+import JitsiModalBVN from './JitsiModalBVN.vue'
+import { useJitsiStore } from '../stores/jitsi'
+
+const props = defineProps<{ withProfileId: string }>()
+const store = useJitsiStore()
+const show = ref(false)
+
+async function join() {
+  const meeting = await store.fetchLatest(props.withProfileId)
+  if (meeting) {
+    show.value = true
+  } else {
+    console.info('No ongoing meeting')
+  }
+}
+</script>
+
+<template>
+  <div class="d-inline">
+    <BButton :pill="true" class="btn-overlay" @click="join">
+      <IconVideo class="svg-icon-lg p-0" />
+    </BButton>
+    <JitsiModalBVN v-model="show" />
+  </div>
+</template>

--- a/apps/frontend/src/features/jitsi/components/VideoCallButton.vue
+++ b/apps/frontend/src/features/jitsi/components/VideoCallButton.vue
@@ -1,0 +1,32 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import { useAuthStore } from '@/features/auth/stores/authStore'
+import IconVideo from '@/assets/icons/interface/video-camera.svg'
+import JitsiModalBVN from './JitsiModalBVN.vue'
+import { useJitsiStore } from '../stores/jitsi'
+
+const props = defineProps<{ targetProfileId: string; persist?: boolean }>()
+const show = ref(false)
+const store = useJitsiStore()
+const auth = useAuthStore()
+
+async function start() {
+  const myId = auth.profileId || ''
+  const room = store.makePublicRoomName(myId, props.targetProfileId)
+  if (props.persist !== false) {
+    await store.createMeeting({ room, targetProfileId: props.targetProfileId })
+  } else {
+    store.currentMeeting = { id: '', room }
+  }
+  show.value = true
+}
+</script>
+
+<template>
+  <div class="d-inline">
+    <BButton :pill="true" class="btn-overlay" @click="start">
+      <IconVideo class="svg-icon-lg p-0" />
+    </BButton>
+    <JitsiModalBVN v-model="show" />
+  </div>
+</template>

--- a/apps/frontend/src/features/jitsi/components/__tests__/VideoCallButton.spec.ts
+++ b/apps/frontend/src/features/jitsi/components/__tests__/VideoCallButton.spec.ts
@@ -1,0 +1,32 @@
+import { mount } from '@vue/test-utils'
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('../JitsiModalBVN.vue', () => ({ default: { template: '<div />' } }))
+const mockStore = {
+  makePublicRoomName: vi.fn().mockReturnValue('room'),
+  createMeeting: vi.fn().mockResolvedValue({ id: '1', room: 'room' }),
+  currentMeeting: null,
+}
+vi.mock('../../stores/jitsi', () => ({
+  useJitsiStore: () => mockStore,
+}))
+vi.mock('@/features/auth/stores/authStore', () => ({
+  useAuthStore: () => ({ profileId: 'me' }),
+}))
+
+import VideoCallButton from '../VideoCallButton.vue'
+
+describe('VideoCallButton', () => {
+  it('creates meeting on click', async () => {
+    const wrapper = mount(VideoCallButton, {
+      props: { targetProfileId: 'b' },
+      global: {
+        stubs: {
+          BButton: { template: '<button @click="$emit(\'click\')"><slot /></button>' },
+        },
+      },
+    })
+    await wrapper.find('button').trigger('click')
+    expect(mockStore.createMeeting).toHaveBeenCalled()
+  })
+})

--- a/apps/frontend/src/features/jitsi/lib/loadJitsi.ts
+++ b/apps/frontend/src/features/jitsi/lib/loadJitsi.ts
@@ -1,0 +1,19 @@
+let loading: Promise<void> | null = null
+
+export function loadJitsi() {
+  if (typeof window === 'undefined') return Promise.resolve()
+  if (loading) return loading
+  loading = new Promise((resolve, reject) => {
+    if (window.JitsiMeetExternalAPI) {
+      resolve()
+      return
+    }
+    const script = document.createElement('script')
+    script.src = 'https://meet.jit.si/external_api.js'
+    script.async = true
+    script.onload = () => resolve()
+    script.onerror = reject
+    document.head.appendChild(script)
+  })
+  return loading
+}

--- a/apps/frontend/src/features/jitsi/stores/__tests__/jitsi.spec.ts
+++ b/apps/frontend/src/features/jitsi/stores/__tests__/jitsi.spec.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { useJitsiStore } from '../jitsi'
+
+describe('jitsi store', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('generates room name with profile ids', () => {
+    const store = useJitsiStore()
+    const name = store.makePublicRoomName('a', 'b')
+    expect(name).toContain('a')
+    expect(name).toContain('b')
+  })
+
+  it('creates meeting via fetch', async () => {
+    const store = useJitsiStore()
+    global.fetch = vi.fn().mockResolvedValue({
+      json: () => Promise.resolve({ success: true, meeting: { id: '1', room: 'r' } }),
+    } as any)
+    await store.createMeeting({ room: 'r', targetProfileId: 'b' })
+    expect(store.currentMeeting?.id).toBe('1')
+    expect((fetch as any).mock.calls[0][1].credentials).toBe('include')
+  })
+})

--- a/apps/frontend/src/features/jitsi/stores/jitsi.ts
+++ b/apps/frontend/src/features/jitsi/stores/jitsi.ts
@@ -1,0 +1,82 @@
+import { defineStore } from 'pinia'
+
+interface Meeting {
+  id: string
+  room: string
+}
+
+interface MeetingState {
+  currentMeeting: Meeting | null
+  loading: boolean
+  error: string | null
+}
+
+const apiBase = __APP_CONFIG__?.API_BASE_URL || ''
+
+export const useJitsiStore = defineStore('jitsi', {
+  state: (): MeetingState => ({
+    currentMeeting: null,
+    loading: false,
+    error: null,
+  }),
+  actions: {
+    makePublicRoomName(a: string, b: string) {
+      const rand = Math.random().toString(36).slice(2)
+      return `oc-${a}-${b}-${rand}-${Date.now()}`
+    },
+    async createMeeting(payload: { room: string; targetProfileId: string }) {
+      this.loading = true
+      try {
+        const res = await fetch(`${apiBase}/meetings`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          credentials: 'include',
+          body: JSON.stringify(payload),
+        })
+        const data = await res.json()
+        if (data.success) {
+          this.currentMeeting = data.meeting
+          this.error = null
+          return data.meeting as Meeting
+        }
+        this.error = data.message || 'Failed to create meeting'
+        return null
+      } catch (err: any) {
+        this.error = err.message
+        return null
+      } finally {
+        this.loading = false
+      }
+    },
+    async fetchLatest(withProfileId: string) {
+      this.loading = true
+      try {
+        const res = await fetch(`${apiBase}/meetings/latest?withProfileId=${withProfileId}`, {
+          credentials: 'include',
+        })
+        const data = await res.json()
+        if (data.success && data.meeting) {
+          this.currentMeeting = data.meeting
+          return data.meeting as Meeting
+        }
+        return null
+      } catch (err: any) {
+        this.error = err.message
+        return null
+      } finally {
+        this.loading = false
+      }
+    },
+    async endMeeting(id: string) {
+      try {
+        await fetch(`${apiBase}/meetings/${id}/end`, {
+          method: 'POST',
+          credentials: 'include',
+        })
+      } catch (err: any) {
+        this.error = err.message
+      }
+      this.currentMeeting = null
+    },
+  },
+})

--- a/apps/frontend/src/features/publicprofile/components/ActionButtons.vue
+++ b/apps/frontend/src/features/publicprofile/components/ActionButtons.vue
@@ -6,6 +6,9 @@ import { type PublicProfileWithContext } from '@zod/profile/profile.dto'
 
 import IconMessage from '@/assets/icons/interface/message.svg'
 import ProfileThumbnail from '@/features/images/components/ProfileThumbnail.vue'
+import SendMessageDialog from './SendMessageDialog.vue'
+import VideoCallButton from '@/features/jitsi/components/VideoCallButton.vue'
+import JoinCallButton from '@/features/jitsi/components/JoinCallButton.vue'
 
 const props = defineProps<{
   profile: PublicProfileWithContext
@@ -45,11 +48,12 @@ const handleMessageIntent = () => {
         @click="handleMessageIntent"
       >
         <IconMessage class="svg-icon-lg p-0" />
-        <!-- {{ $t('profiles.send_message_button') }} -->
       </BButton>
+      <VideoCallButton v-if="!isOwner" :target-profile-id="profile.id" />
+      <JoinCallButton v-if="!isOwner" :with-profile-id="profile.id" />
     </div>
 
-   <SendMessageDialog/>
+    <SendMessageDialog v-model="showMessageModal" />
   </div>
 </template>
 


### PR DESCRIPTION
## Summary
- add Meeting model and Fastify routes for creating, fetching, and ending meetings
- wire up frontend Jitsi feature with Pinia store and modal components
- expose JITSI_DOMAIN config and permit meet.jit.si via CSP

## Testing
- `pnpm run ci:test` *(fails: connect ENETUNREACH 35.244.233.98:443; connect ECONNREFUSED 127.0.0.1:6379)*


------
https://chatgpt.com/codex/tasks/task_e_68b2c24d362c8331b9cf11e4bc2de1e0