### PR TITLE
fix: read backend version from build-time constant

### DIFF
--- a/apps/backend/src/main.ts
+++ b/apps/backend/src/main.ts
@@ -1,5 +1,3 @@
-import path from 'path'
-
 import Sentry from '@/lib/sentry' // keep this at the top
 
 import Fastify from 'fastify'
@@ -11,8 +9,6 @@ import './workers/emailWorker' // ← side‐effect: starts the worker
 import { checkImageRoot } from '@/lib/media'
 
 import { ImageProcessor } from './services/imageprocessor'
-import { getPackageVersion } from '../../../packages/shared/version'
-
 async function main() {
   const app = Fastify({
     trustProxy: true,
@@ -31,13 +27,7 @@ async function main() {
     },
   })
 
-  // Log version information at startup
-  try {
-    const version = getPackageVersion(path.join(__dirname, '..', 'package.json'))
-    app.log.info(`🚀 Starting server, version ${version}`)
-  } catch (err) {
-    app.log.warn({ err }, 'Could not read version info at startup')
-  }
+  app.log.info(`🚀 Starting server, version ${__APP_VERSION__}`)
 
   // Register CORS plugin
   app.register(cors, {

--- a/apps/backend/src/types/global.d.ts
+++ b/apps/backend/src/types/global.d.ts
@@ -1,2 +1,3 @@
 // Global constants injected at build time by tsup
+declare const __APP_VERSION__: string
 declare const __FRONTEND_VERSION__: string

--- a/apps/backend/tsup.config.ts
+++ b/apps/backend/tsup.config.ts
@@ -2,13 +2,11 @@ import { defineConfig } from 'tsup'
 import { getPackageVersion } from '../../packages/shared/version'
 import path from 'path'
 
-// Read frontend version at build time
-const frontendVersion = getPackageVersion(path.join(__dirname, '..', '..', 'package.json'))
+// Read app version from root package.json at build time
+const appVersion = getPackageVersion(path.join(__dirname, '..', '..', 'package.json'))
 
 export default defineConfig({
-  entry: [
-    'src/main.ts',
-  ],
+  entry: ['src/main.ts'],
   outDir: 'dist',
   format: ['cjs'],
   splitting: false,
@@ -18,6 +16,7 @@ export default defineConfig({
   target: 'es2020',
   shims: false,
   define: {
-    __FRONTEND_VERSION__: JSON.stringify(frontendVersion),
+    __APP_VERSION__: JSON.stringify(appVersion),
+    __FRONTEND_VERSION__: JSON.stringify(appVersion),
   },
 })


### PR DESCRIPTION
## Summary
- Replace runtime file read of `apps/backend/package.json` (stuck at 0.6.2) with `__APP_VERSION__` build-time constant injected by tsup from the root `package.json`
- Same mechanism already used for `__FRONTEND_VERSION__` — both now read from the single source of truth

## Test plan
- [ ] `pnpm --filter backend test` passes (273 tests)
- [ ] After rebuild, backend startup log shows correct version from root `package.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)