### PR TITLE
fix: navigate DatingMatch profiles within /matches scope

### DIFF
--- a/apps/frontend/src/features/browse/composables/__tests__/useDatingMatchViewModel.spec.ts
+++ b/apps/frontend/src/features/browse/composables/__tests__/useDatingMatchViewModel.spec.ts
@@ -106,7 +106,7 @@ describe('useDatingMatchViewModel', () => {
     openProfile('profile-42')
     expect(selectedProfileId.value).toBe('profile-42')
     expect(routerReplace).toHaveBeenCalledWith({
-      name: 'PublicProfile',
+      name: 'DatingMatch',
       params: { profileId: 'profile-42' },
     })
   })
@@ -124,7 +124,7 @@ describe('useDatingMatchViewModel', () => {
 
   it('closeProfile navigates to DatingMatch when previousUrl is a profile URL', () => {
     routeRef.value.params = { profileId: 'abc-123' }
-    mockGetPreviousUrl.mockReturnValue('/profile/other-id')
+    mockGetPreviousUrl.mockReturnValue('/matches/other-id')
 
     const { closeProfile } = useDatingMatchViewModel()
     closeProfile()

--- a/apps/frontend/src/features/browse/composables/useDatingMatchViewModel.ts
+++ b/apps/frontend/src/features/browse/composables/useDatingMatchViewModel.ts
@@ -60,13 +60,13 @@ export function useDatingMatchViewModel() {
 
   function openProfile(profileId: string): void {
     selectedProfileId.value = profileId
-    router.replace({ name: 'PublicProfile', params: { profileId } })
+    router.replace({ name: 'DatingMatch', params: { profileId } })
   }
 
   function closeProfile(): void {
     selectedProfileId.value = null
     const returnUrl = getPreviousUrl()
-    if (returnUrl.startsWith('/profile/')) {
+    if (returnUrl.startsWith('/matches/')) {
       router.replace({ name: 'DatingMatch' })
     } else {
       router.replace(returnUrl)


### PR DESCRIPTION
## Summary
- **`openProfile`** now navigates to route `DatingMatch` instead of `PublicProfile`, keeping profile views within the `/matches` URL scope
- **`closeProfile`** guard updated to check `/matches/` prefix instead of `/profile/`, matching the new navigation pattern
- Tests updated to reflect both changes

Fixes #765

## Test plan
- [x] `pnpm --filter frontend exec vitest run -t "useDatingMatchViewModel"` — 8/8 passing
- [x] `pnpm test` — full suite green (269 frontend + 355 backend)
- [ ] Manual: open DatingMatch `/matches`, click a profile — URL should become `/matches/<profileId>` (not `/profile/<profileId>`)
- [ ] Manual: close the profile — should return to `/matches`

🤖 Generated with [Claude Code](https://claude.com/claude-code)