### PR TITLE
fix: add theme-color meta tag and manifest MIME type

### DIFF
--- a/apps/frontend/index.html
+++ b/apps/frontend/index.html
@@ -12,6 +12,7 @@
     <link rel="apple-touch-icon" sizes="180x180" href="/assets/apple-touch-icon.png" />
     <meta name="apple-mobile-web-app-title" content="Gaians.net" />
     <link rel="manifest" href="/assets/site.webmanifest" />
+    <meta name="theme-color" content="#008000" />
     <script>
       // (function () {
       //   const theme = localStorage.getItem('theme')

--- a/apps/frontend/nginx.conf
+++ b/apps/frontend/nginx.conf
@@ -16,6 +16,7 @@ server {
 
   location = /assets/site.webmanifest {
     add_header Cache-Control "no-cache";
+    types { application/manifest+json webmanifest; }
   }
 
   location /assets/ {


### PR DESCRIPTION
## Summary
- Add `<meta name="theme-color" content="#008000">` to `index.html` for PWA compliance
- Set correct `application/manifest+json` MIME type for `site.webmanifest` in frontend nginx

## Test plan
- [ ] `pnpm test` passes
- [ ] After deploy: `curl -I https://<domain>/assets/site.webmanifest` returns `Content-Type: application/manifest+json`
- [ ] After deploy: page source contains `<meta name="theme-color" content="#008000">`

🤖 Generated with [Claude Code](https://claude.com/claude-code)