### PR TITLE
Improve Dependabot grouping to reduce PR noise

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,14 +1,72 @@
 version: 2
 updates:
-  - package-ecosystem: npm 
-    directory: "/" 
+  - package-ecosystem: npm
+    directory: "/"
     schedule:
-      interval: daily
+      interval: weekly
+      day: monday
     versioning-strategy: increase-if-necessary
     open-pull-requests-limit: 10
+
     groups:
-      dev-deps:
+      # ── Vendor families (grouped including majors) ──────────
+      fortawesome:
+        patterns: ["@fortawesome/*"]
+
+      sentry:
+        patterns: ["@sentry/*"]
+
+      fastify:
+        patterns: ["fastify", "fastify-plugin", "@fastify/*"]
+
+      prisma:
+        patterns: ["prisma", "@prisma/*", "prisma-*", "zod-prisma-*"]
+
+      vue-ecosystem:
+        patterns: ["vue", "vue-router", "vue-i18n", "@vue/*", "@vueuse/*", "pinia"]
+
+      bootstrap:
+        patterns: ["bootstrap", "bootstrap-vue-next", "@popperjs/*"]
+
+      tensorflow:
+        patterns: ["@tensorflow/*", "@tensorflow-models/*"]
+
+      fontsource:
+        patterns: ["@fontsource/*"]
+
+      # ── Tooling families (grouped including majors) ─────────
+      eslint:
+        patterns: ["eslint", "eslint-*", "@eslint/*", "@typescript-eslint/*", "@vue/eslint-*"]
+
+      vite:
+        patterns: ["vite", "@vitejs/*", "vite-*"]
+
+      testing:
+        patterns: ["vitest", "@vitest/*", "@vue/test-utils", "@playwright/*", "happy-dom", "jsdom"]
+
+      types:
+        patterns: ["@types/*"]
+        update-types: ["minor", "patch"]
+
+      i18n:
+        patterns: ["i18next", "i18next-*", "vue-i18n-*", "i18n-*", "@cospired/i18n-*", "@intlify/*"]
+
+      # ── Catch-all: remaining minor+patch ────────────────────
+      dev-deps-minor-patch:
+        applies-to: version-updates
         dependency-type: development
         update-types: ["minor", "patch"]
-      eslint:
-        patterns: ["eslint*", "@typescript-eslint/*"]
+
+      prod-deps-minor-patch:
+        applies-to: version-updates
+        dependency-type: production
+        update-types: ["minor", "patch"]
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+    groups:
+      github-actions:
+        patterns: ["*"]


### PR DESCRIPTION
## Summary

- Switch from daily to **weekly (Monday)** schedule to reduce churn
- Add **vendor-scoped groups** so related packages upgrade together: `@fortawesome/*`, `@sentry/*`, `@fastify/*`, `@prisma/*`, Vue ecosystem, Bootstrap, `@tensorflow/*`, `@fontsource/*`
- Add **tooling groups**: ESLint, Vite, testing, `@types/*`, i18n
- Add **prod and dev catch-all groups** for remaining minor/patch updates
- Add **github-actions** ecosystem to track workflow dependency updates
- `@types/*` limited to minor/patch (majors may indicate breaking API changes)
- Security updates remain as individual PRs for visibility

## Test plan

- [ ] After merge, wait for next Monday cycle (or trigger manually via GitHub UI: Security > Dependabot > "Check for updates")
- [ ] Confirm grouped PRs appear instead of individual ones
- [ ] Validate that security-only updates still appear as individual PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)