### PR TITLE
fix: remove SW fetch handler breaking Jitsi script load

### DIFF
--- a/apps/frontend/public/sw.js
+++ b/apps/frontend/public/sw.js
@@ -28,6 +28,3 @@ self.addEventListener('notificationclick', (event) => {
   event.waitUntil(self.clients.openWindow(absoluteUrl))
 })
 
-self.addEventListener('fetch', (event) => {
-  event.respondWith(fetch(event.request))
-})


### PR DESCRIPTION
## Summary
- Remove unnecessary `fetch` event listener from push-only service worker
- The handler was intercepting cross-origin requests (including `meet.gaians.net/external_api.js`) and rejecting when the fetch failed, breaking Jitsi video calls

## Test plan
- [ ] Deploy to prod, open a video call — Jitsi `external_api.js` should load without SW errors
- [ ] Push notifications still work (SW only handles `push` and `notificationclick` events)
- [ ] No more `ServiceWorker passed a promise to FetchEvent.respondWith() that rejected` errors in console

🤖 Generated with [Claude Code](https://claude.com/claude-code)