### PR TITLE
feat: reliable dev server start/stop via setsid + PGID

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ secrets/
 .config-cache/
 .json-autotranslate-cache/
 .env.staging
+.dev.pid

--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
   },
   "scripts": {
     "ci:test": "pnpm install && pnpm --filter backend prisma:generate && pnpm lint && pnpm test && pnpm --filter frontend type-check",
-    "dev": "turbo run dev",
-    "dev:stop": "{ lsof -ti :5173; lsof -ti :3000; } | xargs -r kill -9 || true",
+    "dev": "./scripts/dev-start.sh",
+    "dev:stop": "./scripts/dev-stop.sh",
     "build": "turbo run build",
     "lint": "turbo run lint",
     "test": "turbo run test",

--- a/scripts/dev-start.sh
+++ b/scripts/dev-start.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+PIDFILE="$ROOT/.dev.pid"
+
+# Ensure turbo is on PATH even when invoked outside of pnpm
+export PATH="$ROOT/node_modules/.bin:$PATH"
+
+# If a previous session is still running, stop it first
+if [ -f "$PIDFILE" ]; then
+  "$(dirname "$0")/dev-stop.sh" 2>/dev/null || true
+fi
+
+# Start turbo in a new process group (setsid) so we can kill the whole tree later
+setsid turbo run dev &
+PID=$!
+
+# setsid makes the child its own process group leader, so PGID == child PID
+echo "$PID" > "$PIDFILE"
+echo "Dev server started (PGID $PID), PID file: $PIDFILE"
+
+# Forward SIGINT/SIGTERM to the process group, then clean up
+cleanup() {
+  "$(dirname "$0")/dev-stop.sh" 2>/dev/null || true
+  exit 0
+}
+trap cleanup INT TERM
+
+# Wait so Ctrl+C in the terminal hits our trap
+wait "$PID" 2>/dev/null || true
+rm -f "$PIDFILE"

--- a/scripts/dev-stop.sh
+++ b/scripts/dev-stop.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PIDFILE="$(cd "$(dirname "$0")/.." && pwd)/.dev.pid"
+
+if [ ! -f "$PIDFILE" ]; then
+  echo "No .dev.pid file found — dev server not running."
+  exit 0
+fi
+
+PGID=$(cat "$PIDFILE")
+
+# Check if the process group still exists
+if kill -0 -- "-$PGID" 2>/dev/null; then
+  echo "Stopping dev server (PGID $PGID)..."
+  kill -TERM -- "-$PGID" 2>/dev/null || true
+  # Give processes a moment to exit gracefully
+  sleep 2
+  # Force-kill any survivors
+  kill -9 -- "-$PGID" 2>/dev/null || true
+  echo "Dev server stopped."
+else
+  echo "Process group $PGID not running (stale PID file)."
+fi
+
+rm -f "$PIDFILE"


### PR DESCRIPTION
## Summary
- Replace brittle `lsof` port-scanning `dev:stop` with process group management via `setsid`
- New `scripts/dev-start.sh` starts turbo in its own process group, records PGID to `.dev.pid`
- New `scripts/dev-stop.sh` kills the entire process tree (`kill -- -$PGID`) — no orphan Vite/node processes
- Handles Ctrl+C, stale PID files, and idempotent restarts

## Test plan
- [x] `pnpm dev` starts server, creates `.dev.pid`
- [x] `pnpm dev:stop` kills all processes, removes `.dev.pid`, no orphans on ports
- [x] Ctrl+C triggers clean shutdown
- [x] `pnpm dev:stop` when nothing running exits gracefully
- [x] `pnpm dev` auto-stops previous orphaned session

🤖 Generated with [Claude Code](https://claude.com/claude-code)