### PR TITLE
Fix voice messages: security, robustness, and UI polish

### DIFF
--- a/apps/backend/src/api/routes/media.route.ts
+++ b/apps/backend/src/api/routes/media.route.ts
@@ -1,20 +1,32 @@
 import { FastifyPluginAsync } from 'fastify'
 import path from 'path'
-import fs, { createReadStream } from 'fs'
+import { createReadStream } from 'fs'
 import { promises as fsPromises } from 'fs'
 import { sendError } from '../helpers'
 import { appConfig } from '@/lib/appconfig'
 import { z } from 'zod'
+import { prisma } from '@/lib/prisma'
+
+// Only allow safe filenames: alphanumeric, hyphens, underscores, and a single dot for extension
+const safeFilenameSchema = z.string().regex(/^[\w-]+\.\w+$/, 'Invalid filename')
 
 // Route params for media file lookups
 const MediaParamsSchema = z.object({
   profileId: z.string().cuid(),
-  filename: z.string(),
+  filename: safeFilenameSchema,
 })
 
+const MIME_TYPE_MAP: Record<string, string> = {
+  '.webm': 'audio/webm',
+  '.mp4': 'audio/mp4',
+  '.ogg': 'audio/ogg',
+  '.wav': 'audio/wav',
+  '.mp3': 'audio/mpeg',
+}
+
 const mediaRoutes: FastifyPluginAsync = async fastify => {
-  
-  // Serve voice message files - only accessible by authenticated users
+
+  // Serve voice message files - only accessible by conversation participants
   fastify.get('/voice/:profileId/:filename', { onRequest: [fastify.authenticate] }, async (req, reply) => {
     const currentProfileId = req.session.profileId
     if (!currentProfileId) return sendError(reply, 401, 'Authentication required')
@@ -24,25 +36,47 @@ const mediaRoutes: FastifyPluginAsync = async fastify => {
 
     const { profileId, filename } = params.data
 
+    // Authorization: verify the requesting user is a participant in a conversation
+    // that contains a message with this attachment
+    const relativePath = `voice/${profileId}/${filename}`
+    const attachment = await prisma.messageAttachment.findFirst({
+      where: { filePath: relativePath },
+      include: {
+        message: {
+          include: {
+            conversation: {
+              include: { participants: { select: { profileId: true } } },
+            },
+          },
+        },
+      },
+    })
+
+    if (!attachment) return sendError(reply, 404, 'Voice message not found')
+
+    const isParticipant = attachment.message.conversation.participants
+      .some((p: { profileId: string }) => p.profileId === currentProfileId)
+    if (!isParticipant) return sendError(reply, 403, 'Access denied')
+
     try {
-      // Construct file path
+      // Construct file path - safe because filename is validated by regex
       const filePath = path.join(appConfig.MEDIA_UPLOAD_DIR, 'voice', profileId, filename)
-      
+
       // Check if file exists
       const stats = await fsPromises.stat(filePath).catch(() => null)
       if (!stats || !stats.isFile()) {
         return sendError(reply, 404, 'Voice message not found')
       }
 
-      // TODO: Add authorization check - only allow users who are part of the conversation
-      // For now, any authenticated user can access voice messages
-      // This should be improved to check if the user has access to the specific conversation
+      // Derive Content-Type from the attachment record or file extension
+      const ext = path.extname(filename).toLowerCase()
+      const contentType = attachment.mimeType || MIME_TYPE_MAP[ext] || 'application/octet-stream'
 
       // Set appropriate headers
-      reply.header('Content-Type', 'audio/webm')
+      reply.header('Content-Type', contentType)
       reply.header('Content-Length', stats.size)
       reply.header('Accept-Ranges', 'bytes')
-      
+
       // Send the file
       const stream = createReadStream(filePath)
       return reply.send(stream)

--- a/apps/backend/src/services/messaging.service.ts
+++ b/apps/backend/src/services/messaging.service.ts
@@ -2,10 +2,8 @@ import { Prisma } from '@prisma/client'
 import { prisma } from '@/lib/prisma'
 import type {
   ConversationParticipantWithConversationSummary,
-  DbMessageInConversation,
-  MessageInConversation,
 } from '@zod/messaging/messaging.dto'
-import { Conversation, Message } from '@zod/generated'
+import { Conversation } from '@zod/generated'
 import { blocklistWhereClause } from '@/db/includes/blocklistWhereClause'
 import i18next from 'i18next'
 import { JSDOM } from 'jsdom'
@@ -45,6 +43,8 @@ const sendInclude = {
   },
   attachment: true,
 } satisfies Prisma.MessageInclude
+
+export type MessageWithSendInclude = Prisma.MessageGetPayload<{ include: typeof sendInclude }>
 
 export class MessageService {
   private static instance: MessageService
@@ -126,7 +126,7 @@ export class MessageService {
    * @param conversationId - The ID of the conversation to list messages for.
    * @returns An array of messages in the conversation, including sender profile images.
    */
-  async listMessagesForConversation(conversationId: string): Promise<DbMessageInConversation[]> {
+  async listMessagesForConversation(conversationId: string) {
     return await prisma.message.findMany({
       where: {
         conversationId,
@@ -211,7 +211,7 @@ export class MessageService {
       fileSize?: number
       duration?: number
     }
-  ): Promise<{ convoId: string; message: Message }> {
+  ): Promise<{ convoId: string; message: MessageWithSendInclude }> {
 
     // Clean and sanitize user input for text messages
     const cleanContent = messageType === 'text/plain' ? cleanUserInput(content).trim() : content
@@ -329,7 +329,7 @@ export class MessageService {
 
 export type SendMessageSuccessResponse = {
   conversation: ConversationParticipantWithConversationSummary
-  message: MessageInConversation
+  message: MessageWithSendInclude
 }
 
 export type SendMessageErrorResponse = {

--- a/apps/frontend/src/features/messaging/components/VoiceRecorder.vue
+++ b/apps/frontend/src/features/messaging/components/VoiceRecorder.vue
@@ -98,8 +98,7 @@ const handleRetryPermission = async () => {
                isCompleted ? $t('messaging.voice.record_again') : 
                $t('messaging.voice.record')"
       >
-      <Mic2Icon class="svg-icon"></Mic2Icon> XXX
-        <component :is="isRecording ? Mic2Icon : MicIcon" width="16" height="16" />
+        <component :is="isRecording ? Mic2Icon : MicIcon" class="svg-icon" />
         <span class="ms-1" v-if="isRecording">{{ formatDuration() }}</span>
         <span class="ms-1" v-else-if="isCompleted">{{ formatDuration() }}</span>
       </BButton>
@@ -111,7 +110,7 @@ const handleRetryPermission = async () => {
         size="sm"
         @click="handleCancel"
         :title="$t('messaging.voice.cancel')"
-      >X
+      >
         <i class="fas fa-times"></i>
       </BButton>
     </div>
@@ -146,7 +145,6 @@ const handleRetryPermission = async () => {
     <!-- Error message -->
     <div v-if="isError && !permissionDenied && error" class="mt-2 p-2 bg-danger-subtle border border-danger rounded">
       <small class="text-danger-emphasis">
-        O
         <i class="fas fa-exclamation-circle me-1"></i>
         {{ error }}
       </small>
@@ -156,7 +154,6 @@ const handleRetryPermission = async () => {
     <div v-if="!isSupported" class="mt-2 p-2 bg-info-subtle border border-info rounded">
       <small class="text-info-emphasis">
         <i class="fas fa-info-circle me-1"></i>
-        O
         {{ $t('messaging.voice.unsupported_browser') }}
       </small>
     </div>

--- a/apps/frontend/src/features/messaging/stores/messageStore.ts
+++ b/apps/frontend/src/features/messaging/stores/messageStore.ts
@@ -7,8 +7,7 @@ import type {
   ConversationSummary,
   MessageDTO,
   MessageInConversation,
-  SendMessagePayload,
-  SendVoiceMessagePayload
+  SendMessagePayload
 } from '@zod/messaging/messaging.dto'
 import type {
   MessagesResponse,
@@ -148,10 +147,9 @@ export const useMessageStore = defineStore('message', {
       content: string
     ): Promise<StoreResponse<MessageDTO> | StoreError> {
       try {
-        const payload: SendMessagePayload = { 
-          profileId: recipientProfileId, 
+        const payload: SendMessagePayload = {
+          profileId: recipientProfileId,
           content,
-          messageType: 'text/plain'
         }
         this.isSending = true
         this.error = null

--- a/apps/frontend/src/features/shared/composables/useVoiceRecorder.ts
+++ b/apps/frontend/src/features/shared/composables/useVoiceRecorder.ts
@@ -36,11 +36,10 @@ export function useVoiceRecorder(maxDuration: number = 120) {
     try {
       error.value = null
       permissionDenied.value = false
-      state.value = 'recording'
       duration.value = 0
       chunks = []
 
-      // Request microphone access
+      // Request microphone access (may show permission prompt)
       stream = await navigator.mediaDevices.getUserMedia({
         audio: {
           echoCancellation: true,
@@ -48,6 +47,9 @@ export function useVoiceRecorder(maxDuration: number = 120) {
           autoGainControl: true
         }
       })
+
+      // Microphone access granted - now enter recording state
+      state.value = 'recording'
 
       // Create MediaRecorder instance
       mediaRecorder = new MediaRecorder(stream, {

--- a/packages/shared/zod/messaging/messaging.dto.ts
+++ b/packages/shared/zod/messaging/messaging.dto.ts
@@ -52,7 +52,7 @@ const DbMessageInConversationSchema = MessageSchema.pick({
   sender: ProfileSummarySchema,
   attachment: DbMessageAttachmentDTOSchema.nullable().optional(),
 })
-export type DbMessageInConversation = z.infer<typeof MessageInConversationSchema>
+export type DbMessageInConversation = z.infer<typeof DbMessageInConversationSchema>
 
 
 // this is used in the db layer
@@ -139,7 +139,6 @@ export type ConversationParticipantWithConversationSummary =
 export const SendMessagePayloadSchema = z.object({
   profileId: z.string().cuid(),
   content: z.string().min(1),
-  messageType: z.string().default('text/plain'),
 })
 
 export type SendMessagePayload = z.infer<typeof SendMessagePayloadSchema>
@@ -149,7 +148,7 @@ export const SendVoiceMessagePayloadSchema = z.object({
   profileId: z.string().cuid(),
   content: z.string().default(''), // Can be empty for voice messages
   messageType: z.literal('audio/voice'),
-  duration: z.number().int().min(1).max(120), // Duration in seconds, max 2 minutes
+  duration: z.number().int().min(1), // Duration in seconds; max enforced by backend config
 })
 
 export type SendVoiceMessagePayload = z.infer<typeof SendVoiceMessagePayloadSchema>


### PR DESCRIPTION
## Summary

Code review fixes for PR #339 (voice messages). Addresses security vulnerabilities, robustness issues, and UI polish problems identified during review.

### Security fixes
- **Path traversal protection**: Added filename regex validation (`/^[\w-]+\.\w+$/`) in the media route to prevent directory traversal attacks via crafted filenames
- **Authorization check**: Media endpoint now verifies the requesting user is a participant in the conversation containing the voice message attachment (was previously accessible to any authenticated user)
- **Content-Type from DB**: Derives Content-Type from the attachment's `mimeType` record instead of hardcoding `audio/webm`
- **Restricted messageType**: Removed client-controllable `messageType` from `SendMessagePayloadSchema`; text route always uses `'text/plain'` server-side

### Robustness fixes
- **Type alias bug**: `DbMessageInConversation` was incorrectly inferring from `MessageInConversationSchema` instead of `DbMessageInConversationSchema`
- **Recording state race condition**: Moved `state = 'recording'` after `getUserMedia` resolves, preventing momentary "recording" UI when permission is denied
- **NaN prevention**: Replaced `parseInt(fields.duration)` with `Number() || 0` to handle undefined/non-numeric values
- **Config-driven max duration**: Removed hardcoded `.max(120)` from `SendVoiceMessagePayloadSchema`; server validates against `VOICE_MESSAGE_MAX_DURATION` config
- **Explicit field picking**: `mapAttachmentDTO` now picks fields explicitly instead of spreading unknown DB fields
- **Proper typing**: `sendOrStartConversation` now returns `MessageWithSendInclude` type to include attachment data

### UI fixes
- Removed debug artifacts: `"XXX"` text, stray `"O"` characters, duplicate `Mic2Icon`, literal `"X"` on cancel button
- Precomputed waveform bar heights to prevent re-randomization on every render
- Added fallback to `<audio>` element duration when server-provided duration is null
- Removed `console.error` debug log from `mapMessageForMessageList`

## Test plan
- [x] Backend TypeScript compilation passes (no new errors)
- [x] Frontend TypeScript compilation passes (clean)
- [x] ESLint passes on all modified files
- [x] `messaging.service.spec.ts` tests pass (14/14)
- [ ] Manual test: send and receive voice messages
- [ ] Manual test: verify non-participant cannot access voice message URLs
- [ ] Manual test: verify recording UI no longer shows debug text


🤖 Generated with [Claude Code](https://claude.com/claude-code)