### PR TITLE
fix: use i18n key for voice message notification

### DIFF
--- a/apps/backend/src/__tests__/routes/messaging.route.spec.ts
+++ b/apps/backend/src/__tests__/routes/messaging.route.spec.ts
@@ -8,22 +8,85 @@ let fastify: MockFastify
 let reply: MockReply
 let mockMessageService: any
 let mockWebPushService: any
+let mockNotifierService: any
 
 vi.mock('../../services/messaging.service', () => ({
   MessageService: { getInstance: () => mockMessageService },
+  cleanMessageForNotification: vi.fn((msg: string) => msg),
 }))
 
 vi.mock('../../services/webpush.service', () => ({
-  WebPushService: { getInstance: () => mockWebPushService },
+  WebPushService: { getInstance: () => mockWebPushService, isWebPushConfigured: () => false },
+}))
+
+vi.mock('../../services/notifier.service', () => ({
+  notifierService: {
+    notifyProfile: vi.fn(),
+  },
+}))
+
+vi.mock('../../utils/wsUtils', () => ({
+  broadcastToProfile: vi.fn().mockReturnValue(false),
 }))
 
 vi.mock('../../api/mappers/messaging.mappers', () => ({
   mapMessageForMessageList: vi.fn((m: any) => ({ ...m, mapped: true })),
   mapConversationParticipantToSummary: vi.fn(() => ({ id: 'summary', partnerProfile: {} })),
-  mapMessageDTO: vi.fn(() => ({ id: 'dto' })),
+  mapMessageDTO: vi.fn(() => ({
+    id: 'dto',
+    sender: { publicName: 'TestSender' },
+    content: '',
+  })),
+}))
+
+vi.mock('@/lib/appconfig', () => ({
+  appConfig: {
+    FRONTEND_URL: 'http://test',
+    MEDIA_UPLOAD_DIR: '/tmp/test-media',
+    VOICE_MESSAGE_MAX_DURATION: 120,
+  },
+}))
+
+vi.mock('@/lib/media', () => ({
+  MEDIA_SUBDIR: { VOICE: 'voice' },
+}))
+
+vi.mock('@/services/audioTranscoder', () => ({
+  transcodeToMp3: vi.fn(),
+}))
+
+vi.mock('@fastify/multipart', () => ({ default: vi.fn() }))
+
+vi.mock('i18next', () => ({
+  default: {
+    getFixedT: (_lang: string) => (key: string) => {
+      const translations: Record<string, string> = {
+        'notifications.voice_message_sent': 'Sent a voice message',
+      }
+      return translations[key] || key
+    },
+  },
+}))
+
+vi.mock('../../services/interaction.service', () => ({
+  InteractionService: {
+    getInstance: () => ({
+      markMatchAsSeen: vi.fn().mockResolvedValue(undefined),
+    }),
+  },
+}))
+
+vi.mock('fs', () => ({
+  promises: {
+    mkdir: vi.fn().mockResolvedValue(undefined),
+    writeFile: vi.fn().mockResolvedValue(undefined),
+    stat: vi.fn().mockResolvedValue({ size: 1024 }),
+    unlink: vi.fn().mockResolvedValue(undefined),
+  },
 }))
 
 beforeEach(async () => {
+  vi.clearAllMocks()
   fastify = new MockFastify()
   reply = new MockReply()
   mockMessageService = {
@@ -33,8 +96,16 @@ beforeEach(async () => {
     getConversationSummary: vi.fn(),
     initiateConversation: vi.fn(),
     replyInConversation: vi.fn(),
+    sendOrStartConversation: vi.fn(),
   }
   mockWebPushService = { send: vi.fn() }
+  mockNotifierService = (await import('../../services/notifier.service')).notifierService
+  fastify.prisma = {
+    $transaction: vi.fn(async (fn: any) => fn(fastify.prisma)),
+    profile: {
+      findUnique: vi.fn().mockResolvedValue({ user: { language: 'en' } }),
+    },
+  }
   await messageRoutes(fastify as any, {})
 })
 
@@ -112,5 +183,70 @@ describe('POST /conversations/:id/mark-read', () => {
     expect(reply.statusCode).toBe(200)
     expect(reply.payload.success).toBe(true)
     expect(reply.payload.conversation.id).toBe('summary')
+  })
+})
+
+describe('POST /voice', () => {
+  it('uses i18n-translated string for voice message notification', async () => {
+    const handler = fastify.routes['POST /voice']
+
+    // Mock the recipient profile with a specific language
+    fastify.prisma.profile.findUnique.mockResolvedValue({
+      user: { language: 'de' },
+    })
+
+    // Mock conversation and message creation
+    mockMessageService.sendOrStartConversation.mockResolvedValue({
+      convoId: 'conv1',
+      message: { id: 'm1', senderId: 'p1' },
+    })
+    mockMessageService.getConversationSummary.mockResolvedValue({
+      conversation: { status: 'ACTIVE' },
+    })
+
+    // Create an async iterator that yields file and field parts
+    const parts = (async function* () {
+      yield {
+        type: 'file',
+        fieldname: 'voice',
+        filename: 'voice.webm',
+        mimetype: 'audio/webm',
+        toBuffer: async () => Buffer.from('fake-audio'),
+      }
+      yield { type: 'field', fieldname: 'profileId', value: 'ck1234567890abcd12345678' }
+      yield { type: 'field', fieldname: 'content', value: '' }
+      yield { type: 'field', fieldname: 'duration', value: '5' }
+    })()
+
+    await handler(
+      {
+        session: { profileId: 'p1' },
+        parts: () => parts,
+      } as any,
+      reply as any
+    )
+
+    expect(reply.statusCode).toBe(200)
+    expect(mockNotifierService.notifyProfile).toHaveBeenCalledWith(
+      'ck1234567890abcd12345678',
+      'new_message',
+      expect.objectContaining({
+        sender: 'TestSender',
+        message: 'Sent a voice message', // i18n key resolves to this in English (fallback)
+        link: 'http://test/inbox',
+      })
+    )
+
+    // Verify recipient language was looked up
+    expect(fastify.prisma.profile.findUnique).toHaveBeenCalledWith({
+      where: { id: 'ck1234567890abcd12345678' },
+      select: { user: { select: { language: true } } },
+    })
+  })
+
+  it('returns 401 when session missing', async () => {
+    const handler = fastify.routes['POST /voice']
+    await handler({ session: {} } as any, reply as any)
+    expect(reply.statusCode).toBe(401)
   })
 })

--- a/apps/backend/src/api/routes/messaging.route.ts
+++ b/apps/backend/src/api/routes/messaging.route.ts
@@ -24,6 +24,7 @@ import {
 import { InteractionService } from '../../services/interaction.service'
 import { notifierService } from '@/services/notifier.service'
 import { appConfig } from '@/lib/appconfig'
+import i18next from 'i18next'
 import { MEDIA_SUBDIR } from '@/lib/media'
 import path from 'path'
 import { promises as fsPromises } from 'fs'
@@ -359,9 +360,14 @@ const messageRoutes: FastifyPluginAsync = async (fastify) => {
               fastify.log.error(err, 'Web push failed')
             })
           }
+          const recipientProfile = await fastify.prisma.profile.findUnique({
+            where: { id: payload.data.profileId },
+            select: { user: { select: { language: true } } },
+          })
+          const t = i18next.getFixedT(recipientProfile?.user?.language || 'en')
           await notifierService.notifyProfile(payload.data.profileId, 'new_message', {
             sender: messageDTO.sender.publicName,
-            message: 'Sent a voice message',
+            message: t('notifications.voice_message_sent'),
             link: `${appConfig.FRONTEND_URL}/inbox`,
           })
         }

--- a/packages/shared/i18n/api/en.json
+++ b/packages/shared/i18n/api/en.json
@@ -2,6 +2,9 @@
   "messages": {
     "welcome_message": "Welcome to {{siteName}}!\nI am Mookie, your host.\nThis is a place for us to connect, meet new people, and find like-minded souls. I hope you enjoy your stay here.\nHappy connecting!\n- Mookie"
   },
+  "notifications": {
+    "voice_message_sent": "Sent a voice message"
+  },
   "emails": {
     "loginLink": {
       "subject": "[{{siteName}}] Your login link",
@@ -11,15 +14,15 @@
       "subject": "[{{siteName}}] Welcome!",
       "html": "<p>Hey there, welcome aboard!</p><a href=\"{{link}}\">Go connect with people</a></p>"
     },
-    "new_message":{
+    "new_message": {
       "subject": "[{{siteName}}] You have a new message",
       "html": "<p>Hey there,</p><p>You have a new message from <strong>{{sender}}</strong>:</p><blockquote>{{message}}</blockquote><p><a href=\"{{link}}\">Click here to read it</a></p>"
     },
-    "new_like":{
+    "new_like": {
       "subject": "[{{siteName}}] You have a new like",
       "html": "<p>Hey there,</p>Someone sent you a ❤️<p><p><a href=\"{{link}}\">Find out who</a></p>"
     },
-    "new_match":{
+    "new_match": {
       "subject": "[{{siteName}}] You have a new match!",
       "html": "<p>Hey there,</p><p>You matched with {{name}}<p><a href=\"{{link}}\">Click here to read it</a></p>"
     }

--- a/packages/shared/i18n/api/hu.json
+++ b/packages/shared/i18n/api/hu.json
@@ -1,4 +1,7 @@
 {
+  "notifications": {
+    "voice_message_sent": "Hangüzenetet küldött"
+  },
   "emails": {
     "loginLink": {
       "subject": "{{siteName}} belépő link",


### PR DESCRIPTION
## Summary
- Replace hardcoded English string `'Sent a voice message'` in voice message notifications with an i18n-translated key (`notifications.voice_message_sent`)
- Look up recipient's language at the call site so the notification text renders in their preferred language
- Add the new key to both `en.json` and `hu.json` API translation files

## Test plan
- [x] Added test verifying the voice message notification uses the i18n key and looks up recipient language
- [x] All 282 tests pass (`pnpm test`)
- [x] `pnpm run i18n:check:api` passes with no missing keys
- [x] No remaining hardcoded `'Sent a voice message'` references in production code

🤖 Generated with [Claude Code](https://claude.com/claude-code)