### PR TITLE
chore: include major version bumps in dependabot groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,56 +12,68 @@ updates:
       # ── Vendor families (grouped including majors) ──────────
       fortawesome:
         patterns: ["@fortawesome/*"]
+        update-types: ["major", "minor", "patch"]
 
       sentry:
         patterns: ["@sentry/*"]
+        update-types: ["major", "minor", "patch"]
 
       fastify:
         patterns: ["fastify", "fastify-plugin", "@fastify/*"]
+        update-types: ["major", "minor", "patch"]
 
       prisma:
         patterns: ["prisma", "@prisma/*", "prisma-*", "prisma-zod-generator", "zod-prisma-*"]
+        update-types: ["major", "minor", "patch"]
 
       vue-ecosystem:
         patterns: ["vue", "vue-router", "vue-i18n", "@vue/*", "@vueuse/*", "pinia"]
+        update-types: ["major", "minor", "patch"]
 
       bootstrap:
         patterns: ["bootstrap", "bootstrap-vue-next", "@popperjs/*"]
+        update-types: ["major", "minor", "patch"]
 
       tensorflow:
         patterns: ["@tensorflow/*", "@tensorflow-models/*"]
+        update-types: ["major", "minor", "patch"]
 
       fontsource:
         patterns: ["@fontsource/*"]
+        update-types: ["major", "minor", "patch"]
 
       # ── Tooling families (grouped including majors) ─────────
       eslint:
         patterns: ["eslint", "eslint-*", "@eslint/*", "@typescript-eslint/*", "@vue/eslint-*"]
+        update-types: ["major", "minor", "patch"]
 
       vite:
         patterns: ["vite", "@vitejs/*", "vite-*"]
+        update-types: ["major", "minor", "patch"]
 
       testing:
         patterns: ["vitest", "@vitest/*", "@vue/test-utils", "@playwright/*", "happy-dom", "jsdom"]
+        update-types: ["major", "minor", "patch"]
 
       types:
         patterns: ["@types/*"]
-        update-types: ["minor", "patch"]
+        update-types: ["major", "minor", "patch"]
 
       i18n:
         patterns: ["i18next", "i18next-*", "vue-i18n-*", "i18n-*", "@cospired/i18n-*", "@intlify/*"]
+        update-types: ["major", "minor", "patch"]
 
-      # ── Catch-all: remaining minor+patch ────────────────────
-      dev-deps-minor-patch:
+      # ── Catch-all: remaining deps (including majors) ───────
+      dev-deps:
         applies-to: version-updates
         dependency-type: development
-        update-types: ["minor", "patch"]
+        update-types: ["major", "minor", "patch"]
         exclude-patterns: ["zod-prisma-*", "prisma-zod-*"]
 
-      prod-deps-minor-patch:
+      prod-deps:
         applies-to: version-updates
         dependency-type: production
-        update-types: ["minor", "patch"]
+        update-types: ["major", "minor", "patch"]
 
   - package-ecosystem: github-actions
     directory: "/"


### PR DESCRIPTION
## Summary
- Add explicit `update-types: ["major", "minor", "patch"]` to **all** dependabot groups so major version bumps are grouped with their families instead of creating individual PRs
- Rename catch-all groups (`dev-deps-minor-patch` → `dev-deps`, `prod-deps-minor-patch` → `prod-deps`) since they now include majors too

## Problem
Major version updates were escaping their groups and creating individual PRs. For example:
- `vite-plugin-vue-devtools` 7→8 matched the `vite` group pattern but got its own PR (#671)
- `@sentry/vue` 9→10 matched `sentry` but got its own PR (#673)
- `@intlify/unplugin-vue-i18n` 6→11 matched `i18n` but got its own PR (#669)
- Uncovered packages like `zod`, `@faker-js/faker`, `rollup-plugin-visualizer` also got individual PRs because the catch-all groups only covered minor+patch

This created 7 individual PRs on top of 3 grouped ones — 10 total when it could be ~5.

## Expected result
Next Monday's dependabot run should produce fewer, grouped PRs:
- Named groups (vite, sentry, i18n, types, etc.) will capture their matching majors
- Catch-all groups will capture any remaining majors from uncovered packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)