### PR TITLE
Fix certbot-init command for service ports

### DIFF
--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -100,11 +100,6 @@ services:
     entrypoint: certbot
     command:
       - certonly
-      - --webroot
-      - -w
-      - /var/www/html
-      - -d
-      - ${DOMAIN}
       - -d
       - ${DOMAIN}
       - --email

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -10,7 +10,7 @@ docker volume create certbot-etc
 docker volume create certbot-webroot
 # obtain TLS cert from Letsencrypt via certbot (configure DOMAIN and EMAIL in .env)
 # https://eff-certbot.readthedocs.io/en/latest/install.html#running-with-docker
-docker compose -f docker-compose.production.yml run --rm certbot-init
+docker compose -f docker-compose.production.yml run --rm --service-ports certbot-init
 docker compose -f docker-compose.production.yml build
 docker compose -f docker-compose.production.yml up -d
 ```


### PR DESCRIPTION
Update the certbot-init command to include service ports, ensuring proper execution of the certbot process. Fix webroot parameters