### PR TITLE
chore: enforce changeset requirement in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -202,14 +202,25 @@ Each Docker image has its own semver version in its `apps/<service>/package.json
 
 ### Changesets workflow
 
-Each PR that changes a service should include a changeset file:
+> **HARD RULE — NO EXCEPTIONS:** Every PR that changes a service **must** include a changeset file before it is merged, as part of the finalization workflow. Never finalise a PR without one.
+
+Since `pnpm changeset` requires an interactive TTY that is unavailable in Claude Code, write the file directly instead:
 
 ```bash
-pnpm changeset
-# Select affected packages (@opencupid/backend, @opencupid/frontend, etc.)
-# Choose bump type (patch/minor/major)
-# Write a summary of the change
+# filename: .changeset/<adjective-noun-verb>.md  (three random words, kebab-case)
+cat > .changeset/silver-tags-bloom.md << 'EOF'
+---
+'@opencupid/frontend': patch
+---
+
+Short description of the change (#issue-number)
+EOF
 ```
+
+Bump type guide:
+- `patch` — bug fixes, non-visible improvements
+- `minor` — new features or enhancements
+- `major` — breaking changes
 
 ### Release process
 


### PR DESCRIPTION
## Summary

- Adds a **HARD RULE** to the Changesets workflow section: every PR that touches a service must include a changeset file before merging
- Documents how to write the file directly (bypassing the interactive TTY requirement of `pnpm changeset`) with a concrete example
- Includes bump type guide (patch / minor / major)

## Motivation

Changesets were being omitted (e.g. #864) because `pnpm changeset` can't run non-interactively in Claude Code sessions. The new instructions make the workaround explicit so it can't be forgotten.

🤖 Generated with [Claude Code](https://claude.com/claude-code)