### PR TITLE
feat: disable grid view in SocialMatch

### DIFF
--- a/apps/frontend/src/features/browse/composables/useSocialMatchViewModel.ts
+++ b/apps/frontend/src/features/browse/composables/useSocialMatchViewModel.ts
@@ -39,7 +39,7 @@ export function useSocialMatchViewModel() {
     typeof route.query.viewMode === 'string' &&
     Object.values(ViewMode).includes(route.query.viewMode as ViewMode)
       ? route.query.viewMode
-      : 'grid'
+      : 'map'
   )
 
   function isValidViewMode(mode: string): mode is ViewMode {

--- a/apps/frontend/src/features/browse/views/SocialMatch.vue
+++ b/apps/frontend/src/features/browse/views/SocialMatch.vue
@@ -94,10 +94,10 @@ const getProfileImageUrl = (profile: PublicProfile) => {
         />
       </div>
 
-      <ViewModeToggler
+      <!-- <ViewModeToggler
         v-model="viewModeModel"
         @click.stop
-      />
+      /> -->
     </template>
 
     <template #results="{ onProfileSelect }">


### PR DESCRIPTION
## Summary
- Hide the ViewModeToggler in SocialMatch
- Default view mode to map instead of grid

Closes #768

## Test plan
- [ ] Navigate to `/browse` — should show map view by default
- [ ] No view mode toggle visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)