### PR TITLE
fix: run sentry-sourcemaps after docker build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -147,6 +147,7 @@ jobs:
           tags: ${{ steps.tags.outputs.ingress }}
 
   sentry-sourcemaps:
+    needs: docker
     runs-on: ubuntu-latest
     continue-on-error: true
 


### PR DESCRIPTION
## Summary
- Add `needs: docker` to the `sentry-sourcemaps` job so sourcemaps are only uploaded after Docker images are successfully built and pushed
- Prevents uploading sourcemaps for a release whose images failed to build

## Test plan
- [x] Validated workflow YAML syntax
- [ ] Verify job ordering in next release run

🤖 Generated with [Claude Code](https://claude.com/claude-code)