### PR TITLE
fix: provide viewerProfile injection in PublicProfileView

### DIFF
--- a/.changeset/warm-trees-glow.md
+++ b/.changeset/warm-trees-glow.md
@@ -1,0 +1,5 @@
+---
+'@opencupid/frontend': patch
+---
+
+Fix missing viewerProfile injection on public profile hard refresh (#1048)

--- a/apps/frontend/src/features/publicprofile/views/PublicProfileView.vue
+++ b/apps/frontend/src/features/publicprofile/views/PublicProfileView.vue
@@ -1,9 +1,17 @@
 <script setup lang="ts">
+import { computed, provide } from 'vue'
 import { useRouter } from 'vue-router'
+import { useOwnerProfileStore } from '@/features/myprofile/stores/ownerProfileStore'
 import PublicProfileComponent from '../components/PublicProfile.vue'
 import MiddleColumn from '@/features/shared/ui/MiddleColumn.vue'
 
 const props = defineProps<{ profileId: string }>()
+
+const profileStore = useOwnerProfileStore()
+provide(
+  'viewerProfile',
+  computed(() => profileStore.profile)
+)
 const router = useRouter()
 
 const handleBack = () => {

--- a/apps/frontend/src/features/publicprofile/views/__tests__/PublicProfileView.spec.ts
+++ b/apps/frontend/src/features/publicprofile/views/__tests__/PublicProfileView.spec.ts
@@ -1,0 +1,71 @@
+import { mount, flushPromises } from '@vue/test-utils'
+import { describe, it, expect, vi } from 'vitest'
+import { inject, defineComponent, ref, type Ref } from 'vue'
+
+vi.mock('vue-i18n', () => ({ useI18n: () => ({ t: (k: string) => k }) }))
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push: vi.fn(), back: vi.fn() }),
+}))
+vi.mock('vue-toastification', () => ({
+  useToast: () => ({ warning: vi.fn() }),
+}))
+
+const mockProfile = {
+  id: '1',
+  publicName: 'Test',
+  location: { cityName: 'Berlin', country: 'DE' },
+  isDatingActive: false,
+  profileImages: [],
+  tags: [],
+  languages: [],
+}
+
+vi.mock('@/features/myprofile/stores/ownerProfileStore', () => ({
+  useOwnerProfileStore: () => ({
+    profile: mockProfile,
+  }),
+}))
+
+vi.mock('../../composables/usePublicProfile', () => ({
+  usePublicProfile: () => ({
+    fetchProfile: vi.fn().mockResolvedValue({}),
+    refreshProfile: vi.fn(),
+    blockProfile: vi.fn(),
+    profile: ref({ ...mockProfile, isDatingActive: false }),
+    isLoading: ref(false),
+    error: ref(null),
+  }),
+}))
+
+// Stub all child components to isolate the view
+vi.mock('../../components/PublicProfile.vue', () => ({
+  default: defineComponent({
+    name: 'PublicProfileStub',
+    setup() {
+      const viewerProfile = inject<Ref<any>>('viewerProfile')
+      return { viewerProfile }
+    },
+    template:
+      '<div class="public-profile-stub" :data-has-viewer="!!viewerProfile" :data-viewer-id="viewerProfile?.id" />',
+  }),
+}))
+
+vi.mock('@/features/shared/ui/MiddleColumn.vue', () => ({
+  default: { template: '<div><slot /></div>' },
+}))
+
+import PublicProfileView from '../PublicProfileView.vue'
+
+describe('PublicProfileView', () => {
+  it('provides viewerProfile injection from owner profile store', async () => {
+    const wrapper = mount(PublicProfileView, {
+      props: { profileId: '123' },
+    })
+    await flushPromises()
+
+    const stub = wrapper.find('.public-profile-stub')
+    expect(stub.exists()).toBe(true)
+    expect(stub.attributes('data-has-viewer')).toBe('true')
+    expect(stub.attributes('data-viewer-id')).toBe('1')
+  })
+})


### PR DESCRIPTION
## Summary

- Fixes missing `viewerProfile` injection warning on hard refresh of public profile routes
- Adds `provide('viewerProfile', ...)` to `PublicProfileView.vue`, sourced from the owner profile store

## Root cause

Commit `eeefb884` (refactor: split BrowseProfiles into SocialMatch and DatingMatch views) deleted `BrowseProfiles.vue` which both `provide`d `viewerProfile` and rendered `PublicProfileComponent` inline. The new `ProfileBrowseLayout.vue` carries the provide, but the standalone `PublicProfileView` route was never updated — so on hard refresh (no browse layout ancestor), `ProfileContent.vue`'s `inject('viewerProfile')` finds nothing.

## Test plan

- [x] New test: `PublicProfileView.spec.ts` verifies `viewerProfile` is provided to child components
- [ ] Hard refresh `/browse/profile/:id` — no console warning about missing injection
- [ ] `LocationLabel` still shows relative location correctly when viewer profile is available

Closes #1048

🤖 Generated with [Claude Code](https://claude.com/claude-code)