### PR TITLE
security: remove production secrets from frontend Docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+.git
+.gitignore
+.env
+.env.*
+!.env.example
+node_modules
+dist
+.vscode
+.DS_Store
+.changeset
+coverage
+.claude
+certs
+*.md

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -26,6 +26,14 @@ jobs:
           ${{ secrets.PRODUCTION_ENV_FILE }}
           ENVEOF
 
+      - name: Extract frontend build args
+        id: frontend-args
+        run: |
+          set -a && source .env && set +a
+          for var in VAPID_PUBLIC_KEY SENTRY_DSN SITE_NAME OG_TITLE OG_DESCRIPTION OG_IMAGE OG_URL OG_TYPE; do
+            echo "${var}=${!var}" >> "$GITHUB_OUTPUT"
+          done
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -64,6 +72,15 @@ jobs:
           push: true
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          build-args: |
+            VAPID_PUBLIC_KEY=${{ steps.frontend-args.outputs.VAPID_PUBLIC_KEY }}
+            SENTRY_DSN=${{ steps.frontend-args.outputs.SENTRY_DSN }}
+            SITE_NAME=${{ steps.frontend-args.outputs.SITE_NAME }}
+            OG_TITLE=${{ steps.frontend-args.outputs.OG_TITLE }}
+            OG_DESCRIPTION=${{ steps.frontend-args.outputs.OG_DESCRIPTION }}
+            OG_IMAGE=${{ steps.frontend-args.outputs.OG_IMAGE }}
+            OG_URL=${{ steps.frontend-args.outputs.OG_URL }}
+            OG_TYPE=${{ steps.frontend-args.outputs.OG_TYPE }}
           tags: |
             ghcr.io/${{ github.repository }}-frontend:${{ steps.git-info.outputs.tag-suffix }}
             ghcr.io/${{ github.repository }}-frontend:${{ steps.git-info.outputs.sha }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,6 +78,14 @@ jobs:
           ${{ secrets.PRODUCTION_ENV_FILE }}
           ENVEOF
 
+      - name: Extract frontend build args
+        id: frontend-args
+        run: |
+          set -a && source .env && set +a
+          for var in VAPID_PUBLIC_KEY SENTRY_DSN SITE_NAME OG_TITLE OG_DESCRIPTION OG_IMAGE OG_URL OG_TYPE; do
+            echo "${var}=${!var}" >> "$GITHUB_OUTPUT"
+          done
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -115,6 +123,15 @@ jobs:
           push: true
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          build-args: |
+            VAPID_PUBLIC_KEY=${{ steps.frontend-args.outputs.VAPID_PUBLIC_KEY }}
+            SENTRY_DSN=${{ steps.frontend-args.outputs.SENTRY_DSN }}
+            SITE_NAME=${{ steps.frontend-args.outputs.SITE_NAME }}
+            OG_TITLE=${{ steps.frontend-args.outputs.OG_TITLE }}
+            OG_DESCRIPTION=${{ steps.frontend-args.outputs.OG_DESCRIPTION }}
+            OG_IMAGE=${{ steps.frontend-args.outputs.OG_IMAGE }}
+            OG_URL=${{ steps.frontend-args.outputs.OG_URL }}
+            OG_TYPE=${{ steps.frontend-args.outputs.OG_TYPE }}
           tags: |
             ghcr.io/${{ github.repository }}-frontend:latest
             ghcr.io/${{ github.repository }}-frontend:${{ needs.version.outputs.app-version }}

--- a/apps/frontend/Dockerfile
+++ b/apps/frontend/Dockerfile
@@ -1,19 +1,51 @@
 FROM node:22-bookworm AS builder
 WORKDIR /app
 
+# Build-time variables embedded into the frontend bundle by Vite.
+# None of these are secrets — they are safe to appear in image layers.
+ARG API_BASE_URL="/api"
+ARG WS_BASE_URL="/ws"
+ARG IMAGE_URL_BASE="/images"
+ARG NODE_ENV="production"
+ARG VAPID_PUBLIC_KEY=""
+ARG SENTRY_DSN=""
+ARG SITE_NAME="OpenCupid"
+ARG OG_TITLE="OpenCupid"
+ARG OG_DESCRIPTION="OpenCupid is an open-source dating platform."
+ARG OG_IMAGE=""
+ARG OG_URL=""
+ARG OG_TYPE="website"
+
 RUN apt-get update && apt-get -y install build-essential python3 && \
   ln -sf /usr/bin/python3 /usr/bin/python
 
 # Copy root monorepo files
 COPY pnpm-lock.yaml pnpm-workspace.yaml package.json ./
 COPY apps/frontend/package.json ./apps/frontend/package.json
-COPY .env ./
 RUN corepack enable && pnpm install --frozen-lockfile --filter ./apps/frontend...
 
 # Copy frontend source
 COPY apps/frontend ./apps/frontend
 COPY packages ./packages
 WORKDIR /app/apps/frontend
+
+# Generate a minimal .env with only the non-secret build-time variables.
+# This replaces the previous `COPY .env ./` which leaked all production secrets
+# into the Docker build cache.
+RUN printf '%s\n' \
+  "API_BASE_URL=${API_BASE_URL}" \
+  "WS_BASE_URL=${WS_BASE_URL}" \
+  "IMAGE_URL_BASE=${IMAGE_URL_BASE}" \
+  "NODE_ENV=${NODE_ENV}" \
+  "VAPID_PUBLIC_KEY=${VAPID_PUBLIC_KEY}" \
+  "SENTRY_DSN=${SENTRY_DSN}" \
+  "SITE_NAME=${SITE_NAME}" \
+  "OG_TITLE=${OG_TITLE}" \
+  "OG_DESCRIPTION=${OG_DESCRIPTION}" \
+  "OG_IMAGE=${OG_IMAGE}" \
+  "OG_URL=${OG_URL}" \
+  "OG_TYPE=${OG_TYPE}" \
+  > /app/.env
 
 RUN pnpm run build-only
 


### PR DESCRIPTION
## Summary

The frontend Dockerfile previously `COPY .env ./` the entire production env file into the builder stage. While the multi-stage build kept it out of the final nginx image, **all production secrets** (JWT_SECRET, DATABASE_URL, SMTP creds, API keys, VAPID_PRIVATE_KEY) persisted in Docker build cache layers and GHA cache.

### Changes

- **Frontend Dockerfile**: Replace `COPY .env` with 12 explicit `ARG`s for the non-secret variables Vite needs at build time. A minimal `.env` is generated inside the container from those ARGs only.
- **Both workflows**: New "Extract frontend build args" step sources `.env` and outputs only the non-secret vars (`VAPID_PUBLIC_KEY`, `SENTRY_DSN`, `SITE_NAME`, `OG_*`), passed as `build-args` to `docker/build-push-action`.
- **`.dockerignore`**: Blocks `.env`, `.env.*`, `.git`, `node_modules`, `certs`, etc. from entering the Docker build context.

### Security impact

| Before | After |
|--------|-------|
| All secrets in build cache | Zero secrets in build cache |
| `.env` in Docker context | `.env` blocked by `.dockerignore` |
| Images safe to pull, but cache dangerous | Images AND cache both clean |

The images are now safe to publish publicly.

## Test plan

- [ ] Merge and trigger manual Docker build on main
- [ ] Verify frontend image builds successfully with build-args
- [ ] Inspect final image has no `.env` or secrets: `docker run --rm ghcr.io/opencupid/opencupid-frontend:manual cat /app/.env` should fail
- [ ] Verify OG meta tags and `__APP_CONFIG__` are correctly populated in the bundle

🤖 Generated with [Claude Code](https://claude.com/claude-code)