### PR TITLE
fix: diff-based marker updates in OsmPoiMap

### DIFF
--- a/apps/frontend/src/features/shared/components/OsmPoiMap.vue
+++ b/apps/frontend/src/features/shared/components/OsmPoiMap.vue
@@ -176,7 +176,7 @@ function createMarker(item: T): LMarker | null {
       .getElement()
       ?.querySelector('.leaflet-popup-content') as HTMLElement | null
     popupTarget.value = target
-    popupItem.value = item
+    popupItem.value = itemsById.get(item.id) ?? null
     nextTick(() => e.popup.update())
   })
   m.on('popupclose', () => {


### PR DESCRIPTION
## Summary
- Replace `clusterGroup.clearLayers()` + full rebuild with incremental diff-based marker updates
- When items change, only new markers are added, removed markers are deleted, and existing markers get position/icon updates
- Prevents map tile reload and view reset when `socialFilter` changes

Closes #836

## Test plan
- [x] Existing SocialMatch tests pass
- [ ] Open /browse, change location/tag filters — map should not flicker or reset view
- [ ] Markers should update smoothly without tile reloads

🤖 Generated with [Claude Code](https://claude.com/claude-code)