### PR TITLE
fix: add api.maptiler.com to CSP connect-src and img-src

### DIFF
--- a/apps/ingress/nginx.conf.template
+++ b/apps/ingress/nginx.conf.template
@@ -40,7 +40,7 @@ http {
       local csp = "default-src 'self'"
         .. "; script-src 'self' https://*.${DOMAIN}"
         .. "; style-src 'self' 'unsafe-inline'"
-        .. "; img-src 'self' data: blob:"
+        .. "; img-src 'self' data: blob: https://api.maptiler.com"
         .. "; font-src 'self'"
         .. "; object-src 'none'"
         .. "; base-uri 'self'"
@@ -122,7 +122,7 @@ http {
         "worker-src 'self' blob:"
         .. "; media-src 'self'"
         .. "; frame-src https://*.${DOMAIN}"
-        .. "; connect-src 'self' blob: wss://${DOMAIN} https://*.${DOMAIN} https://photon.komoot.io"
+        .. "; connect-src 'self' blob: wss://${DOMAIN} https://*.${DOMAIN} https://photon.komoot.io https://api.maptiler.com"
       )
     }
 


### PR DESCRIPTION
## Summary
- Add `https://api.maptiler.com` to CSP `connect-src` (tile/style fetches) and `img-src` (raster tiles/sprites)
- Required for the MapTiler vector tiles added in #820

## Test plan
- [ ] Verify no CSP errors in browser console on `/browse` map
- [ ] Confirm map tiles load correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)