### PR TITLE
chore: add prisma-zod-generator to prisma dependabot group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,7 +20,7 @@ updates:
         patterns: ["fastify", "fastify-plugin", "@fastify/*"]
 
       prisma:
-        patterns: ["prisma", "@prisma/*", "prisma-*", "zod-prisma-*"]
+        patterns: ["prisma", "@prisma/*", "prisma-*", "prisma-zod-generator", "zod-prisma-*"]
 
       vue-ecosystem:
         patterns: ["vue", "vue-router", "vue-i18n", "@vue/*", "@vueuse/*", "pinia"]
@@ -56,7 +56,7 @@ updates:
         applies-to: version-updates
         dependency-type: development
         update-types: ["minor", "patch"]
-        exclude-patterns: ["zod-prisma-*"]
+        exclude-patterns: ["zod-prisma-*", "prisma-zod-*"]
 
       prod-deps-minor-patch:
         applies-to: version-updates


### PR DESCRIPTION
## Summary

Ensures `prisma-zod-generator` is grouped with other prisma dependencies in dependabot updates, preventing standalone PRs like #651 from being created separately from the prisma group PR (#565).

- Explicitly add `prisma-zod-generator` to the prisma group patterns
- Add `prisma-zod-*` to the `dev-deps-minor-patch` exclude list

**Note:** Dependabot does not support per-group notification suppression — there is no config option to silence notifications for a specific group while keeping updates active.

🤖 Generated with [Claude Code](https://claude.com/claude-code)