### PR TITLE
feat(a11y): add title attributes to icon-only buttons

### DIFF
--- a/apps/frontend/src/features/auth/components/LogoutButton.vue
+++ b/apps/frontend/src/features/auth/components/LogoutButton.vue
@@ -31,6 +31,7 @@ const props = withDefaults(
     v-bind:variant="variant"
     size="sm"
     @click="handleClick"
+    :title="t('authentication.logout')"
   >
     <slot>
       <IconLogout class="svg-icon" />

--- a/apps/frontend/src/features/images/components/ImageEditor.vue
+++ b/apps/frontend/src/features/images/components/ImageEditor.vue
@@ -126,6 +126,7 @@ const isDeletable = computed(() => {
                   @click="handleDelete(img)"
                   :disabled="isRemoving[img.id]"
                   v-if="isDeletable"
+                  :title="t('profiles.image_editor.delete_button_title')"
                 >
                   <FontAwesomeIcon :icon="faXmark" />
                 </button>

--- a/apps/frontend/src/features/interaction/components/InteractionButtons.vue
+++ b/apps/frontend/src/features/interaction/components/InteractionButtons.vue
@@ -70,6 +70,7 @@ const handleMessageClick = () => {
             class="btn-icon-lg me-2"
             @click="handlePassClick"
             :disabled="!context.canPass"
+            :title="$t('interactions.pass_button_title')"
           >
             <IconCross class="svg-icon-lg" />
           </BButton>
@@ -92,6 +93,7 @@ const handleMessageClick = () => {
         <BButton
           class="btn-icon-lg btn-info me-2"
           @click="handleMessageClick"
+          :title="$t('interactions.message_button_title')"
         >
           <IconMessage class="svg-icon-lg p-0" />
         </BButton>
@@ -117,6 +119,7 @@ const handleMessageClick = () => {
         <BButton
           class="btn-icon-lg btn-dating"
           @click="handleLikeClick"
+          :title="$t('interactions.like_button_title')"
         >
           <IconHeart class="svg-icon-lg" />
         </BButton>

--- a/apps/frontend/src/features/messaging/components/SendMessageForm.vue
+++ b/apps/frontend/src/features/messaging/components/SendMessageForm.vue
@@ -166,6 +166,7 @@ function handleVoiceRecordingError(error: string) {
               size="sm"
               @click="handleSendMessage"
               :disabled="content.trim() === '' || isVoiceActive"
+              :title="$t('messaging.send_message_button')"
             >
               {{ $t('messaging.send_message_button').toUpperCase() }}
             </BButton>

--- a/apps/frontend/src/features/messaging/components/VoiceRecorder.vue
+++ b/apps/frontend/src/features/messaging/components/VoiceRecorder.vue
@@ -163,6 +163,7 @@ defineExpose({ triggerStart: handleRecordClick, reset })
           size="sm"
           variant="outline-warning"
           @click="handleRetryPermission"
+          :title="$t('messaging.voice.retry_permission')"
         >
           {{ $t('messaging.voice.retry_permission') }}
         </BButton>

--- a/apps/frontend/src/features/onboarding/components/BackButton.vue
+++ b/apps/frontend/src/features/onboarding/components/BackButton.vue
@@ -18,6 +18,7 @@ defineEmits<{
     variant="link-secondary"
     class="d-flex align-items-center mt-2"
     size="lg"
+    :title="$t('onboarding.back_button')"
   >
     <IconArrowSingleLeft class="svg-icon-lg" />
   </BButton>

--- a/apps/frontend/src/features/publicprofile/components/ActionButtons.vue
+++ b/apps/frontend/src/features/publicprofile/components/ActionButtons.vue
@@ -38,6 +38,7 @@ const handleMessageIntent = () => {
         :pill="true"
         class="btn-overlay"
         @click="handleMessageIntent"
+        :title="$t('profiles.send_message_button')"
       >
         <IconMessage class="svg-icon-lg p-0" />
         <!-- {{ $t('profiles.send_message_button') }} -->

--- a/apps/frontend/src/features/shared/ui/RouterBackButton.vue
+++ b/apps/frontend/src/features/shared/ui/RouterBackButton.vue
@@ -7,6 +7,7 @@ import IconArrowSingleLeft from '@/assets/icons/arrows/arrow-single-left.svg'
     variant="link-secondary"
     class="d-flex align-items-center mt-2"
     size="lg"
+    :title="$t('uicomponents.back_button_title')"
   >
     <IconArrowSingleLeft class="svg-icon-lg" />
   </BButton>

--- a/packages/shared/i18n/en.json
+++ b/packages/shared/i18n/en.json
@@ -106,6 +106,9 @@
   },
   "profiles": {
     "send_message_button": "Message",
+    "image_editor": {
+      "delete_button_title": "Remove photo"
+    },
     "profile_photos": "{name}'s photos",
     "no_profile_title": "Please fill in your profile",
     "no_profile_create": "Create Profile",
@@ -261,6 +264,9 @@
     }
   },
   "interactions": {
+    "pass_button_title": "Pass",
+    "like_button_title": "Like",
+    "message_button_title": "Message",
     "send_a_message": "Send a message",
     "you_messaged_them": "You messaged them",
     "you_liked_them": "You liked them",
@@ -319,6 +325,7 @@
     "push_notify_messages": "I want notifications when someone messages me"
   },
   "uicomponents": {
+    "back_button_title": "Go back",
     "connection_error": {
       "title": "It's not you, it's us.",
       "description": "Apologies for the interruption.  The Machine Elves need a few seconds to sort things out, we'll be back in a bit."


### PR DESCRIPTION
## Summary

- Adds `:title` bindings to 8 icon-only (or icon-primary) buttons across the frontend so browsers show tooltips on hover and screen readers have meaningful labels
- New i18n keys added: `profiles.image_editor.delete_button_title`, `interactions.{pass,like,message}_button_title`, `uicomponents.back_button_title`
- Existing keys reused for Back (`onboarding.back_button`), Logout (`authentication.logout`), Send (`messaging.send_message_button`), Message (`profiles.send_message_button`), and Retry (`messaging.voice.retry_permission`)

## Components changed

| Component | Button | Title key |
|-----------|--------|-----------|
| `ImageEditor.vue` | Delete photo (×) | `profiles.image_editor.delete_button_title` |
| `BackButton.vue` | Back arrow | `onboarding.back_button` |
| `RouterBackButton.vue` | Back arrow | `uicomponents.back_button_title` |
| `InteractionButtons.vue` | Pass / Message / Like | `interactions.*_button_title` |
| `ActionButtons.vue` | Message pill | `profiles.send_message_button` |
| `LogoutButton.vue` | Logout | `authentication.logout` |
| `SendMessageForm.vue` | Send | `messaging.send_message_button` |
| `VoiceRecorder.vue` | Retry permission | `messaging.voice.retry_permission` |

## Test Plan

- [x] `pnpm test` — 52 test files, 136 tests, 0 failures
- [x] `pnpm build` — builds cleanly (0 errors)
- [ ] Manual: hover over icon buttons in browser to confirm tooltips appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)