### PR TITLE
feat: add infinite scroll for profile browse

### DIFF
--- a/apps/backend/src/services/profileMatch.service.ts
+++ b/apps/backend/src/services/profileMatch.service.ts
@@ -147,7 +147,12 @@ export class ProfileMatchService {
 
 
 
-  async findSocialProfilesFor(profileId: string, orderBy: OrderBy = defaultOrderBy, take: number = 20): Promise<DbProfileWithImages[]> {
+  async findSocialProfilesFor(
+    profileId: string,
+    orderBy: OrderBy = defaultOrderBy,
+    take: number = 20,
+    cursor?: string
+  ): Promise<DbProfileWithImages[]> {
 
     const userPrefs = await this.getSocialMatchFilter(profileId)
 
@@ -184,6 +189,7 @@ export class ProfileMatchService {
       },
       take: take,
       orderBy: orderBy,
+      ...(cursor ? { cursor: { id: cursor }, skip: 1 } : {}),
     })
   }
 
@@ -220,7 +226,12 @@ export class ProfileMatchService {
   }
 
 
-  async findMutualMatchesFor(profileId: string, orderBy: OrderBy = defaultOrderBy, take: number = 20): Promise<DbProfileWithImages[]> {
+  async findMutualMatchesFor(
+    profileId: string,
+    orderBy: OrderBy = defaultOrderBy,
+    take: number = 20,
+    cursor?: string
+  ): Promise<DbProfileWithImages[]> {
     const profile = await prisma.profile.findUnique({
       where: { id: profileId },
     })
@@ -261,6 +272,7 @@ export class ProfileMatchService {
       },
       take: take,
       orderBy: orderBy,
+      ...(cursor ? { cursor: { id: cursor }, skip: 1 } : {}),
     })
   }
 

--- a/packages/shared/zod/apiResponse.dto.ts
+++ b/packages/shared/zod/apiResponse.dto.ts
@@ -33,7 +33,10 @@ export type UpdateDatingPreferencesResponse = ApiSuccess<{ prefs: DatingPreferen
 
 export type GetMyProfileResponse = ApiSuccess<{ profile: OwnerProfile }>
 export type GetPublicProfileResponse = ApiSuccess<{ profile: PublicProfileWithContext }>
-export type GetProfilesResponse = ApiSuccess<{ profiles: PublicProfileWithContext[] }>
+export type GetProfilesResponse = ApiSuccess<{
+  profiles: PublicProfileWithContext[]
+  nextCursor?: string | null
+}>
 export type UpdateProfileResponse = ApiSuccess<{ profile: OwnerProfile }>
 
 export type TagsResponse = ApiSuccess<{ tags: PublicTag[] }>


### PR DESCRIPTION
## Summary
- implement cursor-based pagination in profile browse API and store
- add infinite scrolling to browse profiles view
- extend GetProfilesResponse with optional `nextCursor`

## Testing
- `pnpm run ci:test` *(fails: connect ENETUNREACH in ImageProcessor)*


------
https://chatgpt.com/codex/tasks/task_e_68b4424f4fe0833190129ce3a3d7717f