### PR TITLE
fix: use 2 columns for profile grid on lg breakpoint

### DIFF
--- a/apps/frontend/src/features/browse/components/ProfileCardGrid.vue
+++ b/apps/frontend/src/features/browse/components/ProfileCardGrid.vue
@@ -15,7 +15,7 @@ defineEmits<{
 
 <template>
   <BContainer fluid>
-    <BRow v-bind="{ cols: 1, 'cols-sm': 2, 'cols-lg': 3, 'gutter-y': 4, ...$attrs }">
+    <BRow v-bind="{ cols: 1, 'cols-sm': 2, 'cols-lg': 2, 'gutter-y': 4, ...$attrs }">
       <BCol
         v-for="profile in profiles"
         :key="profile.id"


### PR DESCRIPTION
## Summary
- Change ProfileCardGrid from 3 columns to 2 columns at the `lg` breakpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)