### PR TITLE
fix: constrain ImageEditor modal to viewport height

### DIFF
--- a/apps/frontend/src/features/myprofile/components/EditableFields.vue
+++ b/apps/frontend/src/features/myprofile/components/EditableFields.vue
@@ -61,7 +61,8 @@ provide('isEditable', toRef(props, 'editState'))
     :ok-title="'OK'"
     :ok-class="'btn btn-primary px-5'"
     :initial-animation="false"
-    body-class="d-flex flex-row align-items-center justify-content-center overflow-hidden"
+    body-class="d-flex flex-row align-items-center justify-content-center overflow-hidden flex-grow-1 min-h-0"
+    modal-class="field-edit-modal"
     @ok="handleUpdate"
     @cancel="handleCancelEdit"
     @close="handleCancelEdit"
@@ -78,8 +79,27 @@ provide('isEditable', toRef(props, 'editState'))
     </template>
     <div
       id="field-edit-modal"
-      class="w-100 py-5"
+      class="w-100 py-2"
     ></div>
   </BModal>
   <slot> </slot>
 </template>
+
+<style lang="scss">
+.field-edit-modal .modal-dialog {
+  max-height: calc(100dvh - 2rem);
+  display: flex;
+  flex-direction: column;
+}
+
+.field-edit-modal .modal-content {
+  max-height: inherit;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.field-edit-modal .modal-body {
+  min-height: 0;
+}
+</style>


### PR DESCRIPTION
## Summary
- Constrain EditableFields modal dialog to `max-height: calc(100dvh - 2rem)` with flex column layout
- Reduce excessive `py-5` padding to `py-2` on the modal content container
- Add `min-height: 0` on modal body to allow flex shrinking

This prevents the image grid from pushing the modal beyond the viewport on wide/short screens (~1400x750).

Closes #509

## Test plan
- [ ] Open ImageEditor modal at ~1400x750 viewport — modal fits without scrolling
- [ ] ImageEditor modal still goes fullscreen on small screens
- [ ] Other edit modals (text fields, etc.) still display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)