### PR TITLE
fix: add multi-arch Docker builds for ARM64 support

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -36,6 +36,9 @@ jobs:
             echo "${var}=${!var}" >> "$GITHUB_OUTPUT"
           done
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -97,6 +100,7 @@ jobs:
         with:
           context: .
           file: apps/backend/Dockerfile
+          platforms: linux/amd64,linux/arm64
           push: true
           cache-from: type=gha
           cache-to: type=gha,mode=max
@@ -108,6 +112,7 @@ jobs:
         with:
           context: .
           file: apps/frontend/Dockerfile
+          platforms: linux/amd64,linux/arm64
           push: true
           cache-from: type=gha
           cache-to: type=gha,mode=max
@@ -126,6 +131,7 @@ jobs:
         with:
           context: .
           file: apps/admin/Dockerfile
+          platforms: linux/amd64,linux/arm64
           push: true
           cache-from: type=gha
           cache-to: type=gha,mode=max
@@ -137,6 +143,7 @@ jobs:
         with:
           context: apps/ingress
           file: apps/ingress/Dockerfile
+          platforms: linux/amd64,linux/arm64
           push: true
           cache-from: type=gha
           cache-to: type=gha,mode=max


### PR DESCRIPTION
## Summary
- Add `docker/setup-qemu-action@v3` for cross-platform emulation on the amd64 GitHub Actions runner
- Add `platforms: linux/amd64,linux/arm64` to all 4 `build-push-action` steps (backend, frontend, admin, ingress)

Production host (gaians.net) runs ARM64 (`aarch64`). Without multi-arch builds, Docker images only contain amd64 binaries, requiring emulation overhead on the production host.

## Test plan
- [ ] CI passes on this branch
- [ ] After merge, trigger Docker build workflow and verify all 4 images push successfully with multi-arch manifests
- [ ] Pull images on ARM64 host and verify native execution

🤖 Generated with [Claude Code](https://claude.com/claude-code)