### PR TITLE
chore: add postgres-mcp server for dev database access

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -47,6 +47,13 @@
       "env": {
         "SENTRY_AUTH_TOKEN": "${SENTRY_AUTH_TOKEN}"
       }
+    },
+    "postgres": {
+      "command": "/home/user/.venvs/postgres-mcp/bin/postgres-mcp",
+      "args": [
+        "postgresql://appuser:secret@localhost:5432/app",
+        "--access-mode=unrestricted"
+      ]
     }
   }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,6 +147,10 @@ pnpm --filter backend db:psql -c 'SELECT ...'
 
 Schema: `apps/backend/prisma/schema.prisma`
 
+### Database queries (Claude MCP)
+
+The `postgres` MCP server provides direct SQL access to the dev database during debugging. Use it instead of `docker exec` / `psql` commands for faster iteration. The server is configured in `.claude/settings.json` and connects to the local dev DB automatically.
+
 ## Git workflow
 
 > **HARD RULE — NO EXCEPTIONS:** You MUST NEVER commit anything to the `main` branch. Not documentation, not design files, not a single line. Every commit goes on a feature branch. If you are on `main`, stop and create a branch before touching anything.

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -6,6 +6,18 @@
 sudo apt-get install ripgrep
 ```
 
+### Optional: postgres-mcp (for Claude Code)
+
+Gives Claude direct SQL access to the dev database via MCP. Requires Python 3.12+.
+
+```bash
+uv python install 3.12
+uv venv --python 3.12 ~/.venvs/postgres-mcp
+VIRTUAL_ENV=~/.venvs/postgres-mcp uv pip install postgres-mcp
+```
+
+Already configured in `.claude/settings.json` — no further setup needed after install.
+
 ## Getting started with development
 
 ```bash


### PR DESCRIPTION
## Summary
- Install and configure `postgres-mcp` as an MCP server for Claude Code
- Add MCP server config to `.claude/settings.json` connecting to the local dev DB
- Document the optional dependency in `docs/DEVELOPMENT.md` with install instructions
- Add CLAUDE.md note directing use of postgres MCP for debugging queries

## Test plan
- [x] `postgres-mcp` binary verified working with MCP init handshake
- [x] Connects to dev DB (`postgresql://appuser:secret@localhost:5432/app`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)