### PR TITLE
fix: prevent auth input width shift on validation

### DIFF
--- a/apps/frontend/src/css/theme.scss
+++ b/apps/frontend/src/css/theme.scss
@@ -1,6 +1,8 @@
 @import '../../node_modules/bootstrap/scss/functions';
 @import '../../node_modules/bootstrap/scss/variables';
 
+$enable-validation-icons: false;
+
 // ─── Bootswatch Sandstone warm gray scale ───────────────────────────
 $gray-200: #f8f5f0; // warm off-white
 $gray-300: #dfd7ca; // warm sand border

--- a/apps/frontend/src/features/auth/components/AuthIdComponent.vue
+++ b/apps/frontend/src/features/auth/components/AuthIdComponent.vue
@@ -151,9 +151,4 @@ function handleCaptchaUpdatePayload(payload: string) {
     height: 1.5rem;
   }
 }
-
-input.form-control.is-valid,
-input.form-control.is-invalid {
-  background-image: none !important;
-}
 </style>

--- a/apps/frontend/src/features/auth/components/OtpLoginComponent.vue
+++ b/apps/frontend/src/features/auth/components/OtpLoginComponent.vue
@@ -116,9 +116,4 @@ watch(inputState, (state) => {
   top: 0.75em;
   right: 1em;
 }
-
-input.form-control.is-valid,
-input.form-control.is-invalid {
-  background-image: none !important;
-}
 </style>


### PR DESCRIPTION
## Summary

Closes #661

- Set `$enable-validation-icons: false` in `theme.scss` to prevent Bootstrap from generating extra `padding-right` on validated inputs
- Remove now-redundant scoped CSS in `AuthIdComponent` and `OtpLoginComponent` that was hiding the validation icon background-image

The width shift occurred because Bootstrap's `.is-valid`/`.is-invalid` classes add ~52.5px of padding-right for validation icons. Both auth components already hid the icon image but didn't reset the padding, causing the input's intrinsic width to grow when validation state changed.

## Test plan

- [x] `pnpm --filter frontend test` — 220 tests pass
- [x] `pnpm build` — type-check and build pass
- [ ] Manual: open `/auth`, type a character — input width remains stable
- [ ] Manual: open `/auth/otp`, type a character — input width remains stable

🤖 Generated with [Claude Code](https://claude.com/claude-code)