### PR TITLE
chore: suppress TensorFlow.js log spam

### DIFF
--- a/apps/backend/src/services/imageprocessor.ts
+++ b/apps/backend/src/services/imageprocessor.ts
@@ -2,6 +2,8 @@ import sharp from 'sharp'
 import { encode as encodeBlurhashRaw } from 'blurhash'
 
 import * as tf from '@tensorflow/tfjs'
+// Suppress "install tfjs-node for speed" console warning — we intentionally use the CPU backend
+tf.env().set('IS_NODE', false)
 import '@tensorflow/tfjs-backend-cpu'
 import * as blazeface from '@tensorflow-models/blazeface'
 import smartcrop from 'smartcrop-sharp'


### PR DESCRIPTION
## Summary
- Suppress the "install tfjs-node for speed" console warning by setting `IS_NODE` to `false` before the CPU backend import
- We intentionally use the CPU backend; the warning is noise in both dev and test output

## Test plan
- [x] All 331 backend tests pass
- [x] Verified no TF warning in test output

🤖 Generated with [Claude Code](https://claude.com/claude-code)