### PR TITLE
fix: strip admin auth header on public proxy

### DIFF
--- a/apps/ingress/nginx.conf.template
+++ b/apps/ingress/nginx.conf.template
@@ -54,6 +54,12 @@ http {
     }
   }
 
+  # --- Reject unknown Host headers ---
+  server {
+    listen 443 ssl default_server;
+    ssl_reject_handshake on;
+  }
+
   # --- HTTPS Server ---
   server {
     listen 443 ssl;
@@ -82,6 +88,7 @@ http {
       proxy_set_header Host $host;
       proxy_set_header X-Real-IP $remote_addr;
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header X-Admin-Authenticated "";
     }
 
     location /api/messages/voice {
@@ -92,8 +99,9 @@ http {
       proxy_set_header Host $host;
       proxy_set_header X-Real-IP $remote_addr;
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header X-Admin-Authenticated "";
     }
-  
+
     location /api/ {
       proxy_pass http://backend;
       proxy_http_version 1.1;
@@ -102,6 +110,7 @@ http {
       proxy_set_header Host $host;
       proxy_set_header X-Real-IP $remote_addr;
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header X-Admin-Authenticated "";
 
       add_header 'Access-Control-Allow-Origin' '*' always;
       add_header 'Access-Control-Allow-Methods' 'GET, POST, PUT, DELETE, OPTIONS' always;


### PR DESCRIPTION
## Summary
- Strip `X-Admin-Authenticated` header on all public-domain backend proxy locations, preventing client-supplied headers from reaching the backend even if the `/api/admin/` block is bypassed or removed
- Add a default `ssl_reject_handshake` server block to reject TLS connections with unrecognised `Host` headers

## Context
Security review of #656 identified that the public-domain proxy blocks forward client-supplied headers to the backend without stripping `X-Admin-Authenticated`. While `/api/admin/` returns 404 on the public domain, nginx path matching bypasses are a known attack vector. Clearing the header at the proxy level makes the defense robust regardless of location matching.

## Test plan
- [ ] Verify admin panel still works via mTLS domain
- [ ] Verify `curl -H 'X-Admin-Authenticated: true' https://DOMAIN/api/admin/stats` returns 404
- [ ] Verify requests to unknown Host headers are rejected at TLS level

🤖 Generated with [Claude Code](https://claude.com/claude-code)