### PR TITLE
fix: harden Docker build workflows

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -21,7 +21,10 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Create .env from secret
-        run: echo "${{ secrets.PRODUCTION_ENV_FILE }}" > .env
+        run: |
+          cat <<'ENVEOF' > .env
+          ${{ secrets.PRODUCTION_ENV_FILE }}
+          ENVEOF
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,10 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Create .env from secret
-        run: echo "${{ secrets.PRODUCTION_ENV_FILE }}" > .env
+        run: |
+          cat <<'ENVEOF' > .env
+          ${{ secrets.PRODUCTION_ENV_FILE }}
+          ENVEOF
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3


### PR DESCRIPTION
## Summary

- **Fix copy-paste tag bug** in `release.yml` — backend image was tagged as `*-frontend:<sha>` instead of `*-backend:<sha>`
- **Fix undefined `matrix.node-version`** in `docker.yml` — no matrix strategy existed
- **Remove unused pnpm/Node/install steps** from docker jobs in both workflows (Dockerfiles run their own `pnpm install`)
- **Switch GHCR auth** from hardcoded `peterzen` + personal PAT to `github.actor` + `GITHUB_TOKEN`
- **Replace `SpicyPizza/create-envfile`** third-party action with inline `echo`
- **Add Docker layer caching** (`type=gha`) to all build-push-action steps
- **Remove dead "Tag app bundle version"** step that only echoed strings
- **Add ingress image build** to both workflows (referenced by docker-compose but never built)

## Test plan

- [ ] Verify YAML is valid (confirmed locally with `yaml.safe_load`)
- [ ] Trigger manual Docker build workflow and confirm all three images (backend, frontend, ingress) push to GHCR
- [ ] Verify release workflow runs correctly on next push to main
- [ ] Confirm `PRODUCTION_ENV_FILE` secret is written correctly via `echo`

🤖 Generated with [Claude Code](https://claude.com/claude-code)