### PR TITLE
fix: hide call button while recording voice message

### DIFF
--- a/apps/frontend/src/features/messaging/__tests__/SendMessageForm.spec.ts
+++ b/apps/frontend/src/features/messaging/__tests__/SendMessageForm.spec.ts
@@ -10,6 +10,9 @@ vi.mock('@/features/shared/profiledisplay/LanguageList.vue', () => ({
   default: { template: '<div />' },
 }))
 vi.mock('@/features/shared/ui/StoreErrorOverlay.vue', () => ({ default: { template: '<div />' } }))
+vi.mock('@/assets/icons/interface/call.svg', () => ({
+  default: { template: '<span data-testid="icon-call" />' },
+}))
 
 import SendMessageForm from '../components/SendMessageForm.vue'
 import { useLocalStore } from '@/store/localStore'
@@ -111,6 +114,57 @@ describe('SendMessageForm', () => {
     newLocalStore.initialize()
 
     expect(newLocalStore.getSendMode).toBe('click')
+  })
+
+  function mountForm(props: Record<string, unknown> = {}) {
+    return mount(SendMessageForm, {
+      props: {
+        recipientProfile: mockRecipient,
+        conversationId: 'conv-1',
+        ...props,
+      },
+      global: {
+        stubs: {
+          BFormGroup: true,
+          BFormTextarea: true,
+          BButton: true,
+          BDropdown: true,
+          BDropdownItem: true,
+          TagList: true,
+          LanguageList: true,
+          StoreErrorOverlay: true,
+          VoiceRecorder: true,
+          IconMenuDotsVert: true,
+          IconCall: true,
+          Mic2Icon: true,
+        },
+        mocks: {
+          $t: (key: string) => key,
+        },
+      },
+    })
+  }
+
+  it('shows call button when canCall is true', () => {
+    const wrapper = mountForm({ canCall: true })
+    expect(wrapper.find('[title="calls.call_button_title"]').exists()).toBe(true)
+  })
+
+  it('hides call button when canCall is false', () => {
+    const wrapper = mountForm({ canCall: false })
+    expect(wrapper.find('[title="calls.call_button_title"]').exists()).toBe(false)
+  })
+
+  it('hides call button while recording voice message', async () => {
+    const wrapper = mountForm({ canCall: true })
+    expect(wrapper.find('[title="calls.call_button_title"]').exists()).toBe(true)
+
+    // Simulate recording started
+    const voiceRecorder = wrapper.findComponent({ name: 'VoiceRecorder' })
+    await voiceRecorder.vm.$emit('recording:started')
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.find('[title="calls.call_button_title"]').exists()).toBe(false)
   })
 
   it('renders radio buttons in dropdown menu', async () => {

--- a/apps/frontend/src/features/messaging/components/SendMessageForm.vue
+++ b/apps/frontend/src/features/messaging/components/SendMessageForm.vue
@@ -166,7 +166,7 @@ function handleVoiceRecordingError(error: string) {
               @recording:error="handleVoiceRecordingError"
             />
             <a
-              v-if="canCall"
+              v-if="canCall && !isVoiceActive"
               class="btn btn-outline-secondary btn-sm icon-btn-round"
               role="button"
               :title="$t('calls.call_button_title')"


### PR DESCRIPTION
## Summary
- Hides the call button in `SendMessageForm` while a voice message is being recorded
- Adds `!isVoiceActive` condition to the existing `v-if="canCall"` guard
- Adds tests for call button visibility and hiding during recording

Closes #624

## Test plan
- [x] `pnpm test` — all 211 tests pass
- [ ] Manual: open a conversation with calls enabled, start recording a voice message, confirm call button disappears
- [ ] Manual: cancel/complete the recording, confirm call button reappears

🤖 Generated with [Claude Code](https://claude.com/claude-code)