### PR TITLE
Refactor posts list to use view model and centralized queries

### DIFF
--- a/apps/frontend/src/features/posts/composables/usePostListViewModel.ts
+++ b/apps/frontend/src/features/posts/composables/usePostListViewModel.ts
@@ -1,0 +1,141 @@
+import { ref, computed, watch, onMounted } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+import type {
+  PublicPostWithProfile,
+  OwnerPost,
+} from '@zod/post/post.dto'
+import { type PostTypeType } from '@zod/generated'
+
+import { usePostStore } from '../stores/postStore'
+
+interface UsePostListOptions {
+  scope?: 'all' | 'nearby' | 'recent' | 'my'
+  type?: PostTypeType
+  nearbyParams?: { lat: number; lon: number; radius: number }
+}
+
+export function usePostListViewModel(options: UsePostListOptions) {
+  const postStore = usePostStore()
+  const { t } = useI18n()
+
+  const selectedType = ref<string>(options.type || '')
+  const currentPage = ref(0)
+  const pageSize = 20
+
+  const showFullView = ref(false)
+  const showEditModal = ref(false)
+  const selectedPost = ref<PublicPostWithProfile | OwnerPost | null>(null)
+  const editingPost = ref<OwnerPost | null>(null)
+
+  const posts = computed(() => {
+    return options.scope === 'my' ? postStore.myPosts : postStore.posts
+  })
+
+  const canLoadMore = computed(() => {
+    return posts.value.length >= (currentPage.value + 1) * pageSize
+  })
+
+  const loadPosts = async (append = false) => {
+    if (!append) {
+      currentPage.value = 0
+    }
+    await postStore.loadPosts(options.scope || 'all', {
+      type: (selectedType.value as PostTypeType) || undefined,
+      page: currentPage.value,
+      pageSize,
+      nearbyParams: options.nearbyParams,
+    })
+  }
+
+  const handleTypeFilter = () => {
+    loadPosts()
+  }
+
+  const handleLoadMore = () => {
+    currentPage.value++
+    loadPosts(true)
+  }
+
+  const handleRetry = () => {
+    postStore.clearError()
+    loadPosts()
+  }
+
+  const handlePostClick = (post: PublicPostWithProfile | OwnerPost) => {
+    selectedPost.value = post
+    showFullView.value = true
+  }
+
+  const handlePostEdit = (post: PublicPostWithProfile | OwnerPost) => {
+    editingPost.value = post as OwnerPost
+    showEditModal.value = true
+  }
+
+  const handlePostDelete = async (post: PublicPostWithProfile | OwnerPost) => {
+    if (confirm(t('posts.confirm_delete'))) {
+      const success = await postStore.deletePost(post.id)
+      if (success) {
+        closeFullView()
+      }
+    }
+  }
+
+  const handlePostSaved = (post: OwnerPost) => {
+    closeEditModal()
+    loadPosts()
+  }
+
+  const closeFullView = () => {
+    showFullView.value = false
+    selectedPost.value = null
+  }
+
+  const closeEditModal = () => {
+    showEditModal.value = false
+    editingPost.value = null
+  }
+
+  watch(
+    () => options.type,
+    newType => {
+      selectedType.value = newType || ''
+      loadPosts()
+    }
+  )
+
+  watch(
+    () => options.nearbyParams,
+    () => {
+      if (options.scope === 'nearby') {
+        loadPosts()
+      }
+    },
+    { deep: true }
+  )
+
+  onMounted(() => {
+    loadPosts()
+  })
+
+  return {
+    postStore,
+    posts,
+    selectedType,
+    canLoadMore,
+    showFullView,
+    showEditModal,
+    selectedPost,
+    editingPost,
+    handleTypeFilter,
+    handleLoadMore,
+    handleRetry,
+    handlePostClick,
+    handlePostEdit,
+    handlePostDelete,
+    handlePostSaved,
+    closeFullView,
+    closeEditModal,
+  }
+}
+

--- a/apps/frontend/src/features/posts/stores/postStore.ts
+++ b/apps/frontend/src/features/posts/stores/postStore.ts
@@ -16,6 +16,7 @@ import type {
   DeletePostResponse,
 } from '@zod/apiResponse.dto'
 import { PostType } from '@prisma/client'
+import type { PostTypeType } from '@zod/generated'
 
 export const usePostStore = defineStore('posts', {
   state: () => ({
@@ -132,6 +133,38 @@ export const usePostStore = defineStore('posts', {
         return false
       } finally {
         this.isLoading = false
+      }
+    },
+
+    async loadPosts(scope: 'all' | 'nearby' | 'recent' | 'my', options: {
+      type?: PostTypeType
+      page?: number
+      pageSize?: number
+      nearbyParams?: { lat: number; lon: number; radius?: number }
+    } = {}) {
+      const { type, page = 0, pageSize = 20, nearbyParams } = options
+      const baseQuery: PostQueryInput = {
+        type,
+        limit: pageSize,
+        offset: page * pageSize,
+      }
+      switch (scope) {
+        case 'nearby':
+          if (nearbyParams) {
+            return await this.fetchNearbyPosts({
+              ...baseQuery,
+              lat: nearbyParams.lat,
+              lon: nearbyParams.lon,
+              radius: nearbyParams.radius ?? 50,
+            })
+          }
+          return []
+        case 'recent':
+          return await this.fetchRecentPosts(baseQuery)
+        case 'my':
+          return await this.fetchMyPosts(baseQuery)
+        default:
+          return await this.fetchPosts(baseQuery)
       }
     },
 


### PR DESCRIPTION
## Summary
- introduce `usePostListViewModel` composable to manage posts list state
- simplify `PostList.vue` to use view model
- move query building into `loadPosts` action in `postStore`

## Testing
- `pnpm run ci:test` (fails: Command "generate" not found)
- `pnpm lint`
- `pnpm test` (fails: redis connection refused)
- `pnpm --filter frontend type-check`


------
https://chatgpt.com/codex/tasks/task_e_68b98628916c833185bafb4fd8521e73