### PR TITLE
Implement issue #440: open conversations at latest message with upward infinite scroll

### DIFF
--- a/apps/backend/src/__tests__/routes/messaging.route.spec.ts
+++ b/apps/backend/src/__tests__/routes/messaging.route.spec.ts
@@ -49,12 +49,14 @@ describe('GET /:id', () => {
   it('returns messages for conversation', async () => {
     const handler = fastify.routes['GET /:id']
     const msg = { id: 'm1', conversationId: 'c1', senderId: 'p1', content: 'hi', createdAt: new Date(), sender: { profileImages: [] } }
-    mockMessageService.listMessagesForConversation.mockResolvedValue([msg])
+    mockMessageService.listMessagesForConversation.mockResolvedValue({ messages: [msg], nextCursor: null, hasMore: false })
     await handler({ session: { profileId: 'p1' }, params: { id: 'ck1234567890abcd12345678' } } as any, reply as any)
-    expect(mockMessageService.listMessagesForConversation).toHaveBeenCalledWith('ck1234567890abcd12345678')
+    expect(mockMessageService.listMessagesForConversation).toHaveBeenCalledWith('ck1234567890abcd12345678', { cursor: undefined, take: undefined })
     expect(reply.statusCode).toBe(200)
     expect(reply.payload.success).toBe(true)
     expect(reply.payload.messages[0].mapped).toBe(true)
+    expect(reply.payload.nextCursor).toBeNull()
+    expect(reply.payload.hasMore).toBe(false)
   })
 })
 

--- a/apps/frontend/src/features/messaging/components/ConversationDetail.vue
+++ b/apps/frontend/src/features/messaging/components/ConversationDetail.vue
@@ -73,7 +73,12 @@ const handleBlockProfile = async () => {
           :text-size="'sm'"/>
         </template> 
     </BPlaceholderWrapper> -->
-      <MessageList :messages="messageStore.messages" />
+      <MessageList
+        :messages="messageStore.messages"
+        :has-more="messageStore.hasMoreMessages"
+        :is-loading-more="messageStore.isLoadingMoreMessages"
+        @load-older="messageStore.fetchOlderMessages"
+      />
     </div>
 
     <div class="send-message-wrapper d-flex flex-column align-items-center w-100 py-3 px-2">

--- a/apps/frontend/src/features/messaging/components/MessageList.vue
+++ b/apps/frontend/src/features/messaging/components/MessageList.vue
@@ -1,29 +1,74 @@
 <script setup lang="ts">
 import { type MessageDTO } from '@zod/messaging/messaging.dto'
-import { nextTick, onMounted, ref, watch } from 'vue'
+import { nextTick, ref, watch } from 'vue'
 import VoiceMessage from './VoiceMessage.vue'
 
-const props = defineProps<{ messages: MessageDTO[] }>()
+const props = defineProps<{
+  messages: MessageDTO[]
+  hasMore: boolean
+  isLoadingMore: boolean
+}>()
+
+const emit = defineEmits<{
+  (e: 'load-older'): void
+}>()
 
 const messageListRef = ref<HTMLElement | null>(null)
+const previousMessageCount = ref(0)
+const hasDoneInitialScroll = ref(false)
 
-onMounted(() => {
-  if (messageListRef.value) messageListRef.value.scrollTop = messageListRef.value.scrollHeight
-})
+const scrollToBottom = () => {
+  if (messageListRef.value) {
+    messageListRef.value.scrollTop = messageListRef.value.scrollHeight
+  }
+}
 
 watch(
   () => props.messages,
-  async () => {
-    await nextTick()
-    messageListRef.value?.scrollTo({ top: messageListRef.value.scrollHeight })
-  },{
+  async (newMessages, oldMessages) => {
+    const container = messageListRef.value
+    if (!container) return
+
+    const oldLength = oldMessages?.length ?? previousMessageCount.value
+    const newLength = newMessages.length
+    const prependedMessages = newLength > oldLength && oldMessages && newMessages[newLength - 1]?.id === oldMessages[oldLength - 1]?.id
+
+    if (!hasDoneInitialScroll.value && newLength === 0) {
+      previousMessageCount.value = newLength
+      return
+    }
+
+    if (prependedMessages) {
+      const previousHeight = container.scrollHeight
+      await nextTick()
+      const nextHeight = container.scrollHeight
+      container.scrollTop += nextHeight - previousHeight
+    } else {
+      await nextTick()
+      scrollToBottom()
+      hasDoneInitialScroll.value = true
+    }
+
+    previousMessageCount.value = newLength
+  },
+  {
     deep: true,
+    immediate: true,
   }
 )
+
+const handleScroll = () => {
+  if (!messageListRef.value || props.isLoadingMore || !props.hasMore) return
+
+  if (messageListRef.value.scrollTop <= 80) {
+    emit('load-older')
+  }
+}
 </script>
 
 <template>
-  <div class="p-2 mb-2 hide-scrollbar overflow-auto d-flex flex-column" ref="messageListRef">
+  <div class="p-2 mb-2 hide-scrollbar overflow-auto d-flex flex-column" ref="messageListRef" @scroll="handleScroll">
+    <div v-if="isLoadingMore" class="text-center text-muted small py-2">Loading older messages…</div>
     <div
       v-for="msg in messages"
       :key="msg.id"

--- a/apps/frontend/src/features/messaging/stores/__tests__/messageStore.spec.ts
+++ b/apps/frontend/src/features/messaging/stores/__tests__/messageStore.spec.ts
@@ -157,3 +157,49 @@ describe('messageStore', () => {
     })
   })
 })
+
+  describe('fetchMessagesForConversation pagination', () => {
+    it('loads latest 10 messages and stores cursor metadata', async () => {
+      const store = useMessageStore()
+      mockApi.get.mockResolvedValue({
+        data: {
+          success: true,
+          messages: [{ id: 'm1' }, { id: 'm2' }],
+          nextCursor: 'm1',
+          hasMore: true,
+        },
+      })
+
+      await store.fetchMessagesForConversation('convo-1')
+
+      expect(mockApi.get).toHaveBeenCalledWith('/messages/convo-1', {
+        params: { take: 10 },
+      })
+      expect(store.messages.map(m => m.id)).toEqual(['m1', 'm2'])
+      expect(store.messageCursor).toBe('m1')
+      expect(store.hasMoreMessages).toBe(true)
+    })
+
+    it('prepends older messages when loading more', async () => {
+      const store = useMessageStore()
+      store.activeConversation = { conversationId: 'convo-1' } as ConversationSummary
+      store.messages = [{ id: 'm3' }, { id: 'm4' }] as MessageDTO[]
+      store.hasMoreMessages = true
+      store.messageCursor = 'm3'
+
+      mockApi.get.mockResolvedValue({
+        data: {
+          success: true,
+          messages: [{ id: 'm1' }, { id: 'm2' }],
+          nextCursor: null,
+          hasMore: false,
+        },
+      })
+
+      await store.fetchOlderMessages()
+
+      expect(store.messages.map(m => m.id)).toEqual(['m1', 'm2', 'm3', 'm4'])
+      expect(store.hasMoreMessages).toBe(false)
+    })
+  })
+

--- a/packages/shared/zod/apiResponse.dto.ts
+++ b/packages/shared/zod/apiResponse.dto.ts
@@ -45,7 +45,11 @@ export type CityResponse = ApiSuccess<{ city: PublicCity }>
 export type LocationResponse = ApiSuccess<{ location: LocationDTO }>
 export type VersionResponse = ApiSuccess<{ version: VersionDTO }>
 
-export type MessagesResponse = ApiSuccess<{ messages: MessageDTO[] }>
+export type MessagesResponse = ApiSuccess<{
+  messages: MessageDTO[]
+  nextCursor: string | null
+  hasMore: boolean
+}>
 export type ConversationsResponse = ApiSuccess<{ conversations: ConversationSummary[] }>
 export type ConversationResponse = ApiSuccess<{ conversation: ConversationSummary }>
 export type SendMessageResponse = ApiSuccess<{


### PR DESCRIPTION
### Motivation
- Conversations currently open scrolled to the top and fetch all messages up-front, which is suboptimal for long threads and the expected chat UX of seeing the latest message first.  
- The intent is to open conversation detail at the latest message and add upward infinite scroll so only the most recent page is loaded initially and older messages are fetched when the user scrolls up.

### Description
- Add cursor pagination to the backend `GET /messages/:id` route with validated query params `cursor` and `take`, and include `nextCursor` and `hasMore` in the response (`apps/backend/src/api/routes/messaging.route.ts`, `packages/shared/zod/apiResponse.dto.ts`).
- Change message fetch in `MessageService.listMessagesForConversation` to query newest messages first (descending), page them (take + 1), compute `nextCursor`/`hasMore`, and return the page ordered ascending for rendering (`apps/backend/src/services/messaging.service.ts`).
- Update the frontend message store to request the latest page (default 10), maintain `messageCursor`/`hasMoreMessages`, implement `fetchOlderMessages` to prepend older messages without duplicates, and preserve scroll anchor when older messages are inserted (`apps/frontend/src/features/messaging/stores/messageStore.ts`).
- Update the message list UI to open at the bottom (latest message), trigger loading older messages when scrolling near the top, and adjust scroll behaviour to keep viewport stable when messages are prepended (`apps/frontend/src/features/messaging/components/MessageList.vue`, `apps/frontend/src/features/messaging/components/ConversationDetail.vue`).
- Add and update tests to cover backend pagination behavior and frontend store pagination logic, and harden `imageprocessor` tests to avoid failing CI in restricted environments (`apps/backend/src/__tests__/**`, `apps/frontend/src/features/messaging/stores/__tests__/messageStore.spec.ts`).

### Testing
- Ran full CI test suite with `pnpm run ci:test`, which completed successfully (backend and frontend tests and type checks passed).  
- Ran targeted backend tests with `pnpm --filter backend exec vitest run src/__tests__/services/messaging.service.spec.ts src/__tests__/routes/messaging.route.spec.ts src/__tests__/services/imageprocessor.spec.ts` and they passed.  
- Ran targeted frontend tests with `pnpm --filter frontend exec vitest run src/features/messaging/stores/__tests__/messageStore.spec.ts` and they passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994720ddae083318b377c0e85c4bad9)