### PR TITLE
fix: increase rate limit burst for SPA page loads

### DIFF
--- a/apps/ingress/nginx.conf.template
+++ b/apps/ingress/nginx.conf.template
@@ -17,7 +17,7 @@ http {
   server_tokens off;
 
   # --- Rate / connection limiting ---
-  limit_req_zone  $binary_remote_addr  zone=req_per_ip:10m  rate=5r/s;
+  limit_req_zone  $binary_remote_addr  zone=req_per_ip:10m  rate=10r/s;
   limit_conn_zone $binary_remote_addr  zone=conn_per_ip:10m;
 
   # --- Enable Gzip ---
@@ -111,7 +111,9 @@ http {
     ssl_ciphers HIGH:!aNULL:!MD5;
 
     limit_conn conn_per_ip 20;
-    limit_req  zone=req_per_ip burst=20 nodelay;
+    limit_req  zone=req_per_ip burst=50 nodelay;
+    limit_req_status 429;
+    limit_conn_status 429;
 
     # Security headers (set via Lua to apply to all locations including those with add_header)
     header_filter_by_lua_block {


### PR DESCRIPTION
## Summary
- Increase nginx rate limit from 5r/s to 10r/s and burst from 20 to 50
- Return proper 429 Too Many Requests instead of 503 Service Unavailable

A single SPA page load fires 30+ concurrent requests (API calls, profile images, static assets, WebSocket upgrade), easily exhausting burst=20. This caused images to fail loading and WebSocket connections to be refused during normal browsing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)