### PR TITLE
chore: exclude zod-prisma-types from dev-deps catch-all

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -56,6 +56,7 @@ updates:
         applies-to: version-updates
         dependency-type: development
         update-types: ["minor", "patch"]
+        exclude-patterns: ["zod-prisma-*"]
 
       prod-deps-minor-patch:
         applies-to: version-updates


### PR DESCRIPTION
## Summary
- Exclude `zod-prisma-*` from the `dev-deps-minor-patch` catch-all Dependabot group
- `zod-prisma-types` must remain on 3.2.4 — upgrading it breaks tests and needs to be coordinated with a prisma upgrade
- It will still appear in the `prisma` group where it can be reviewed/upgraded intentionally

🤖 Generated with [Claude Code](https://claude.com/claude-code)