### PR TITLE
fix: add latest tag to workflow_dispatch Docker builds

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -68,12 +68,13 @@ jobs:
             done
           else
             TAG="${{ github.event.inputs.tag || 'manual' }}"
-            # For manual: tag suffix + version + sha
+            # For manual: tag suffix + version + sha + latest
             for SVC in backend frontend admin ingress; do
               {
                 echo "${PREFIX}-${SVC}:${TAG}"
                 echo "${PREFIX}-${SVC}:${VERSION}"
                 echo "${PREFIX}-${SVC}:${SHA}"
+                echo "${PREFIX}-${SVC}:latest"
               } >> "tags-${SVC}.txt"
             done
           fi


### PR DESCRIPTION
## Summary
- The `workflow_dispatch` path in the Docker build workflow was missing `:latest` tags — only the `release` path included them
- This caused production (configured with `DOCKER_IMAGE_TAG=latest`) to fail pulling images after manual `workflow_dispatch` builds
- Adds `echo "${PREFIX}-${SVC}:latest"` to the workflow_dispatch tag list, matching the release path behavior

## Test plan
- [ ] Merge PR, trigger a `workflow_dispatch` build
- [ ] Verify `:latest` manifests exist with both amd64 and arm64 via `docker manifest inspect ghcr.io/opencupid/opencupid-backend:latest`
- [ ] On production: `docker compose -f docker-compose.production.yml pull` should work with default `DOCKER_IMAGE_TAG=latest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)