### PR TITLE
fix: use dedicated map endpoint for browse map view

### DIFF
--- a/apps/backend/src/__tests__/routes/findProfile.route.spec.ts
+++ b/apps/backend/src/__tests__/routes/findProfile.route.spec.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+const mockFindSocialProfilesWithLocation = vi.fn()
+const mockFindSocialProfilesFor = vi.fn()
+
+vi.mock('@/services/profileMatch.service', () => ({
+  ProfileMatchService: {
+    getInstance: () => ({
+      findSocialProfilesFor: mockFindSocialProfilesFor,
+      findSocialProfilesWithLocation: mockFindSocialProfilesWithLocation,
+      getSocialMatchFilter: vi.fn(),
+      updateSocialMatchFilter: vi.fn(),
+    }),
+  },
+}))
+
+vi.mock('@/services/profile.service', () => ({
+  ProfileService: {
+    getInstance: () => ({
+      getProfileByUserId: vi.fn(),
+    }),
+  },
+}))
+
+vi.mock('@/lib/appconfig', () => ({
+  appConfig: {},
+}))
+
+vi.mock('../../api/mappers/profile.mappers', () => ({
+  mapProfileToPublic: vi.fn((p: any) => ({
+    id: p.id,
+    publicName: p.publicName,
+    location: { country: p.country, cityName: p.cityName, lat: p.lat, lon: p.lon },
+    profileImages: p.profileImages ?? [],
+    tags: p.tags ?? [],
+  })),
+}))
+
+import findProfileRoutes from '../../api/routes/findProfile.route'
+import { MockFastify, MockReply } from '../../test-utils/fastify'
+
+let fastify: MockFastify
+let reply: MockReply
+
+const mockSession = {
+  profileId: 'profile-123',
+  lang: 'en',
+  profile: { isSocialActive: true, isDatingActive: false },
+}
+
+beforeEach(async () => {
+  fastify = new MockFastify()
+  reply = new MockReply()
+  await findProfileRoutes(fastify as any, {})
+})
+
+afterEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('GET /social/map', () => {
+  const handler = () => fastify.routes['GET /social/map']
+
+  it('returns profiles with location data', async () => {
+    const mockProfiles = [
+      {
+        id: 'p1',
+        publicName: 'Alice',
+        lat: 47.5,
+        lon: 19.0,
+        country: 'HU',
+        cityName: 'Budapest',
+        localized: [],
+        profileImages: [],
+        tags: [],
+      },
+    ]
+    mockFindSocialProfilesWithLocation.mockResolvedValue(mockProfiles)
+
+    await handler()({ session: mockSession, query: {}, log: { error: vi.fn() } }, reply)
+
+    expect(reply.statusCode).toBe(200)
+    expect(reply.payload.success).toBe(true)
+    expect(reply.payload.profiles).toHaveLength(1)
+    expect(mockFindSocialProfilesWithLocation).toHaveBeenCalledWith(
+      'profile-123',
+      [{ updatedAt: 'desc' }],
+      undefined
+    )
+  })
+
+  it('passes bounding box to service when provided', async () => {
+    mockFindSocialProfilesWithLocation.mockResolvedValue([])
+
+    await handler()(
+      {
+        session: mockSession,
+        query: { south: '45.0', north: '48.0', west: '16.0', east: '23.0' },
+      },
+      reply
+    )
+
+    expect(reply.statusCode).toBe(200)
+    expect(mockFindSocialProfilesWithLocation).toHaveBeenCalledWith(
+      'profile-123',
+      [{ updatedAt: 'desc' }],
+      { south: 45.0, north: 48.0, west: 16.0, east: 23.0 }
+    )
+  })
+
+  it('returns 403 when social is not active', async () => {
+    await handler()(
+      {
+        session: { ...mockSession, profile: { ...mockSession.profile, isSocialActive: false } },
+        query: {},
+      },
+      reply
+    )
+
+    expect(reply.statusCode).toBe(403)
+    expect(mockFindSocialProfilesWithLocation).not.toHaveBeenCalled()
+  })
+
+  it('returns 500 on service error', async () => {
+    mockFindSocialProfilesWithLocation.mockRejectedValue(new Error('DB error'))
+
+    await handler()({ session: mockSession, query: {}, log: { error: vi.fn() } }, reply)
+
+    expect(reply.statusCode).toBe(500)
+  })
+})

--- a/apps/backend/src/__tests__/services/profileMatch_social.service.spec.ts
+++ b/apps/backend/src/__tests__/services/profileMatch_social.service.spec.ts
@@ -78,6 +78,95 @@ describe('ProfileMatchService.findSocialProfilesFor', () => {
   })
 })
 
+describe('ProfileMatchService.findSocialProfilesWithLocation', () => {
+  it('returns empty array if no user preferences found', async () => {
+    mockPrisma.socialMatchFilter.findUnique.mockResolvedValue(null)
+    const result = await service.findSocialProfilesWithLocation(mockProfileId)
+    expect(result).toEqual([])
+  })
+
+  it('requires lat and lon to be non-null in the where clause', async () => {
+    const mockUserPrefs = { profileId: mockProfileId }
+    mockPrisma.socialMatchFilter.findUnique.mockResolvedValue(mockUserPrefs)
+    mockPrisma.profile.findMany.mockResolvedValue(mockProfiles)
+
+    await service.findSocialProfilesWithLocation(mockProfileId)
+
+    expect(mockPrisma.profile.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          lat: { not: null },
+          lon: { not: null },
+        }),
+      })
+    )
+  })
+
+  it('applies country filter from user preferences', async () => {
+    const mockUserPrefs = { profileId: mockProfileId, country: 'HU' }
+    mockPrisma.socialMatchFilter.findUnique.mockResolvedValue(mockUserPrefs)
+    mockPrisma.profile.findMany.mockResolvedValue(mockProfiles)
+
+    await service.findSocialProfilesWithLocation(mockProfileId)
+
+    expect(mockPrisma.profile.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          country: 'HU',
+          lat: { not: null },
+          lon: { not: null },
+        }),
+      })
+    )
+  })
+
+  it('applies tag filter from user preferences', async () => {
+    const mockUserPrefs = { profileId: mockProfileId, tags: [{ id: 'tag-1' }] }
+    mockPrisma.socialMatchFilter.findUnique.mockResolvedValue(mockUserPrefs)
+    mockPrisma.profile.findMany.mockResolvedValue(mockProfiles)
+
+    await service.findSocialProfilesWithLocation(mockProfileId)
+
+    expect(mockPrisma.profile.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          tags: { some: { id: { in: ['tag-1'] } } },
+        }),
+      })
+    )
+  })
+
+  it('applies bounding box when provided', async () => {
+    const mockUserPrefs = { profileId: mockProfileId }
+    mockPrisma.socialMatchFilter.findUnique.mockResolvedValue(mockUserPrefs)
+    mockPrisma.profile.findMany.mockResolvedValue(mockProfiles)
+
+    const bounds = { south: 45.0, north: 48.0, west: 16.0, east: 23.0 }
+    await service.findSocialProfilesWithLocation(mockProfileId, undefined, bounds)
+
+    expect(mockPrisma.profile.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          lat: { not: null, gte: 45.0, lte: 48.0 },
+          lon: { not: null, gte: 16.0, lte: 23.0 },
+        }),
+      })
+    )
+  })
+
+  it('has no skip/take when no bounds provided', async () => {
+    const mockUserPrefs = { profileId: mockProfileId }
+    mockPrisma.socialMatchFilter.findUnique.mockResolvedValue(mockUserPrefs)
+    mockPrisma.profile.findMany.mockResolvedValue(mockProfiles)
+
+    await service.findSocialProfilesWithLocation(mockProfileId)
+
+    const call = mockPrisma.profile.findMany.mock.calls[0][0]
+    expect(call.take).toBe(500)
+    expect(call).not.toHaveProperty('skip')
+  })
+})
+
 describe('ProfileMatchService.createSocialMatchFilter', () => {
   it('creates filter with full location data', async () => {
     const createdFilter = { profileId: mockProfileId, country: 'US', tags: [] }

--- a/apps/backend/src/api/routes/findProfile.route.ts
+++ b/apps/backend/src/api/routes/findProfile.route.ts
@@ -26,16 +26,16 @@ import {
 // Pagination query schema for infinite scrolling
 const PaginationQuerySchema = z.object({
   skip: z.preprocess(
-    val => (typeof val === 'string' ? parseInt(val, 10) : val),
+    (val) => (typeof val === 'string' ? parseInt(val, 10) : val),
     z.number().int().min(0).default(0)
   ),
   take: z.preprocess(
-    val => (typeof val === 'string' ? parseInt(val, 10) : val),
+    (val) => (typeof val === 'string' ? parseInt(val, 10) : val),
     z.number().int().min(1).max(50).default(10)
   ),
 })
 
-const findProfileRoutes: FastifyPluginAsync = async fastify => {
+const findProfileRoutes: FastifyPluginAsync = async (fastify) => {
   // instantiate services
   const profileMatchService = ProfileMatchService.getInstance()
   const profileService = ProfileService.getInstance()
@@ -43,6 +43,40 @@ const findProfileRoutes: FastifyPluginAsync = async fastify => {
   fastify.get('/social', { onRequest: [fastify.authenticate] }, async (req, reply) => {
     const { skip, take } = PaginationQuerySchema.parse(req.query)
     return getSocialProfiles(req, reply, [{ updatedAt: 'desc' }], take, skip)
+  })
+
+  fastify.get('/social/map', { onRequest: [fastify.authenticate] }, async (req, reply) => {
+    if (!req.session.profile.isSocialActive) {
+      return sendForbiddenError(reply)
+    }
+
+    const myProfileId = req.session.profileId
+    const locale = req.session.lang
+    const query = req.query as Record<string, string>
+
+    const bounds =
+      query.south && query.north && query.west && query.east
+        ? {
+            south: parseFloat(query.south),
+            north: parseFloat(query.north),
+            west: parseFloat(query.west),
+            east: parseFloat(query.east),
+          }
+        : undefined
+
+    try {
+      const profiles = await profileMatchService.findSocialProfilesWithLocation(
+        myProfileId,
+        [{ updatedAt: 'desc' }],
+        bounds
+      )
+      const mappedProfiles = profiles.map((p) => mapProfileToPublic(p, false, locale))
+      const response: GetProfilesResponse = { success: true, profiles: mappedProfiles }
+      return reply.code(200).send(response)
+    } catch (err) {
+      req.log.error(err)
+      return sendError(reply, 500, 'Failed to fetch map profiles')
+    }
   })
 
   fastify.get('/dating', { onRequest: [fastify.authenticate] }, async (req, reply) => {
@@ -67,7 +101,7 @@ const findProfileRoutes: FastifyPluginAsync = async fastify => {
         take,
         skip
       )
-      const mappedProfiles = profiles.map(p =>
+      const mappedProfiles = profiles.map((p) =>
         mapProfileToPublic(p, false /* includeDatingContext */, locale)
       )
       const response: GetProfilesResponse = { success: true, profiles: mappedProfiles }
@@ -167,7 +201,7 @@ const findProfileRoutes: FastifyPluginAsync = async fastify => {
         take,
         skip
       )
-      const mappedProfiles = profiles.map(p =>
+      const mappedProfiles = profiles.map((p) =>
         mapProfileToPublic(p, true /* includeDatingContext */, locale)
       )
       const response: GetProfilesResponse = { success: true, profiles: mappedProfiles }
@@ -199,7 +233,7 @@ const findProfileRoutes: FastifyPluginAsync = async fastify => {
         take,
         skip
       )
-      const mappedProfiles = profiles.map(p =>
+      const mappedProfiles = profiles.map((p) =>
         mapProfileToPublic(p, false /* includeDatingContext */, locale)
       )
       const response: GetProfilesResponse = { success: true, profiles: mappedProfiles }

--- a/apps/backend/src/services/profileMatch.service.ts
+++ b/apps/backend/src/services/profileMatch.service.ts
@@ -87,7 +87,7 @@ export class ProfileMatchService {
     profileId: string,
     data: UpdateSocialMatchFilterPayload
   ): Promise<SocialMatchFilterWithTags | null> {
-    const tagIds = (data.tags ?? []).map(id => ({ id }))
+    const tagIds = (data.tags ?? []).map((id) => ({ id }))
     const update = {
       profileId,
       country: data.location?.country || null,
@@ -162,53 +162,67 @@ export class ProfileMatchService {
       */
   }
 
+  private async buildSocialWhereClause(profileId: string) {
+    const userPrefs = await this.getSocialMatchFilter(profileId)
+    if (!userPrefs) return null
+
+    const tagIds = userPrefs.tags?.map((tag) => tag.id)
+
+    return {
+      ...statusFlags,
+      isSocialActive: true,
+      id: { not: profileId },
+      ...(userPrefs.country ? { country: userPrefs.country } : {}),
+      ...(userPrefs.tags?.length ? { tags: { some: { id: { in: tagIds } } } } : {}),
+      ...blocklistWhereClause(profileId),
+    }
+  }
+
   async findSocialProfilesFor(
     profileId: string,
     orderBy: OrderBy = defaultOrderBy,
     take: number = 10,
     skip: number = 0
   ): Promise<DbProfileWithImages[]> {
-    const userPrefs = await this.getSocialMatchFilter(profileId)
+    const where = await this.buildSocialWhereClause(profileId)
+    if (!where) return []
 
-    if (!userPrefs) {
-      return [] // no preferences set, return empty array
-    }
-
-    const tagIds = userPrefs.tags?.map(tag => tag.id)
-
-    const filters = {
-      ...(userPrefs.country ? { country: userPrefs.country } : {}),
-      ...(userPrefs.tags?.length
-        ? {
-            tags: {
-              some: {
-                id: { in: tagIds },
-              },
-            },
-          }
-        : {}),
-    }
-
-    const profiles = await prisma.profile.findMany({
-      where: {
-        ...statusFlags,
-        isSocialActive: true,
-        id: {
-          not: profileId,
-        },
-        ...filters,
-        ...blocklistWhereClause(profileId),
-      },
+    return await prisma.profile.findMany({
+      where,
       include: {
         ...tagsInclude(),
         ...profileImageInclude(),
       },
-      take: take,
-      skip: skip,
-      orderBy: orderBy,
+      take,
+      skip,
+      orderBy,
     })
+  }
 
-    return profiles
+  async findSocialProfilesWithLocation(
+    profileId: string,
+    orderBy: OrderBy = defaultOrderBy,
+    bounds?: { south: number; north: number; west: number; east: number }
+  ): Promise<DbProfileWithImages[]> {
+    const where = await this.buildSocialWhereClause(profileId)
+    if (!where) return []
+
+    const locationFilter = bounds
+      ? {
+          lat: { not: null, gte: bounds.south, lte: bounds.north },
+          lon: { not: null, gte: bounds.west, lte: bounds.east },
+        }
+      : { lat: { not: null }, lon: { not: null } }
+
+    return await prisma.profile.findMany({
+      where: { ...where, ...locationFilter },
+      include: {
+        ...tagsInclude(),
+        ...profileImageInclude(),
+      },
+      take: 500,
+      orderBy,
+    })
   }
 
   async findLocalProfiles(

--- a/apps/frontend/src/features/browse/composables/__tests__/useFindMatchViewModel.spec.ts
+++ b/apps/frontend/src/features/browse/composables/__tests__/useFindMatchViewModel.spec.ts
@@ -42,6 +42,7 @@ const mockFindProfileStore = {
   datingPrefs: null,
   socialFilter: null,
   findSocial: vi.fn(),
+  findSocialForMap: vi.fn(),
   findDating: vi.fn(),
   fetchSocialFilter: vi.fn(),
   fetchDatingPrefs: vi.fn(),
@@ -154,6 +155,53 @@ describe('useFindMatchViewModel', () => {
       (call) => call[0]?.name === 'BrowseProfilesScope'
     )
     expect(scopeCalls).toHaveLength(0)
+  })
+
+  it('fetchResults calls findSocial for grid viewMode', async () => {
+    routeRef.value = {
+      params: { scope: 'social' },
+      query: { viewMode: 'grid' },
+      fullPath: '/browse/social?viewMode=grid',
+    }
+    const vm = useFindMatchViewModel()
+    await vm.initialize()
+
+    expect(mockFindProfileStore.findSocial).toHaveBeenCalled()
+    expect(mockFindProfileStore.findSocialForMap).not.toHaveBeenCalled()
+  })
+
+  it('fetchResults calls findSocialForMap for map viewMode', async () => {
+    routeRef.value = {
+      params: { scope: 'social' },
+      query: { viewMode: 'map' },
+      fullPath: '/browse/social?viewMode=map',
+    }
+    const vm = useFindMatchViewModel()
+    await vm.initialize()
+
+    expect(mockFindProfileStore.findSocialForMap).toHaveBeenCalled()
+    expect(mockFindProfileStore.findSocial).not.toHaveBeenCalled()
+  })
+
+  it('re-fetches when viewMode changes from grid to map', async () => {
+    routeRef.value = {
+      params: { scope: 'social' },
+      query: { viewMode: 'grid' },
+      fullPath: '/browse/social?viewMode=grid',
+    }
+    const vm = useFindMatchViewModel()
+    await vm.initialize()
+
+    mockFindProfileStore.findSocial.mockClear()
+    mockFindProfileStore.findSocialForMap.mockClear()
+
+    // Switch to map — mutate existing reactive object to preserve proxy connection
+    routeRef.value.query = { viewMode: 'map' }
+    routeRef.value.fullPath = '/browse/social?viewMode=map'
+    await nextTick()
+
+    expect(mockFindProfileStore.findSocialForMap).toHaveBeenCalled()
+    expect(mockFindProfileStore.findSocial).not.toHaveBeenCalled()
   })
 
   it('currentScope watcher skips re-fetch when scope has not actually changed', async () => {

--- a/apps/frontend/src/features/browse/composables/useFindMatchViewModel.ts
+++ b/apps/frontend/src/features/browse/composables/useFindMatchViewModel.ts
@@ -117,7 +117,11 @@ export function useFindMatchViewModel() {
   const fetchResults = async () => {
     switch (currentScope.value) {
       case 'social': {
-        await findProfileStore.findSocial()
+        if (currentViewMode.value === 'map') {
+          await findProfileStore.findSocialForMap()
+        } else {
+          await findProfileStore.findSocial()
+        }
         break
       }
       case 'dating': {
@@ -130,14 +134,22 @@ export function useFindMatchViewModel() {
       }
     }
     lastFetchedScope = currentScope.value
+    lastFetchedViewMode = currentViewMode.value
   }
 
   let lastFetchedScope: ProfileScope | null = null
+  let lastFetchedViewMode: string | null = null
 
   watch(currentScope, (newScope) => {
     if (!newScope) return
     if (newScope === lastFetchedScope) return
     lastFetchedScope = newScope
+    fetchResults()
+  })
+
+  watch(currentViewMode, (newMode) => {
+    if (!isInitialized.value || !currentScope.value) return
+    if (newMode === lastFetchedViewMode) return
     fetchResults()
   })
 

--- a/apps/frontend/src/features/browse/stores/findProfileStore.ts
+++ b/apps/frontend/src/features/browse/stores/findProfileStore.ts
@@ -118,6 +118,24 @@ export const useFindProfileStore = defineStore('findProfile', {
       }
     },
 
+    async findSocialForMap(): Promise<StoreResponse<StoreVoidSuccess | StoreError>> {
+      try {
+        this.isLoading = true
+        this.hasMoreProfiles = false
+
+        const res = await safeApiCall(() => api.get<GetProfilesResponse>('/find/social/map'))
+        const fetched = PublicProfileArraySchema.parse(res.data.profiles)
+        this.profileList = fetched
+
+        return storeSuccess()
+      } catch (error: any) {
+        this.profileList = []
+        return storeError(error, 'Failed to fetch map profiles')
+      } finally {
+        this.isLoading = false
+      }
+    },
+
     async fetchNewSocial(): Promise<StoreProfileListResponse> {
       try {
         const res = await safeApiCall(() => api.get<GetProfilesResponse>('/find/social/new'))


### PR DESCRIPTION
## Summary
- Map view only showed user's own profile with "Anywhere" selected because infinite scroll never triggered (map has no overflow), loading only 10 profiles — most without coordinates
- Adds `GET /find/social/map` endpoint returning only profiles with lat/lon, optional bounding box filtering, 500 result cap
- Extracts shared `buildSocialWhereClause()` in `ProfileMatchService` to avoid duplicating filter logic between grid and map consumers
- Frontend composable dispatches to correct store action based on viewMode, with watcher to re-fetch on viewMode change

## Test plan
- [ ] Verify map view shows all profiles with location when "Anywhere" is selected
- [ ] Verify map view shows correct filtered results when a specific location is selected
- [ ] Verify grid view still works with pagination and infinite scroll
- [ ] Verify switching between grid and map re-fetches with the correct endpoint
- [ ] Backend: 6 new service tests, 4 new route tests
- [ ] Frontend: 3 new composable tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)