### PR TITLE
feat: raise post content max length to 300 characters

### DIFF
--- a/apps/frontend/src/features/posts/components/PostEdit.vue
+++ b/apps/frontend/src/features/posts/components/PostEdit.vue
@@ -7,6 +7,8 @@ import type { CreatePostPayload, UpdatePostPayload, OwnerPost } from '@zod/post/
 import type { LocationDTO } from '@zod/dto/location.dto'
 import { type PostTypeType } from '@zod/generated'
 
+const POST_CONTENT_MAX_LENGTH = 300
+
 import PostIt from '@/features/shared/ui/PostIt.vue'
 import PostTypeBadge from './PostTypeBadge.vue'
 import LocationSelector from '@/features/shared/profileform/LocationSelector.vue'
@@ -163,13 +165,13 @@ const handleSubmit = async () => {
             id="post-content"
             v-model="form.content"
             :placeholder="$t('posts.placeholders.content')"
-            maxlength="150"
+            :maxlength="POST_CONTENT_MAX_LENGTH"
             required
             rows="4"
             :label="$t('posts.labels.content')"
           ></BFormTextarea>
           <div class="fs-6 text-end form-text text-muted character-count">
-            {{ form.content.length }}/150
+            {{ form.content.length }}/{{ POST_CONTENT_MAX_LENGTH }}
           </div>
         </BFormGroup>
 


### PR DESCRIPTION
## Summary

- Raise post content character limit from 150 to 300
- Extract `POST_CONTENT_MAX_LENGTH` constant used by both the textarea `maxlength` and the character counter

## Test plan

- [x] Create a post with >150 characters, verify it's accepted
- [x] Verify character counter shows `/300`

🤖 Generated with [Claude Code](https://claude.com/claude-code)