### PR TITLE
chore: suppress i18next Locize ad

### DIFF
--- a/apps/backend/src/lib/i18n.ts
+++ b/apps/backend/src/lib/i18n.ts
@@ -32,6 +32,7 @@ i18next.use(FsBackend).init({
   fallbackLng: 'en',
   preload: Object.keys(labels),
   initImmediate: false,
+  showSupportNotice: false,
   backend: {
     loadPath: translationsPath,
   },


### PR DESCRIPTION
## Summary
- Add `showSupportNotice: false` to i18next init options to suppress the Locize promotional message logged on every backend start

## Test plan
- [x] Backend tests pass
- [x] Verified no console output from i18next init

🤖 Generated with [Claude Code](https://claude.com/claude-code)