### PR TITLE
Fix auth ID input frozen by conflicting v-model and :value bindings

### DIFF
--- a/.changeset/bright-inputs-glow.md
+++ b/.changeset/bright-inputs-glow.md
@@ -1,0 +1,5 @@
+---
+'@opencupid/frontend': patch
+---
+
+Fix auth ID input field not accepting user input due to conflicting v-model and :value bindings (#969)

--- a/apps/frontend/src/features/auth/components/AuthIdComponent.vue
+++ b/apps/frontend/src/features/auth/components/AuthIdComponent.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, computed, onMounted } from 'vue'
+import { ref, computed } from 'vue'
 import type { UserIdentifyPayload } from '@zod/user/user.dto'
 import { emailRegex, phoneRegex } from '@/lib/utils'
 import CaptchaWidget from './CaptchaWidget.vue'
@@ -13,8 +13,8 @@ import IconLogin from '@/assets/icons/interface/login.svg'
 const { t } = useI18n()
 
 const props = defineProps<{
-  isLoading: boolean,
-  defaultAuthId?: string,
+  isLoading: boolean
+  defaultAuthId?: string
 }>()
 
 const emit = defineEmits<{
@@ -22,7 +22,7 @@ const emit = defineEmits<{
 }>()
 
 // State variables
-const authIdInput = ref('')
+const authIdInput = ref(props.defaultAuthId || '')
 const captchaPayload = ref('')
 const error = ref('')
 
@@ -94,7 +94,6 @@ function handleCaptchaUpdatePayload(payload: string) {
             autofocus
             autocomplete="off"
             :state="inputState"
-            :value="defaultAuthId"
             lazy
           >
           </BInput>

--- a/apps/frontend/src/features/auth/views/AuthUserId.vue
+++ b/apps/frontend/src/features/auth/views/AuthUserId.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, reactive, onMounted } from 'vue'
+import { ref, reactive } from 'vue'
 import { useRouter } from 'vue-router'
 import { type UserIdentifyPayload } from '@zod/user/user.dto'
 import { type LoginUser } from '@zod/user/user.dto'
@@ -61,11 +61,7 @@ const handleSetLanguage = (lang: string) => {
   i18nStore.setLanguage(lang)
 }
 
-const defaultAuthId = ref('')
-
-onMounted(() => {
-  defaultAuthId.value = localStorage.getItem('authId') || ''
-})
+const defaultAuthId = localStorage.getItem('authId') || ''
 </script>
 
 <template>


### PR DESCRIPTION
## Summary
- Removed conflicting `:value="defaultAuthId"` binding from `AuthIdComponent` input that fought with `v-model.trim`, preventing user input
- Initialize `authIdInput` ref from `defaultAuthId` prop instead
- Simplified `AuthUserId` to read localStorage synchronously at setup time (no need for `onMounted`)

## Test plan
- [x] All 300 frontend tests pass
- [ ] Navigate to `/auth`, verify input accepts typed email/phone
- [ ] Set localStorage `authId`, reload `/auth`, verify input is pre-populated AND still editable

Fixes regression from #969

🤖 Generated with [Claude Code](https://claude.com/claude-code)