### PR TITLE
fix: allow blob: in CSP connect-src for Sentry transport

### DIFF
--- a/apps/ingress/nginx.conf.template
+++ b/apps/ingress/nginx.conf.template
@@ -115,7 +115,7 @@ http {
         "worker-src 'self' blob:"
         .. "; media-src 'self'"
         .. "; frame-src https://*.${DOMAIN}"
-        .. "; connect-src 'self' wss://${DOMAIN} https://*.${DOMAIN}"
+        .. "; connect-src 'self' blob: wss://${DOMAIN} https://*.${DOMAIN}"
       )
     }
 


### PR DESCRIPTION
## Summary
- Add `blob:` to the `connect-src` CSP directive in the nginx config
- Sentry SDK uses `blob:` URLs as a fetch transport for sending error reports, which was being blocked by the current policy

## Test plan
- [ ] Deploy and verify Sentry errors are no longer blocked by CSP
- [ ] Check browser console for absence of `connect-src` CSP violations on `blob:` URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)