### PR TITLE
fix: add role="button" and title to anchor-styled buttons

### DIFF
--- a/apps/frontend/src/features/auth/views/AuthOtp.vue
+++ b/apps/frontend/src/features/auth/views/AuthOtp.vue
@@ -102,6 +102,8 @@ function handleBackButton() {
       <div class="back-button">
         <a
           class="btn btn-secondary-outline"
+          role="button"
+          :title="$t('uicomponents.back_button_title')"
           @click="handleBackButton"
         >
           <ChevronLeftIcon class="svg-icon" />

--- a/apps/frontend/src/features/messaging/__tests__/MessagingNav.spec.ts
+++ b/apps/frontend/src/features/messaging/__tests__/MessagingNav.spec.ts
@@ -14,7 +14,10 @@ describe('MessagingNav', () => {
   it('emits events on icon clicks', async () => {
     const wrapper = mount(MessagingNav, {
       props: { recipient: { id: '1', publicName: 'B', profileImages: [] } },
-      global: { stubs: { BButton: true, ProfileThumbnail: true } },
+      global: {
+        stubs: { BButton: true, ProfileThumbnail: true },
+        mocks: { $t: (key: string) => key },
+      },
     })
     await wrapper.find('.back-button a').trigger('click')
     await wrapper.find('.action-button a').trigger('click')

--- a/apps/frontend/src/features/messaging/components/MessagingNav.vue
+++ b/apps/frontend/src/features/messaging/components/MessagingNav.vue
@@ -21,6 +21,8 @@ defineEmits<{
     <div class="back-button">
       <a
         class="btn btn-secondary-outline fs-1"
+        role="button"
+        :title="$t('uicomponents.back_button_title')"
         @click="$emit('deselect:convo')"
       >
         <IconArrowSingleLeft class="svg-icon" />
@@ -42,6 +44,8 @@ defineEmits<{
     <div class="action-button">
       <a
         class="btn btn-secondary-outline"
+        role="button"
+        :title="$t('messaging.conversation_options_title')"
         @click="$emit('modal:open')"
       >
         <IconMenuDotsVert class="svg-icon-lg fs-4" />

--- a/apps/frontend/src/features/myprofile/components/EditField.vue
+++ b/apps/frontend/src/features/myprofile/components/EditField.vue
@@ -50,6 +50,8 @@ const fieldProxy = getModelProxy(props.fieldName)
     </span>
     <a
       href="#"
+      role="button"
+      :title="$t('uicomponents.edit_button_title')"
       @click="handleButtonClick"
       v-bind:class="props.buttonClass"
       class="edit-button me-2"

--- a/apps/frontend/src/features/myprofile/views/MyProfile.vue
+++ b/apps/frontend/src/features/myprofile/views/MyProfile.vue
@@ -121,6 +121,8 @@ const hint = computed(() => history?.state?.hint || null)
               >
                 <span
                   class="btn-social-toggle px-4 py-1 rounded-4 me-2"
+                  role="button"
+                  :title="$t('general.connectiontypes.socializing')"
                   @click="toggleSocial"
                   :class="{ active: formData.isSocialActive }"
                 >
@@ -137,6 +139,8 @@ const hint = computed(() => history?.state?.hint || null)
                 </span>
                 <span
                   class="btn-dating-toggle px-4 py-1 rounded-4"
+                  role="button"
+                  :title="$t('general.connectiontypes.dating')"
                   @click="toggleDating"
                   :class="{ active: formData.isDatingActive }"
                 >

--- a/apps/frontend/src/features/onboarding/components/GoalsSelector.vue
+++ b/apps/frontend/src/features/onboarding/components/GoalsSelector.vue
@@ -31,6 +31,8 @@ const toggleDating = () => {
   <div class="d-flex gap-2 flex-column justify-content-between w-100 mb-1 mb-sm-3 mb-md-3">
     <div
       class="card btn-social-toggle clickable mb-2 mb-sm-2 mb-md-4"
+      role="button"
+      :title="t('onboarding.goals.socializing')"
       :class="{ active: model.isSocialActive }"
       @click="toggleSocial"
     >
@@ -56,6 +58,8 @@ const toggleDating = () => {
 
     <div
       class="card btn-dating-toggle clickable"
+      role="button"
+      :title="t('onboarding.goals.dating')"
       :class="{ active: model.isDatingActive }"
       @click="toggleDating"
     >

--- a/packages/shared/i18n/en.json
+++ b/packages/shared/i18n/en.json
@@ -299,6 +299,7 @@
     "message_sent_success": "Message sent successfully!",
     "my_turn": "My turn",
     "their_turn": "Their turn",
+    "conversation_options_title": "Conversation options",
     "block_report_unmatch": "Block/report/unmatch",
     "block_user_ok": "Block {name}",
     "nevermind": "Nevermind",
@@ -335,6 +336,7 @@
   },
   "uicomponents": {
     "back_button_title": "Go back",
+    "edit_button_title": "Edit",
     "connection_error": {
       "title": "It's not you, it's us.",
       "description": "Apologies for the interruption.  The Machine Elves need a few seconds to sort things out, we'll be back in a bit."


### PR DESCRIPTION
Closes #570

## Summary

- Add `role="button"` and `title` attributes to `<a>` and `<span>/<div>` elements styled as buttons
- Affected: AuthOtp back button, MessagingNav back/options buttons, EditField edit button, social/dating toggles in MyProfile and GoalsSelector
- Add i18n keys `uicomponents.edit_button_title` and `messaging.conversation_options_title`
- Fix MessagingNav test to mock `$t`

## Test plan

- [x] `pnpm test` — all 432 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)