### PR TITLE
fix: show baked-in frontend version in Settings instead of API response

### DIFF
--- a/apps/frontend/src/features/settings/components/VersionInfo.vue
+++ b/apps/frontend/src/features/settings/components/VersionInfo.vue
@@ -1,28 +1,5 @@
 <script setup lang="ts">
-import { ref, onMounted } from 'vue'
-import { useAppStore } from '@/features/app/stores/appStore'
-import type { VersionDTO } from '@zod/dto/version.dto'
-
-const appStore = useAppStore()
-
-const version = ref<VersionDTO | null>(null)
-const isLoading = ref(false)
-const error = ref<string | null>(null)
-
-onMounted(async () => {
-  isLoading.value = true
-  error.value = null
-
-  const result = await appStore.checkVersion()
-
-  if (result.success) {
-    version.value = result.data!
-  } else {
-    error.value = result.message
-  }
-
-  isLoading.value = false
-})
+const version = __APP_VERSION__?.app || 'unknown'
 </script>
 
 <template>
@@ -30,25 +7,8 @@ onMounted(async () => {
     class="text-center w-100"
     style="font-size: 0.5rem"
   >
-    <div
-      v-if="isLoading"
-      class="text-muted"
-    >
-      Loading version information...
-    </div>
-
-    <div
-      v-else-if="error"
-      class="text-danger"
-    >
-      {{ error }}
-    </div>
-
-    <code
-      v-else-if="version"
-      class="text-muted"
-    >
-      <span>v{{ version.frontendVersion }}</span>
+    <code class="text-muted">
+      <span>v{{ version }}</span>
     </code>
   </div>
 </template>


### PR DESCRIPTION
## Summary
- Replace the API call to fetch version info with the version baked into the frontend at build time via `__APP_VERSION__`
- Remove unnecessary loading state, error handling, and API dependency from VersionInfo component
- Simplifies the component significantly (~40 lines removed)

## Test plan
- [ ] Verify Settings page shows the correct version string
- [ ] Confirm no network request is made for version info

🤖 Generated with [Claude Code](https://claude.com/claude-code)