### PR TITLE
fix: redirect authenticated users from landing page to /home

### DIFF
--- a/apps/frontend/src/lib/__tests__/main.spec.ts
+++ b/apps/frontend/src/lib/__tests__/main.spec.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest'
+import { shouldShowLandingPage } from '@/lib/bootstrapRoute'
+
+describe('shouldShowLandingPage', () => {
+  it('returns true for root path without token', () => {
+    expect(shouldShowLandingPage('/', false)).toBe(true)
+  })
+
+  it('returns false for root path with token (authenticated user)', () => {
+    expect(shouldShowLandingPage('/', true)).toBe(false)
+  })
+
+  it('returns false for non-root path without token', () => {
+    expect(shouldShowLandingPage('/home', false)).toBe(false)
+  })
+
+  it('returns false for non-root path with token', () => {
+    expect(shouldShowLandingPage('/home', true)).toBe(false)
+  })
+})

--- a/apps/frontend/src/lib/bootstrapRoute.ts
+++ b/apps/frontend/src/lib/bootstrapRoute.ts
@@ -1,0 +1,3 @@
+export function shouldShowLandingPage(pathname: string, hasToken: boolean): boolean {
+  return pathname === '/' && !hasToken
+}

--- a/apps/frontend/src/main.ts
+++ b/apps/frontend/src/main.ts
@@ -6,8 +6,9 @@ import '@/css/fonts.scss'
 import '@/css/bootstrap.scss'
 import '@/css/main.scss'
 import { useLocalStore } from './store/localStore'
+import { shouldShowLandingPage } from './lib/bootstrapRoute'
 
-if (window.location.pathname === '/') {
+if (shouldShowLandingPage(window.location.pathname, !!localStorage.getItem('token'))) {
   import('@/features/landingpage/views/LandingPage.vue').then(({ default: Landing }) => {
     const app = createApp(Landing)
     app.use(createPinia())


### PR DESCRIPTION
## Summary
- Authenticated users visiting `/` are now redirected to `/home` instead of seeing the landing page
- The landing page (`/`) uses a lightweight bootstrap that bypasses Vue Router, so the existing `beforeEach` auth guard never fires. This adds a synchronous `localStorage.getItem('token')` check before mounting the landing page — if a token exists, the full app bootstrap runs instead, whose router redirects `/` → `/home`
- Landing page performance optimization is preserved for unauthenticated users

Closes #611

## Test plan
- [ ] `pnpm --filter frontend test` passes (206 tests, including 4 new ones for `shouldShowLandingPage`)
- [ ] Clear localStorage, visit `/` → landing page shows (existing behavior)
- [ ] Log in, visit `/` → redirected to `/home`
- [ ] Log out, visit `/` → landing page shows again

🤖 Generated with [Claude Code](https://claude.com/claude-code)