### PR TITLE
fix: remove wildcard CORS headers from nginx ingress

### DIFF
--- a/apps/backend/src/lib/appconfig.ts
+++ b/apps/backend/src/lib/appconfig.ts
@@ -9,7 +9,7 @@ export const configSchema = z.object({
   API_PORT: z.coerce.number().default(3000),
   FRONTEND_PORT: z.coerce.number().default(5173),
 
-  FRONTEND_URL: z.string(),
+  FRONTEND_URL: z.string().url(),
   API_BASE_URL: z.string(),
   WS_BASE_URL: z.string(),
 

--- a/apps/backend/src/main.ts
+++ b/apps/backend/src/main.ts
@@ -31,7 +31,7 @@ async function main() {
 
   // Register CORS plugin
   app.register(cors, {
-    origin: appConfig.NODE_ENV === 'production' ? appConfig.FRONTEND_URL : '*',
+    origin: appConfig.NODE_ENV === 'production' ? appConfig.FRONTEND_URL : true,
     allowedHeaders: ['Content-Type', 'Authorization'],
     credentials: true,
     methods: ['GET', 'PUT', 'POST', 'DELETE', 'PATCH'],

--- a/apps/ingress/nginx.conf.template
+++ b/apps/ingress/nginx.conf.template
@@ -115,13 +115,6 @@ http {
       proxy_set_header X-Real-IP $remote_addr;
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header X-Admin-Authenticated "";
-
-      add_header 'Access-Control-Allow-Origin' '*' always;
-      add_header 'Access-Control-Allow-Methods' 'GET, POST, PUT, DELETE, OPTIONS' always;
-      add_header 'Access-Control-Allow-Headers' 'Origin, Content-Type, Accept, Authorization' always;
-      if ($request_method = OPTIONS) {
-        return 204;
-      }
     }
 
     location /ws/ {
@@ -136,7 +129,6 @@ http {
       proxy_read_timeout 3600;
       proxy_send_timeout 3600;
 
-      add_header 'Access-Control-Allow-Origin' '*' always;
     }
 
     location /user-content/ {


### PR DESCRIPTION
## Summary
- Remove all `Access-Control-*` headers and OPTIONS shortcircuit from nginx ingress — CORS is now handled exclusively by `@fastify/cors`
- Change non-production CORS origin from `'*'` to `true` (spec-compliant with `credentials: true`)
- Add `.url()` validation to `FRONTEND_URL` in appconfig schema

## Test plan
- [x] `pnpm test` passes (311 backend tests, frontend/shared cached)
- [ ] Verify in staging that preflight OPTIONS requests are handled correctly by Fastify
- [ ] Confirm no duplicate `Access-Control-Allow-Origin` headers in production responses

🤖 Generated with [Claude Code](https://claude.com/claude-code)