### PR TITLE
chore: add dev:stop script to kill all dev processes

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "scripts": {
     "ci:test": "pnpm install && pnpm --filter backend prisma:generate && pnpm lint && pnpm test && pnpm --filter frontend type-check",
     "dev": "turbo run dev",
+    "dev:stop": "lsof -ti :5173,:3000 | xargs -r kill -9 || true",
     "build": "turbo run build",
     "lint": "turbo run lint",
     "test": "turbo run test",


### PR DESCRIPTION
## Summary
- Adds `pnpm dev:stop` script that kills all processes on ports 5173 (Vite) and 3000 (Fastify)
- Uses `lsof` to find PIDs and `kill -9` to ensure clean shutdown

## Test plan
- [ ] Run `pnpm dev` to start services
- [ ] Run `pnpm dev:stop` to verify both frontend and backend processes are killed
- [ ] Run `pnpm dev:stop` with no services running to verify it exits cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)