### PR TITLE
feat: serve admin SPA in its own container

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -88,6 +88,20 @@ jobs:
             ghcr.io/${{ github.repository }}-frontend:${{ steps.git-info.outputs.version }}
             ghcr.io/${{ github.repository }}-frontend:${{ steps.git-info.outputs.sha }}
 
+      # Build and push admin image
+      - name: Build and push admin image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: apps/admin/Dockerfile
+          push: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          tags: |
+            ghcr.io/${{ github.repository }}-admin:${{ steps.git-info.outputs.tag-suffix }}
+            ghcr.io/${{ github.repository }}-admin:${{ steps.git-info.outputs.version }}
+            ghcr.io/${{ github.repository }}-admin:${{ steps.git-info.outputs.sha }}
+
       # Build and push ingress image
       - name: Build and push ingress image
         uses: docker/build-push-action@v6

--- a/apps/admin/Dockerfile
+++ b/apps/admin/Dockerfile
@@ -1,0 +1,31 @@
+FROM node:22-bookworm AS builder
+WORKDIR /app
+
+ARG API_BASE_URL="/api"
+
+RUN apt-get update && apt-get -y install build-essential python3 && \
+  ln -sf /usr/bin/python3 /usr/bin/python
+
+# Copy root monorepo files
+COPY pnpm-lock.yaml pnpm-workspace.yaml package.json ./
+COPY apps/admin/package.json ./apps/admin/package.json
+RUN corepack enable && pnpm install --frozen-lockfile --filter ./apps/admin...
+
+# Copy admin source and shared packages
+COPY apps/admin ./apps/admin
+COPY packages ./packages
+WORKDIR /app/apps/admin
+
+RUN printf '%s\n' \
+  "API_BASE_URL=${API_BASE_URL}" \
+  > /app/.env
+
+RUN pnpm run build
+
+FROM nginx:bookworm
+LABEL org.opencontainers.image.source=https://github.com/opencupid/opencupid
+COPY apps/admin/nginx.conf /etc/nginx/conf.d/default.conf
+COPY --from=builder /app/apps/admin/dist /var/www
+
+EXPOSE 3002
+CMD ["nginx", "-g", "daemon off;"]

--- a/apps/admin/nginx.conf
+++ b/apps/admin/nginx.conf
@@ -1,0 +1,20 @@
+server {
+  listen 3002;
+  server_name localhost;
+
+  root /var/www;
+  index index.html;
+
+  location = /index.html {
+    add_header Cache-Control "no-cache";
+  }
+
+  location /assets/ {
+    add_header Cache-Control "public, max-age=43200";
+    try_files $uri =404;
+  }
+
+  location / {
+    try_files $uri $uri/ /index.html;
+  }
+}

--- a/apps/ingress/nginx.conf.template
+++ b/apps/ingress/nginx.conf.template
@@ -35,6 +35,10 @@ http {
     server jitsi-web:80;
   }
 
+  upstream admin {
+    server admin:3002;
+  }
+
   upstream listmonk {
     server listmonk:9000;
   }
@@ -239,8 +243,11 @@ http {
     }
 
     location / {
-      root /var/www/admin;
-      try_files $uri $uri/ /index.html;
+      proxy_pass http://admin;
+      proxy_http_version 1.1;
+      proxy_set_header Host $host;
+      proxy_set_header X-Real-IP $remote_addr;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     }
   }
 }

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -71,6 +71,15 @@ services:
       - '${MEDIA_UPLOAD_DIR}:${MEDIA_UPLOAD_DIR}'
       - '${PWD}/secrets:/secrets'
 
+  admin:
+    image: ghcr.io/opencupid/opencupid-admin
+    build:
+      context: .
+      dockerfile: apps/admin/Dockerfile
+    restart: always
+    depends_on:
+      - backend
+
   frontend:
     image: ghcr.io/opencupid/opencupid-frontend
     build:
@@ -97,6 +106,7 @@ services:
       context: apps/ingress
     restart: always
     depends_on:
+      - admin
       - frontend
       - backend
       - jitsi-web
@@ -110,7 +120,6 @@ services:
       - ${CERTBOT_ETCDIR}:/etc/letsencrypt
       - certbot-webroot:/var/www/html
       - ${ADMIN_CA_CERT_FILE}:/etc/nginx/client-ca.crt:ro
-      - ./apps/admin/dist:/var/www/admin:ro
 
   certbot:
     image: certbot/certbot


### PR DESCRIPTION
## Summary

- Add `apps/admin/Dockerfile` (multi-stage build mirroring the frontend pattern: Node 22 builder → nginx on port 3002)
- Add `apps/admin/nginx.conf` (SPA fallback, cache headers for assets, no-cache for index.html)
- Replace static file serving in ingress admin server block with `proxy_pass http://admin`
- Add `admin` service to `docker-compose.production.yml` and remove the `dist/` volume mount from ingress
- Add admin image build step to `.github/workflows/docker.yml`

## Test plan

- [ ] `pnpm test` passes (all 223 tests green)
- [ ] `pnpm build` succeeds (type-check passes)
- [ ] `docker compose -f docker-compose.production.yml build admin` succeeds
- [ ] Deploy to production: build & push via `gh workflow run docker.yml`, restart admin + ingress, verify `https://admin.gaians.net/` loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)