### PR TITLE
fix: pin @sentry/cli to 1.77.3 to restore releases files command

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "@intlify/unplugin-vue-i18n": "6.0.8",
     "@lingual/i18n-check": "^0.8.19",
     "@modelcontextprotocol/server-filesystem": "2026.1.14",
-    "@sentry/cli": "^3.2.2",
+    "@sentry/cli": "1.77.3",
     "@types/geojson": "7946.0.16",
     "acorn": "8.16.0",
     "dotenv-expand": "12.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,8 +40,8 @@ importers:
         specifier: 2026.1.14
         version: 2026.1.14(zod@3.24.4)
       '@sentry/cli':
-        specifier: ^3.2.2
-        version: 3.2.2
+        specifier: 1.77.3
+        version: 1.77.3
       '@types/geojson':
         specifier: 7946.0.16
         version: 7946.0.16
@@ -615,6 +615,8 @@ importers:
       vue-tsc:
         specifier: 3.2.5
         version: 3.2.5(typescript@5.9.3)
+
+  apps/ingress: {}
 
   packages/shared:
     devDependencies:
@@ -2633,56 +2635,9 @@ packages:
     resolution: {integrity: sha512-DCn6VoJCWMjZm5sOfD2+2EgEVdr+H/8Hqs080ruWZo1MZzIUmF1+qnG7AtYeIlm93OydU0PLjvYeWo0zttgGvg==}
     engines: {node: '>=18'}
 
-  '@sentry/cli-darwin@3.2.2':
-    resolution: {integrity: sha512-y1uglMBbo9dYqC92hTQBkuGk7SegLPo1cVwJzX0dhplJoBMuanLMhOMYd1J20qhkDdBhguflCHGf0tOzNTGWhg==}
-    engines: {node: '>=18'}
-    os: [darwin]
-
-  '@sentry/cli-linux-arm64@3.2.2':
-    resolution: {integrity: sha512-SIGJknEQNDw9S/8QPTl8QLVe2IEiTKH3NeeHQ/Q2XWXig1ZebJfm4iTrdu47ypszIfxHeLvQkkVrr8mRKq16xA==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [linux, freebsd, android]
-
-  '@sentry/cli-linux-arm@3.2.2':
-    resolution: {integrity: sha512-CC7N3hjOgs3cwrW0T9hqirFVUpKO6ASjdd0JT4DQHaAn34pruv8J+OoSnj1jkrT2DHxDkNNZPOFSK05AnHr8wA==}
-    engines: {node: '>=18'}
-    cpu: [arm]
-    os: [linux, freebsd, android]
-
-  '@sentry/cli-linux-i686@3.2.2':
-    resolution: {integrity: sha512-W2hQ2DvIlZI05j2JN/87lfeo51F24zmQOJU6Uz+fZz/mkSvpnjeWxjAvfDNVGlLxp7XSoDbhHfrLBxdIh6jMeg==}
-    engines: {node: '>=18'}
-    cpu: [x86, ia32]
-    os: [linux, freebsd, android]
-
-  '@sentry/cli-linux-x64@3.2.2':
-    resolution: {integrity: sha512-4mh3yvOUxO63lq3teexRvalD1mWaRVjpgL2cCMKA2wkB69lcL5nK2gkdzDUKx2y/elluVdvGPPZaqOr1bfNI0w==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [linux, freebsd, android]
-
-  '@sentry/cli-win32-arm64@3.2.2':
-    resolution: {integrity: sha512-TQgfkdJgd8Y/lPzDibqc5Hamg8Hl5rN1sZwX80n4r9Ly46Yzu8Bv6KUhoNL/ktAvw9Aeko6Bx54rwZnzxFZHwg==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [win32]
-
-  '@sentry/cli-win32-i686@3.2.2':
-    resolution: {integrity: sha512-vAcnq0SdYuvwIdREgF5APocjW3d9Z17xLwugpaAz8wpOjCeC1iMEFWqbz5k49i4iDkDVNFRMENiVvWVSu1kEnA==}
-    engines: {node: '>=18'}
-    cpu: [x86, ia32]
-    os: [win32]
-
-  '@sentry/cli-win32-x64@3.2.2':
-    resolution: {integrity: sha512-xWPTXjSSdmoyG/0ee7A9KSfsScGHCdaXMP6ASt4bMx3yYJO7ziEoZzfJE2M6oglz+woAm0LV9+O/n7g80tixlQ==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [win32]
-
-  '@sentry/cli@3.2.2':
-    resolution: {integrity: sha512-qmjsm9+Bq/3QGTnIfOsJdhq+8LI3imxAPbGNBpRj4R0YFk+b1ry9huRHCLgkMcRFWtPkJmGZwEq2Z7e+02QPLA==}
-    engines: {node: '>= 18'}
+  '@sentry/cli@1.77.3':
+    resolution: {integrity: sha512-c3eDqcDRmy4TFz2bFU5Y6QatlpoBPPa8cxBooaS4aMQpnIdLYPF1xhyyiW0LQlDUNc3rRjNF7oN5qKoaRoMTQQ==}
+    engines: {node: '>= 8'}
     hasBin: true
 
   '@sentry/core@10.39.0':
@@ -5806,6 +5761,10 @@ packages:
   mkdirp-classic@0.5.3:
     resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
 
+  mkdirp@0.5.6:
+    resolution: {integrity: sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==}
+    hasBin: true
+
   mkdirp@1.0.4:
     resolution: {integrity: sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==}
     engines: {node: '>=10'}
@@ -7560,10 +7519,6 @@ packages:
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
-
-  undici@6.23.0:
-    resolution: {integrity: sha512-VfQPToRA5FZs/qJxLIinmU59u0r7LXqoJkCzinq3ckNJp3vKEh7jTWN589YQ5+aoAC/TGRLyJLCPKcLQbM8r9g==}
-    engines: {node: '>=18.17'}
 
   undici@7.22.0:
     resolution: {integrity: sha512-RqslV2Us5BrllB+JeiZnK4peryVTndy9Dnqq62S3yYRRTj0tFQCwEniUy2167skdGOy3vqRzEvl1Dm4sV2ReDg==}
@@ -10160,45 +10115,17 @@ snapshots:
       '@sentry-internal/replay-canvas': 9.36.0
       '@sentry/core': 9.36.0
 
-  '@sentry/cli-darwin@3.2.2':
-    optional: true
-
-  '@sentry/cli-linux-arm64@3.2.2':
-    optional: true
-
-  '@sentry/cli-linux-arm@3.2.2':
-    optional: true
-
-  '@sentry/cli-linux-i686@3.2.2':
-    optional: true
-
-  '@sentry/cli-linux-x64@3.2.2':
-    optional: true
-
-  '@sentry/cli-win32-arm64@3.2.2':
-    optional: true
-
-  '@sentry/cli-win32-i686@3.2.2':
-    optional: true
-
-  '@sentry/cli-win32-x64@3.2.2':
-    optional: true
-
-  '@sentry/cli@3.2.2':
+  '@sentry/cli@1.77.3':
     dependencies:
+      https-proxy-agent: 5.0.1
+      mkdirp: 0.5.6
+      node-fetch: 2.6.13
       progress: 2.0.3
       proxy-from-env: 1.1.0
-      undici: 6.23.0
       which: 2.0.2
-    optionalDependencies:
-      '@sentry/cli-darwin': 3.2.2
-      '@sentry/cli-linux-arm': 3.2.2
-      '@sentry/cli-linux-arm64': 3.2.2
-      '@sentry/cli-linux-i686': 3.2.2
-      '@sentry/cli-linux-x64': 3.2.2
-      '@sentry/cli-win32-arm64': 3.2.2
-      '@sentry/cli-win32-i686': 3.2.2
-      '@sentry/cli-win32-x64': 3.2.2
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
 
   '@sentry/core@10.39.0': {}
 
@@ -13758,6 +13685,10 @@ snapshots:
 
   mkdirp-classic@0.5.3: {}
 
+  mkdirp@0.5.6:
+    dependencies:
+      minimist: 1.2.8
+
   mkdirp@1.0.4: {}
 
   mktemp@2.0.2: {}
@@ -15609,8 +15540,6 @@ snapshots:
       util-deprecate: 1.0.2
 
   undici-types@6.21.0: {}
-
-  undici@6.23.0: {}
 
   undici@7.22.0: {}
 


### PR DESCRIPTION
## Summary

`sentry-cli` v2+ removed the `releases files upload-sourcemaps` subcommand that GlitchTip requires for sourcemap resolution (restored by #849). The root package.json had `^3.2.2` which silently broke the Sentry sourcemap upload workflow — discovered during the v0.17.2 release Docker+Sentry e2e run.

Pin to `1.77.3` (last v1.x release) which retains `releases files`.

## Test plan
- [x] `pnpm exec sentry-cli releases --help` shows `files` subcommand
- [ ] Re-run Sentry sourcemaps workflow after merge confirms upload succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)