### PR TITLE
chore(frontend): limit font imports to latin weights

### DIFF
--- a/apps/frontend/src/css/fonts.scss
+++ b/apps/frontend/src/css/fonts.scss
@@ -9,9 +9,11 @@
 // @import "~@fontsource/mukta/index.css";
 // import "@fontsource/poppins/index.css";
 
-// TODO tighten this up, only import the weights we need
-@import '@fontsource/nunito/index.css';
-@import '@fontsource/rubik/index.css';
+// Import only latin subset and required weights
+@import '@fontsource/nunito/latin-400.css';
+@import '@fontsource/nunito/latin-700.css';
+@import '@fontsource/rubik/latin-400.css';
+@import '@fontsource/rubik/latin-700.css';
 
 // scribble
 // @import '@fontsource/caveat'; // Defaults to weight 400


### PR DESCRIPTION
## Summary
- restrict Nunito and Rubik font imports to latin subset with regular and bold weights

## Testing
- `pnpm run ci:test` *(fails: connect ENETUNREACH 35.244.233.98:443 / connect ECONNREFUSED 127.0.0.1:6379)*

------
https://chatgpt.com/codex/tasks/task_e_68b4418195208331a63b746f13000168