### PR TITLE
feat: modular release pipeline with auto-deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,99 @@
+name: Deploy
+
+on:
+  workflow_run:
+    workflows: ['Docker Build']
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to deploy (e.g. v0.13.6)'
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    if: >-
+      (github.event_name == 'workflow_dispatch') ||
+      (github.event.workflow_run.conclusion == 'success')
+
+    steps:
+      - name: Check deploy secrets
+        id: secrets-check
+        run: |
+          if [[ -z "${{ secrets.DEPLOY_SSH_KEY }}" ]]; then
+            echo "::notice::DEPLOY_SSH_KEY not configured — skipping deployment."
+            echo "has_secrets=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_secrets=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Determine release tag
+        if: steps.secrets-check.outputs.has_secrets == 'true'
+        id: meta
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            TAG="${{ github.event.inputs.tag }}"
+            echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+            echo "should_deploy=true" >> "$GITHUB_OUTPUT"
+          else
+            TAG="${{ github.event.workflow_run.head_branch }}"
+            if [[ ! "$TAG" =~ ^v[0-9] ]]; then
+              echo "::warning::head_branch '$TAG' is not a release tag. Skipping."
+              echo "should_deploy=false" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+            echo "should_deploy=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Semver gate
+        if: >-
+          steps.secrets-check.outputs.has_secrets == 'true' &&
+          steps.meta.outputs.should_deploy == 'true' &&
+          github.event_name != 'workflow_dispatch'
+        id: semver
+        run: |
+          TAG="${{ steps.meta.outputs.tag }}"
+          CURRENT_MAJOR=$(echo "$TAG" | sed 's/^v//' | cut -d. -f1)
+
+          # Fetch previous release tag
+          PREV_TAG=$(gh release list --limit 2 --json tagName --jq '.[1].tagName // empty')
+          if [[ -z "$PREV_TAG" ]]; then
+            echo "No previous release found — proceeding with deploy."
+            echo "should_deploy=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          PREV_MAJOR=$(echo "$PREV_TAG" | sed 's/^v//' | cut -d. -f1)
+
+          if [[ "$CURRENT_MAJOR" != "$PREV_MAJOR" ]]; then
+            echo "::warning::Major version changed ($PREV_TAG → $TAG). Skipping auto-deploy — deploy manually."
+            echo "should_deploy=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "Version check passed ($PREV_TAG → $TAG). Proceeding with deploy."
+            echo "should_deploy=true" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Deploy via SSH
+        if: >-
+          steps.secrets-check.outputs.has_secrets == 'true' &&
+          steps.meta.outputs.should_deploy == 'true' &&
+          (github.event_name == 'workflow_dispatch' || steps.semver.outputs.should_deploy == 'true')
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.DEPLOY_HOST }}
+          username: ${{ secrets.DEPLOY_USER }}
+          key: ${{ secrets.DEPLOY_SSH_KEY }}
+          script: |
+            cd ~/opencupid
+            git fetch --tags
+            git checkout ${{ steps.meta.outputs.tag }}
+            docker compose -f docker-compose.production.yml pull backend frontend admin ingress
+            docker compose -f docker-compose.production.yml up -d --no-deps frontend ingress admin
+            docker compose -f docker-compose.production.yml up -d --no-deps backend

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,4 +1,4 @@
-name: Release
+name: Docker Build
 
 on:
   release:
@@ -145,62 +145,3 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           tags: ${{ steps.tags.outputs.ingress }}
-
-  sentry-sourcemaps:
-    needs: docker
-    runs-on: ubuntu-latest
-    continue-on-error: true
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 10.30.1
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: '22'
-          cache: 'pnpm'
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Extract version
-        id: version
-        run: echo "version=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
-
-      - name: Build frontend
-        run: pnpm --filter frontend build-only
-
-      - name: Build backend
-        run: pnpm --filter backend prisma:generate && pnpm --filter backend build
-
-      - name: Upload frontend sourcemaps
-        run: |
-          pnpm exec sentry-cli --url $SENTRY_URL sourcemaps inject ./apps/frontend/dist
-          pnpm exec sentry-cli --url $SENTRY_URL sourcemaps upload \
-            --org $SENTRY_ORG --project $SENTRY_PROJECT \
-            --release "frontend@${{ steps.version.outputs.version }}" \
-            ./apps/frontend/dist
-        env:
-          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-          SENTRY_URL: ${{ vars.SENTRY_URL }}
-          SENTRY_ORG: ${{ vars.SENTRY_ORG }}
-          SENTRY_PROJECT: ${{ vars.SENTRY_PROJECT }}
-
-      - name: Upload backend sourcemaps
-        run: |
-          pnpm exec sentry-cli --url $SENTRY_URL sourcemaps inject ./apps/backend/dist
-          pnpm exec sentry-cli --url $SENTRY_URL sourcemaps upload \
-            --org $SENTRY_ORG --project $SENTRY_PROJECT \
-            --release "api@${{ steps.version.outputs.version }}" \
-            ./apps/backend/dist
-        env:
-          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-          SENTRY_URL: ${{ vars.SENTRY_URL }}
-          SENTRY_ORG: ${{ vars.SENTRY_ORG }}
-          SENTRY_PROJECT: ${{ vars.SENTRY_PROJECT }}

--- a/.github/workflows/sentry-sourcemaps.yml
+++ b/.github/workflows/sentry-sourcemaps.yml
@@ -1,0 +1,90 @@
+name: Sentry Sourcemaps
+
+on:
+  workflow_run:
+    workflows: ['Docker Build']
+    types: [completed]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  sentry-sourcemaps:
+    runs-on: ubuntu-latest
+    if: >-
+      (github.event_name == 'workflow_dispatch') ||
+      (github.event.workflow_run.conclusion == 'success')
+    continue-on-error: true
+    steps:
+      - name: Check Sentry secrets
+        id: secrets-check
+        run: |
+          if [[ -z "${{ secrets.SENTRY_AUTH_TOKEN }}" ]]; then
+            echo "::notice::SENTRY_AUTH_TOKEN not configured — skipping sourcemap upload."
+            echo "has_secrets=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_secrets=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Checkout code
+        if: steps.secrets-check.outputs.has_secrets == 'true'
+        uses: actions/checkout@v6
+
+      - name: Install pnpm
+        if: steps.secrets-check.outputs.has_secrets == 'true'
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.30.1
+
+      - name: Setup Node.js
+        if: steps.secrets-check.outputs.has_secrets == 'true'
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        if: steps.secrets-check.outputs.has_secrets == 'true'
+        run: pnpm install --frozen-lockfile
+
+      - name: Extract version
+        if: steps.secrets-check.outputs.has_secrets == 'true'
+        id: version
+        run: echo "version=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
+
+      - name: Build frontend
+        if: steps.secrets-check.outputs.has_secrets == 'true'
+        run: pnpm --filter frontend build-only
+
+      - name: Build backend
+        if: steps.secrets-check.outputs.has_secrets == 'true'
+        run: pnpm --filter backend prisma:generate && pnpm --filter backend build
+
+      - name: Upload frontend sourcemaps
+        if: steps.secrets-check.outputs.has_secrets == 'true'
+        run: |
+          pnpm exec sentry-cli --url $SENTRY_URL sourcemaps inject ./apps/frontend/dist
+          pnpm exec sentry-cli --url $SENTRY_URL sourcemaps upload \
+            --org $SENTRY_ORG --project $SENTRY_PROJECT \
+            --release "frontend@${{ steps.version.outputs.version }}" \
+            ./apps/frontend/dist
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_URL: ${{ vars.SENTRY_URL }}
+          SENTRY_ORG: ${{ vars.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ vars.SENTRY_PROJECT }}
+
+      - name: Upload backend sourcemaps
+        if: steps.secrets-check.outputs.has_secrets == 'true'
+        run: |
+          pnpm exec sentry-cli --url $SENTRY_URL sourcemaps inject ./apps/backend/dist
+          pnpm exec sentry-cli --url $SENTRY_URL sourcemaps upload \
+            --org $SENTRY_ORG --project $SENTRY_PROJECT \
+            --release "api@${{ steps.version.outputs.version }}" \
+            ./apps/backend/dist
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_URL: ${{ vars.SENTRY_URL }}
+          SENTRY_ORG: ${{ vars.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ vars.SENTRY_PROJECT }}

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -180,11 +180,11 @@ The admin domain is protected by **mutual TLS (mTLS)** — only clients presenti
 
 ## Sentry / GlitchTip Sourcemap Uploads
 
-The release workflow uploads frontend and backend sourcemaps to GlitchTip so that error stack traces show original source code instead of minified bundles.
+The Sentry Sourcemaps workflow (`.github/workflows/sentry-sourcemaps.yml`) uploads frontend and backend sourcemaps to GlitchTip so that error stack traces show original source code instead of minified bundles. It runs automatically after the Docker Build workflow completes and is **secrets-gated** — it skips gracefully when `SENTRY_AUTH_TOKEN` is not configured (e.g. in forks).
 
 ### How it works
 
-The `sentry-sourcemaps` job in `.github/workflows/release.yml` runs in parallel with the Docker build on every release. It:
+The workflow:
 
 1. Builds frontend and backend locally to produce `dist/` with sourcemaps
 2. Runs `sentry-cli sourcemaps inject` to stamp debug IDs into the files
@@ -213,6 +213,58 @@ Sourcemaps are tagged with release names that match the Sentry SDK configuration
 | Backend  | `api@{version}`      | `api@0.12.2`      |
 
 The version is read from the root `package.json`.
+
+## Continuous Deployment
+
+The release pipeline consists of three independent GitHub Actions workflows:
+
+| Workflow          | File                    | Trigger                | Purpose                        |
+| ----------------- | ----------------------- | ---------------------- | ------------------------------ |
+| Docker Build      | `docker-build.yml`      | `release: published`   | Build and push images to GHCR  |
+| Sentry Sourcemaps | `sentry-sourcemaps.yml` | Docker Build completes | Upload sourcemaps to GlitchTip |
+| Deploy            | `deploy.yml`            | Docker Build completes | SSH deploy to production       |
+
+Sentry and Deploy run in parallel after Docker Build. Both are **secrets-gated** — they skip gracefully when required secrets are not configured (e.g. in forks).
+
+### Enabling auto-deploy
+
+1. Generate an SSH keypair for deployment:
+
+   ```bash
+   ssh-keygen -t ed25519 -f deploy_key -N "" -C "github-actions-deploy"
+   ```
+
+2. Add the public key to the production server:
+
+   ```bash
+   cat deploy_key.pub >> ~/.ssh/authorized_keys
+   ```
+
+3. Add these GitHub repository secrets (Settings > Secrets > Actions):
+
+   | Secret           | Value                                  |
+   | ---------------- | -------------------------------------- |
+   | `DEPLOY_HOST`    | Production server hostname             |
+   | `DEPLOY_USER`    | SSH username                           |
+   | `DEPLOY_SSH_KEY` | Contents of `deploy_key` (private key) |
+
+4. The deploy workflow will now run automatically on each release.
+
+### Semver gating
+
+- **Patch/minor** releases (e.g. 0.13.5 > 0.13.6): auto-deployed
+- **Major** releases (e.g. 0.x > 1.0): skipped with a warning — deploy manually and run migrations:
+  ```bash
+  ssh example.org
+  cd ~/opencupid && git fetch --tags && git checkout vX.Y.Z
+  docker compose -f docker-compose.production.yml pull backend frontend admin ingress
+  docker compose -f docker-compose.production.yml up -d
+  docker compose -f docker-compose.production.yml exec backend npx prisma migrate deploy
+  ```
+
+### Manual deploy trigger
+
+The deploy workflow can be triggered manually via GitHub Actions UI (`workflow_dispatch`) with a specific release tag, regardless of semver gating.
 
 ## Firewall
 


### PR DESCRIPTION
## Summary

- Split monolithic `release.yml` into three independent, chainable GitHub Actions workflows: `docker-build.yml`, `sentry-sourcemaps.yml`, and `deploy.yml`
- Sentry and Deploy trigger in parallel via `workflow_run` after Docker Build completes — each can also run independently via `workflow_dispatch`
- Both downstream workflows are **secrets-gated** (skip gracefully in forks) and the deploy workflow includes **semver gating** (skips major version bumps)
- Updated `docs/DEPLOYMENT.md` with new Continuous Deployment section documenting the pipeline, setup instructions, and semver gating behavior

## Test plan

- [ ] Merge and create a patch release to test the full chain: docker-build → sentry + deploy
- [ ] Verify `workflow_dispatch` works independently on each workflow
- [ ] Verify semver gate logs correctly (check Actions log output)
- [ ] Verify secrets-gating: fork without secrets should show "skipped" status, not failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)