### PR TITLE
test: add viewerProfile inject to ProfileCardComponent tests

### DIFF
--- a/apps/frontend/src/features/browse/components/__tests__/ProfileCardComponent.spec.ts
+++ b/apps/frontend/src/features/browse/components/__tests__/ProfileCardComponent.spec.ts
@@ -1,4 +1,5 @@
 import { mount } from '@vue/test-utils'
+import { ref } from 'vue'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
 vi.mock('@/features/images/components/ProfileImage.vue', () => ({
@@ -19,7 +20,11 @@ vi.mock('@/features/shared/profiledisplay/TagList.vue', () => ({
   default: { template: '<div />', props: ['tags'] },
 }))
 vi.mock('@/features/shared/profiledisplay/LocationLabel.vue', () => ({
-  default: { template: '<div />' },
+  default: {
+    name: 'LocationLabel',
+    template: '<div class="location-label-stub" />',
+    props: ['viewerLocation', 'location', 'showCountryLabel', 'showCity', 'showOnlyForeignCountry'],
+  },
 }))
 
 import ProfileCardComponent from '../ProfileCardComponent.vue'
@@ -30,11 +35,11 @@ const getLoadedUrls = (): Set<string> => {
   return (ProfileCardComponent as any).__test_loadedUrls
 }
 
-const makeProfile = (blurhash: string | null = null) => ({
+const makeProfile = (blurhash: string | null = null, location: any = null) => ({
   id: '1',
   publicName: 'Test User',
   tags: [],
-  location: null,
+  location,
   profileImages: [
     {
       position: 0,
@@ -44,9 +49,25 @@ const makeProfile = (blurhash: string | null = null) => ({
   ],
 })
 
-const mountCard = (blurhash: string | null = null) =>
+const makeViewerProfile = () => ({
+  id: 'viewer-1',
+  location: { country: 'HU', cityName: 'Budapest', lat: 47.5, lon: 19.04 },
+  tags: [],
+  profileImages: [],
+})
+
+const mountCard = (
+  blurhash: string | null = null,
+  opts?: { showLocation?: boolean; viewerProfile?: any; profileLocation?: any }
+) =>
   mount(ProfileCardComponent, {
-    props: { profile: makeProfile(blurhash) as any },
+    props: {
+      profile: makeProfile(blurhash, opts?.profileLocation) as any,
+      showLocation: opts?.showLocation,
+    },
+    global: opts?.viewerProfile
+      ? { provide: { viewerProfile: ref(opts.viewerProfile) } }
+      : undefined,
   })
 
 describe('ProfileCardComponent', () => {
@@ -101,5 +122,32 @@ describe('ProfileCardComponent', () => {
     const wrapper = mountCard()
     await wrapper.find('.profile-card').trigger('click')
     expect(wrapper.emitted('click')![0]).toEqual(['1'])
+  })
+
+  describe('with viewerProfile provided', () => {
+    it('renders without warnings when viewerProfile is injected', () => {
+      const wrapper = mountCard(null, { viewerProfile: makeViewerProfile() })
+      expect(wrapper.find('.profile-card').exists()).toBe(true)
+    })
+
+    it('shows LocationLabel when showLocation is true', () => {
+      const profileLocation = { country: 'DE', cityName: 'Berlin', lat: 52.52, lon: 13.4 }
+      const wrapper = mountCard(null, {
+        showLocation: true,
+        viewerProfile: makeViewerProfile(),
+        profileLocation,
+      })
+      const locationLabel = wrapper.findComponent({ name: 'LocationLabel' })
+      expect(locationLabel.exists()).toBe(true)
+      expect(locationLabel.props('viewerLocation')).toEqual(makeViewerProfile().location)
+    })
+
+    it('hides LocationLabel when showLocation is false', () => {
+      const wrapper = mountCard(null, {
+        showLocation: false,
+        viewerProfile: makeViewerProfile(),
+      })
+      expect(wrapper.find('.location').exists()).toBe(false)
+    })
   })
 })


### PR DESCRIPTION
## Summary
- Add `viewerProfile` injection via `global.provide` to new tests covering the provide/inject code path
- Add 3 new tests: injection rendering, LocationLabel with `showLocation: true`, and hidden LocationLabel with `showLocation: false`
- Existing tests retained without injection to verify the component renders gracefully when no provider exists
- LocationLabel mock updated with props to enable assertion on `viewerLocation` prop pass-through

Closes #717

## Test plan
- [x] All 253 tests pass (`pnpm test`)
- [x] New tests validate the `viewerProfile` injection path
- [x] Existing tests confirm component works without provider (Vue warn is expected and harmless)

🤖 Generated with [Claude Code](https://claude.com/claude-code)