### PR TITLE
fix(frontend): recover ApiError overlay when API responds again

### DIFF
--- a/apps/frontend/src/lib/__tests__/api.spec.ts
+++ b/apps/frontend/src/lib/__tests__/api.spec.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach, afterAll } from 'vitest'
+import { AxiosError } from 'axios'
 
 // Mock the bus module
 const mockEmit = vi.fn()
@@ -25,8 +26,9 @@ describe('api error handling', () => {
     vi.useRealTimers()
   })
 
-  it('detects network errors correctly', () => {
-    // Test the network error detection logic
+  it('detects network errors correctly', async () => {
+    const { isNetworkError } = await import('../api')
+
     const testCases = [
       { code: 'ECONNABORTED', expected: true },
       { code: 'ENETUNREACH', expected: true },
@@ -36,58 +38,35 @@ describe('api error handling', () => {
       { code: 'ECONNRESET', expected: true },
       { code: 'ERR_NETWORK', expected: true },
       { code: 'ERR_BAD_RESPONSE', expected: true },
-      { response: null, expected: true }, // no response = network error
+      { response: null, expected: true },
       { code: 'SOME_OTHER_ERROR', response: { status: 500 }, expected: false },
     ]
 
     testCases.forEach(({ code, response, expected }) => {
-      const error = { code, response }
-      const isNetworkError =
-        !error.response ||
-        [
-          'ECONNABORTED',
-          'ENETUNREACH',
-          'ENOTFOUND',
-          'ECONNREFUSED',
-          'ETIMEDOUT',
-          'ECONNRESET',
-          'ERR_NETWORK',
-          'ERR_BAD_RESPONSE',
-        ].includes(error.code ?? '')
-
-      expect(isNetworkError).toBe(expected)
+      expect(isNetworkError({ code, response })).toBe(expected)
     })
   })
 
-  it('handles various network error codes', () => {
-    const errorCodes = [
-      'ECONNABORTED',
-      'ENETUNREACH',
-      'ENOTFOUND',
-      'ECONNREFUSED',
-      'ETIMEDOUT',
-      'ECONNRESET',
-      'ERR_NETWORK',
-      'ERR_BAD_RESPONSE',
-    ]
+  it('marks API online when a response is received while offline', async () => {
+    const { api } = await import('../api')
 
-    for (const code of errorCodes) {
-      const mockError: { code: string; response?: unknown } = { code }
+    const rejected = api.interceptors.response.handlers[0].rejected
 
-      const isNetworkError =
-        !mockError.response ||
-        [
-          'ECONNABORTED',
-          'ENETUNREACH',
-          'ENOTFOUND',
-          'ECONNREFUSED',
-          'ETIMEDOUT',
-          'ECONNRESET',
-          'ERR_NETWORK',
-          'ERR_BAD_RESPONSE',
-        ].includes(mockError.code)
+    await rejected(
+      new AxiosError('Network Error', 'ERR_NETWORK', undefined, undefined, undefined as any)
+    ).catch(() => undefined)
+    expect(mockEmit).toHaveBeenCalledWith('api:offline')
 
-      expect(isNetworkError).toBe(true)
-    }
+    await rejected(
+      new AxiosError('Internal Server Error', 'ERR_BAD_REQUEST', undefined, undefined, {
+        status: 500,
+        statusText: 'Internal Server Error',
+        headers: {},
+        config: {},
+        data: {},
+      } as any)
+    ).catch(() => undefined)
+
+    expect(mockEmit).toHaveBeenCalledWith('api:online')
   })
 })

--- a/apps/frontend/src/lib/api.ts
+++ b/apps/frontend/src/lib/api.ts
@@ -15,6 +15,44 @@ let isOffline = false
 let retryTimeoutId: NodeJS.Timeout | null = null
 let waitForRecovery: (() => void)[] = []
 
+function markApiOnline() {
+  if (!isOffline) return
+
+  isOffline = false
+  bus.emit('api:online')
+  waitForRecovery.forEach((fn) => fn())
+  waitForRecovery = []
+
+  if (retryTimeoutId) {
+    clearTimeout(retryTimeoutId)
+    retryTimeoutId = null
+  }
+}
+
+function markApiOffline() {
+  if (isOffline) return
+
+  isOffline = true
+  bus.emit('api:offline')
+  startRetryMechanism()
+}
+
+export function isNetworkError(error: { response?: unknown; code?: string }) {
+  return (
+    !error.response ||
+    [
+      'ECONNABORTED',
+      'ENETUNREACH',
+      'ENOTFOUND',
+      'ECONNREFUSED',
+      'ETIMEDOUT',
+      'ECONNRESET',
+      'ERR_NETWORK',
+      'ERR_BAD_RESPONSE',
+    ].includes(error.code ?? '')
+  )
+}
+
 export const isApiOnline = () =>
   isOffline ? new Promise<void>((resolve) => waitForRecovery.push(resolve)) : Promise.resolve()
 
@@ -54,22 +92,18 @@ function addRefreshSubscriber(callback: (token: string) => void) {
 
 api.interceptors.response.use(
   (response) => {
-    if (isOffline) {
-      isOffline = false
-      bus.emit('api:online')
-      waitForRecovery.forEach((fn) => fn())
-      waitForRecovery = []
-
-      if (retryTimeoutId) {
-        clearTimeout(retryTimeoutId)
-        retryTimeoutId = null
-      }
-    }
+    markApiOnline()
 
     return response
   },
   async (error) => {
     const originalRequest = error.config
+
+    // If the backend is responding again (even with a non-2xx status),
+    // clear the offline overlay and resume pending calls.
+    if (isOffline && error.response) {
+      markApiOnline()
+    }
 
     // Handle 401 with silent refresh
     if (error.response?.status === 401 && !originalRequest._retry) {
@@ -139,23 +173,8 @@ api.interceptors.response.use(
     }
 
     // Network error handling
-    const isNetworkError =
-      !error.response ||
-      [
-        'ECONNABORTED',
-        'ENETUNREACH',
-        'ENOTFOUND',
-        'ECONNREFUSED',
-        'ETIMEDOUT',
-        'ECONNRESET',
-        'ERR_NETWORK',
-        'ERR_BAD_RESPONSE',
-      ].includes(error.code)
-
-    if (isNetworkError && !isOffline) {
-      isOffline = true
-      bus.emit('api:offline')
-      startRetryMechanism()
+    if (isNetworkError(error)) {
+      markApiOffline()
     }
 
     return Promise.reject(error)
@@ -171,22 +190,8 @@ export async function safeApiCall<T>(fn: () => Promise<T>): Promise<T> {
     const result = await fn()
     return result
   } catch (err: any) {
-    const isNetworkError =
-      !err.response ||
-      [
-        'ECONNABORTED',
-        'ENETUNREACH',
-        'ENOTFOUND',
-        'ECONNREFUSED',
-        'ETIMEDOUT',
-        'ECONNRESET',
-        'ERR_NETWORK',
-        'ERR_BAD_RESPONSE',
-      ].includes(err.code)
-
-    if (isNetworkError) {
-      isOffline = true
-      startRetryMechanism()
+    if (isNetworkError(err)) {
+      markApiOffline()
       await isApiOnline()
       return safeApiCall(fn) // try again after recovery
     }


### PR DESCRIPTION
### Motivation
- The frontend could get stuck behind the `ApiError` overlay after an in-place container update (path: `docker compose pull` + `docker compose up`) because offline state was only cleared on successful responses, causing recovery to require a full restart.
- Ensure the app dismisses the offline overlay as soon as the backend becomes reachable again (even if it temporarily returns non-2xx responses) to avoid a dead-end state. 

### Description
- Extracted API connectivity transitions into dedicated helpers `markApiOffline` and `markApiOnline` in `apps/frontend/src/lib/api.ts` for consistent state changes and event emission.
- Added and exported `isNetworkError` to centralize network error classification and reused it in the axios interceptor and `safeApiCall` retry flow.
- Updated the axios response interceptor to call `markApiOnline()` on any backend response (including error responses) when previously offline, and to call `markApiOffline()` when a network error is detected, allowing the UI to clear the `ApiError` overlay as soon as the backend is reachable again.
- Updated `safeApiCall` to use the new helpers so retry behavior is consistent with the interceptor.
- Added a regression test `apps/frontend/src/lib/__tests__/api.spec.ts` that verifies network error classification and the offline→online transition when a response is received after a network outage.

### Testing
- Ran `pnpm --filter frontend exec vitest run src/lib/__tests__/api.spec.ts src/features/app/components/__tests__/AppNotifier.spec.ts` and the targeted frontend tests passed (all tests in those files succeeded).
- Ran `pnpm --filter frontend exec vitest run src/lib/__tests__/api.spec.ts` and the new api tests passed.
- Ran the full `pnpm test` in this environment but it failed due to Corepack attempting to download a pnpm release (network error `ENETUNREACH`) unrelated to the code changes; targeted frontend unit tests were validated successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4fad0f5cc8331b36f8f276ea6734e)