### PR TITLE
fix: remove extra bottom padding from browse profile results

### DIFF
--- a/apps/frontend/src/features/browse/views/BrowseProfiles.vue
+++ b/apps/frontend/src/features/browse/views/BrowseProfiles.vue
@@ -256,7 +256,7 @@ useInfiniteScroll(
         <template v-else-if="isInitialized && haveResults">
           <div
             ref="scrollContainer"
-            class="overflow-auto hide-scrollbar pb-5 flex-grow-1"
+            class="overflow-auto hide-scrollbar flex-grow-1"
           >
             <MiddleColumn
               v-if="viewModeModel === 'grid'"


### PR DESCRIPTION
## Summary
- Remove `pb-5` class from the browse profile results scroll container to eliminate unnecessary bottom padding

## Test plan
- [ ] Browse to `/browse` and verify no excessive gap at the bottom of the profile grid

🤖 Generated with [Claude Code](https://claude.com/claude-code)