### PR TITLE
fix: pass --repo to gh release list in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -61,7 +61,7 @@ jobs:
           CURRENT_MAJOR=$(echo "$TAG" | sed 's/^v//' | cut -d. -f1)
 
           # Fetch previous release tag
-          PREV_TAG=$(gh release list --limit 2 --json tagName --jq '.[1].tagName // empty')
+          PREV_TAG=$(gh release list --repo "${{ github.repository }}" --limit 2 --json tagName --jq '.[1].tagName // empty')
           if [[ -z "$PREV_TAG" ]]; then
             echo "No previous release found — proceeding with deploy."
             echo "should_deploy=true" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

- The semver gate step in `deploy.yml` calls `gh release list` but the workflow has no checkout step, so `gh` can't infer the repository from git context
- Fix: pass `--repo ${{ github.repository }}` explicitly

## Test plan

- [ ] Merge, create a patch release, verify deploy workflow passes the semver gate step

🤖 Generated with [Claude Code](https://claude.com/claude-code)