### PR TITLE
Fix scroll position lost when returning to UserHome

### DIFF
--- a/apps/frontend/src/App.vue
+++ b/apps/frontend/src/App.vue
@@ -33,7 +33,11 @@ useUpdateChecker()
   <!-- <ViewportSizeDebug class="position-absolute bg-dark" /> -->
   <UpdateBanner />
   <Navbar />
-  <RouterView />
+  <RouterView v-slot="{ Component }">
+    <KeepAlive include="UserHome">
+      <component :is="Component" />
+    </KeepAlive>
+  </RouterView>
   <AppNotifier />
   <!-- <router-view v-slot="{ Component }">
     <transition name="fade">


### PR DESCRIPTION
## Summary
- Wrap `<RouterView>` with `<KeepAlive include="UserHome">` in `App.vue` so UserHome's DOM (and scroll position) survives navigation to `/profile/:id` and back
- Add `defineOptions({ name: 'UserHome' })` for KeepAlive `include` matching
- Move `fetchNewSocial()` from `onMounted` to `onActivated` so profile data refreshes on each revisit

## Test plan
- [ ] Scroll down on `/home`, click a profile card, press back — scroll position is preserved
- [ ] Navigate to `/browse`, `/inbox`, etc. — those routes still mount/unmount normally
- [ ] Return to `/home` from other routes — data refreshes via `onActivated`
- [ ] First visit to `/home` — onboarding redirect still works for non-onboarded users
- [ ] All frontend and backend tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)