### PR TITLE
fix: adjust notification dot vertical position

### DIFF
--- a/apps/frontend/src/features/shared/ui/NotificationDot.vue
+++ b/apps/frontend/src/features/shared/ui/NotificationDot.vue
@@ -12,10 +12,15 @@ const props = defineProps<{ show: boolean }>()
     <FontAwesomeIcon
       v-if="props.show"
       :icon="faCircle"
-      class="text-danger position-absolute top-0 start-55 translate-middle"
+      class="text-danger position-absolute start-55 translate-middle notification-dot"
       style="font-size: 0.75rem"
     />
   </span>
 </template>
 
-<style scoped></style>
+<style scoped>
+:deep(.notification-dot) {
+  top: 5px !important;
+}
+
+</style>


### PR DESCRIPTION
## Summary
- Adjust notification dot position from `top-0` to a fixed `top: 5px` for better alignment

🤖 Generated with [Claude Code](https://claude.com/claude-code)