### PR TITLE
fix: read app version from package.json in tests

### DIFF
--- a/apps/frontend/src/features/app/stores/__tests__/appStore.spec.ts
+++ b/apps/frontend/src/features/app/stores/__tests__/appStore.spec.ts
@@ -2,6 +2,9 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { setActivePinia, createPinia } from 'pinia'
 import { useAppStore } from '../appStore'
 import * as apiModule from '@/lib/api'
+import rootPackageJson from '../../../../../../../package.json'
+
+const APP_VERSION = rootPackageJson.version
 
 // Mock the api module
 vi.mock('@/lib/api', () => ({
@@ -9,11 +12,6 @@ vi.mock('@/lib/api', () => ({
     get: vi.fn(),
   },
 }))
-
-// Mock __APP_VERSION__
-vi.stubGlobal('__APP_VERSION__', {
-  app: '0.5.0',
-})
 
 describe('useAppStore - checkVersion', () => {
   beforeEach(() => {
@@ -28,8 +26,8 @@ describe('useAppStore - checkVersion', () => {
         success: true,
         version: {
           updateAvailable: false,
-          frontendVersion: '0.5.0',
-          currentVersion: '0.5.0',
+          frontendVersion: APP_VERSION,
+          currentVersion: APP_VERSION,
         },
       },
     })
@@ -42,9 +40,9 @@ describe('useAppStore - checkVersion', () => {
       expect(result.data?.updateAvailable).toBe(false)
     }
     expect(store.updateAvailable).toBe(false)
-    expect(store.latestVersion).toBe('0.5.0')
+    expect(store.latestVersion).toBe(APP_VERSION)
     expect(mockApi.get).toHaveBeenCalledWith('/app/version', {
-      params: { v: '0.5.0' },
+      params: { v: APP_VERSION },
     })
   })
 
@@ -56,7 +54,7 @@ describe('useAppStore - checkVersion', () => {
         version: {
           updateAvailable: true,
           frontendVersion: '0.6.0',
-          currentVersion: '0.5.0',
+          currentVersion: APP_VERSION,
         },
       },
     })
@@ -93,8 +91,8 @@ describe('useAppStore - checkVersion', () => {
         success: true,
         version: {
           updateAvailable: false,
-          frontendVersion: '0.5.0',
-          currentVersion: '0.5.0',
+          frontendVersion: APP_VERSION,
+          currentVersion: APP_VERSION,
         },
       },
     })
@@ -103,7 +101,7 @@ describe('useAppStore - checkVersion', () => {
     await store.checkVersion()
 
     expect(mockApi.get).toHaveBeenCalledWith('/app/version', {
-      params: { v: '0.5.0' },
+      params: { v: APP_VERSION },
     })
   })
 })

--- a/apps/frontend/src/setupTests.ts
+++ b/apps/frontend/src/setupTests.ts
@@ -5,6 +5,7 @@
   NODE_ENV: 'test',
   SENTRY_DSN: '',
 }
+import rootPackageJson from '../../../package.json'
 ;(globalThis as any).__APP_VERSION__ = {
-  app: '0.5.0',
+  app: rootPackageJson.version,
 }


### PR DESCRIPTION
## Summary

- Import the actual version from root `package.json` in `appStore.spec.ts` and `setupTests.ts` instead of hardcoding `'0.5.0'`
- Remove the ineffective `vi.stubGlobal('__APP_VERSION__', ...)` call — Vite inlines the value at compile time so the stub had no effect
- Fixes the pre-existing CI failure seen in PR #554 (dependabot bump) which was caused by the version mismatch, not the dependency change

## Test plan

- [x] `pnpm --filter frontend test` — all 58 test files / 177 tests pass
- [x] `pnpm test` — full suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)