### PR TITLE
fix: reduce image URL HMAC TTL to 1 hour

### DIFF
--- a/apps/backend/src/lib/appconfig.ts
+++ b/apps/backend/src/lib/appconfig.ts
@@ -27,7 +27,7 @@ export const configSchema = z.object({
   MEDIA_UPLOAD_DIR: z.string(),
   MEDIA_URL_BASE: z.string(),
   IMAGE_MAX_SIZE: z.coerce.number(),
-  IMAGE_URL_HMAC_TTL_SECONDS: z.coerce.number().default(60 * 60 * 6),
+  IMAGE_URL_HMAC_TTL_SECONDS: z.coerce.number().default(60 * 60), // 1 hour
   AUTH_IMG_HMAC_SECRET: z.string().min(10),
 
   SMS_API_KEY: z.string(),


### PR DESCRIPTION
Reduce signed image URL expiry from 6h to 1h for tighter security.