### PR TITLE
fix(i18n): add missing Hungarian translation for posts.create_title

### DIFF
--- a/packages/shared/i18n/hu.json
+++ b/packages/shared/i18n/hu.json
@@ -397,6 +397,7 @@
   },
   "posts": {
     "title": "Hirdetőtábla",
+    "create_title": "Új hirdetés",
     "types": {
       "OFFER": "Felajánlás",
       "REQUEST": "Keresés"


### PR DESCRIPTION
## Summary
- Adds missing `posts.create_title` key (`"Új hirdetés"`) to Hungarian translations

## Test plan
- [x] `pnpm test` passes
- [ ] Switch language to Hungarian, verify "Post something" button shows "Új hirdetés"

🤖 Generated with [Claude Code](https://claude.com/claude-code)