### PR TITLE
fix: quote origins in Permissions-Policy header

### DIFF
--- a/apps/ingress/nginx.conf.template
+++ b/apps/ingress/nginx.conf.template
@@ -29,7 +29,7 @@ http {
       ngx.header["X-Content-Type-Options"] = "nosniff"
       ngx.header["X-Frame-Options"] = "DENY"
       ngx.header["Referrer-Policy"] = "strict-origin-when-cross-origin"
-      ngx.header["Permissions-Policy"] = "camera=(self https://meet.${DOMAIN}), microphone=(self https://meet.${DOMAIN}), geolocation=(self)"
+      ngx.header["Permissions-Policy"] = 'camera=(self "https://meet.${DOMAIN}"), microphone=(self "https://meet.${DOMAIN}"), geolocation=(self)'
 
       local csp = "default-src 'self'"
         .. "; script-src 'self' https://*.${DOMAIN}"


### PR DESCRIPTION
## Summary
- Quote origin URLs in the `Permissions-Policy` HTTP header so Android Chrome correctly delegates camera/microphone permissions to the Jitsi iframe on the `meet.` subdomain
- Without quotes, Chrome ignores the origin and treats it as `camera=(self)`, blocking the iframe

## Test plan
- [ ] Deploy to production and test video call on Android Chrome — camera and mic should work
- [ ] Verify desktop Chrome still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)