### PR TITLE
fix: forward build args to frontend in production compose

### DIFF
--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -76,6 +76,15 @@ services:
     build:
       context: .
       dockerfile: apps/frontend/Dockerfile
+      args:
+        SITE_NAME: ${SITE_NAME:-OpenCupid}
+        VAPID_PUBLIC_KEY: ${VAPID_PUBLIC_KEY:-}
+        SENTRY_DSN: ${SENTRY_DSN:-}
+        OG_TITLE: ${OG_TITLE:-OpenCupid}
+        OG_DESCRIPTION: ${OG_DESCRIPTION:-OpenCupid is an open-source dating platform.}
+        OG_IMAGE: ${OG_IMAGE:-}
+        OG_URL: ${OG_URL:-}
+        OG_TYPE: ${OG_TYPE:-website}
     restart: always
     env_file:
       - .env


### PR DESCRIPTION
## Summary
- Add `args` to the frontend `build` section in `docker-compose.production.yml` to forward `SITE_NAME`, `VAPID_PUBLIC_KEY`, `SENTRY_DSN`, and OG meta variables from `.env` into the Docker build
- Without this, `docker compose build` on the production host always uses the Dockerfile defaults (e.g. `SITE_NAME=OpenCupid`) because Vite bakes these values at build time — runtime `env_file` has no effect on the already-bundled frontend

## Root cause
The CI workflow (`docker.yml`) correctly passes `--build-arg SITE_NAME=...` etc., but the production compose file had no `args`, so local rebuilds on the host ignored `.env` values.

## Test plan
- [ ] On production host: rebuild frontend with `docker compose -f docker-compose.production.yml build frontend`
- [ ] Verify landing page shows configured `SITE_NAME` instead of "OpenCupid"

🤖 Generated with [Claude Code](https://claude.com/claude-code)