### PR TITLE
fix: dev:stop lsof comma-separated ports not supported

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "scripts": {
     "ci:test": "pnpm install && pnpm --filter backend prisma:generate && pnpm lint && pnpm test && pnpm --filter frontend type-check",
     "dev": "turbo run dev",
-    "dev:stop": "lsof -ti :5173,:3000 | xargs -r kill -9 || true",
+    "dev:stop": "{ lsof -ti :5173; lsof -ti :3000; } | xargs -r kill -9 || true",
     "build": "turbo run build",
     "lint": "turbo run lint",
     "test": "turbo run test",


### PR DESCRIPTION
## Summary

- The `dev:stop` script used `lsof -ti :5173,:3000` which fails on the installed lsof version (doesn't support comma-separated ports)
- Changed to `{ lsof -ti :5173; lsof -ti :3000; }` which works across all lsof versions

## Test plan

- [x] `pnpm dev:stop` runs without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)