### PR TITLE
chore: bump version to 0.11.0

### DIFF
--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -71,15 +71,6 @@ services:
       - '${MEDIA_UPLOAD_DIR}:${MEDIA_UPLOAD_DIR}'
       - '${PWD}/secrets:/secrets'
 
-  admin:
-    image: ghcr.io/opencupid/opencupid-admin
-    build:
-      context: .
-      dockerfile: apps/admin/Dockerfile
-    restart: always
-    depends_on:
-      - backend
-
   frontend:
     image: ${DOCKER_IMAGE_PREFIX:-ghcr.io/opencupid/opencupid}-frontend:${DOCKER_IMAGE_TAG:-latest}
     build:
@@ -118,7 +109,6 @@ services:
       - admin
       - frontend
       - backend
-      - admin
       - jitsi-web
     env_file:
       - .env

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencupid",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "private": true,
   "workspaces": [
     "apps/*",


### PR DESCRIPTION
## Summary
- Bump package.json version to 0.11.0 ahead of release
- Fix duplicate `admin` service definition in docker-compose.production.yml (leftover from merge of #700 and #703)
- Remove duplicate `admin` entry in ingress `depends_on`

🤖 Generated with [Claude Code](https://claude.com/claude-code)