### PR TITLE
fix: open popup on spiderfied marker click

### DIFF
--- a/.changeset/quiet-spiders-click.md
+++ b/.changeset/quiet-spiders-click.md
@@ -1,5 +1,0 @@
----
-'@opencupid/frontend': patch
----
-
-Fix spiderfied cluster avatar icons not opening popup on click (#1061)

--- a/apps/frontend/src/features/shared/components/OsmPoiMap.vue
+++ b/apps/frontend/src/features/shared/components/OsmPoiMap.vue
@@ -99,6 +99,7 @@ const SPIDER_HOVER_PADDING_PX = 40
 
 let activeSpiderCluster: MCCluster | null = null
 let activeSpiderHoverBounds: L.LatLngBounds | null = null
+const spiderClickHandlers = new WeakMap<L.Marker, (ev: Event) => void>()
 
 function computeViewportMultiplier(map: L.Map) {
   const { x: w, y: h } = map.getSize()
@@ -319,7 +320,7 @@ function onClusterSpiderfied(e: any) {
       L.DomEvent.stopPropagation(ev as any)
       marker.openPopup()
     }
-    ;(marker as any)._spiderClickHandler = handler
+    spiderClickHandlers.set(marker, handler)
     L.DomEvent.on(el, 'click', handler)
   }
 }
@@ -330,10 +331,10 @@ function onClusterUnspiderfied(e: any) {
   if (e?.markers) {
     for (const marker of e.markers) {
       const el = marker.getElement?.()
-      const handler = (marker as any)._spiderClickHandler
+      const handler = spiderClickHandlers.get(marker)
       if (el && handler) {
         L.DomEvent.off(el, 'click', handler)
-        delete (marker as any)._spiderClickHandler
+        spiderClickHandlers.delete(marker)
       }
     }
   }

--- a/apps/frontend/src/features/shared/components/__tests__/OsmPoiMap.spec.ts
+++ b/apps/frontend/src/features/shared/components/__tests__/OsmPoiMap.spec.ts
@@ -315,9 +315,9 @@ describe('OsmPoiMap', () => {
     await flushPromises()
 
     const clusterInstance = (L as any).markerClusterGroup.mock.results[0].value
-    const spiderfiedHandler = clusterInstance.on.mock.calls.find(
-      (c: any) => c[0] === 'spiderfied'
-    )[1]
+    const spiderfiedCall = clusterInstance.on.mock.calls.find((c: any) => c[0] === 'spiderfied')
+    expect(spiderfiedCall).toBeDefined()
+    const spiderfiedHandler = spiderfiedCall![1]
     const mapInstance = (L.map as any).mock.results[0].value
     const mousemoveHandler = mapInstance.on.mock.calls.find((c: any) => c[0] === 'mousemove')[1]
 
@@ -340,9 +340,9 @@ describe('OsmPoiMap', () => {
     await flushPromises()
 
     const clusterInstance = (L as any).markerClusterGroup.mock.results[0].value
-    const spiderfiedHandler = clusterInstance.on.mock.calls.find(
-      (c: any) => c[0] === 'spiderfied'
-    )[1]
+    const spiderfiedCall = clusterInstance.on.mock.calls.find((c: any) => c[0] === 'spiderfied')
+    expect(spiderfiedCall).toBeDefined()
+    const spiderfiedHandler = spiderfiedCall![1]
     const mapInstance = (L.map as any).mock.results[0].value
     const mousemoveHandler = mapInstance.on.mock.calls.find((c: any) => c[0] === 'mousemove')[1]
 
@@ -543,9 +543,9 @@ describe('OsmPoiMap', () => {
     await flushPromises()
 
     const clusterInstance = (L as any).markerClusterGroup.mock.results[0].value
-    const spiderfiedHandler = clusterInstance.on.mock.calls.find(
-      (c: any) => c[0] === 'spiderfied'
-    )[1]
+    const spiderfiedCall = clusterInstance.on.mock.calls.find((c: any) => c[0] === 'spiderfied')
+    expect(spiderfiedCall).toBeDefined()
+    const spiderfiedHandler = spiderfiedCall![1]
 
     // Create a fake marker with a DOM element to simulate spiderfied state
     const fakeEl = document.createElement('div')
@@ -577,12 +577,12 @@ describe('OsmPoiMap', () => {
     await flushPromises()
 
     const clusterInstance = (L as any).markerClusterGroup.mock.results[0].value
-    const spiderfiedHandler = clusterInstance.on.mock.calls.find(
-      (c: any) => c[0] === 'spiderfied'
-    )[1]
-    const unspiderfiedHandler = clusterInstance.on.mock.calls.find(
-      (c: any) => c[0] === 'unspiderfied'
-    )[1]
+    const spiderfiedCall = clusterInstance.on.mock.calls.find((c: any) => c[0] === 'spiderfied')
+    expect(spiderfiedCall).toBeDefined()
+    const spiderfiedHandler = spiderfiedCall![1]
+    const unspiderfiedCall = clusterInstance.on.mock.calls.find((c: any) => c[0] === 'unspiderfied')
+    expect(unspiderfiedCall).toBeDefined()
+    const unspiderfiedHandler = unspiderfiedCall![1]
 
     const fakeEl = document.createElement('div')
     const fakeMarker = { getElement: () => fakeEl, openPopup: vi.fn() }
@@ -602,7 +602,6 @@ describe('OsmPoiMap', () => {
     const domOffCalls = (L as any).DomEvent.off.mock.calls
     const cleanupCall = domOffCalls.find((c: any) => c[0] === fakeEl && c[1] === 'click')
     expect(cleanupCall).toBeDefined()
-    expect((fakeMarker as any)._spiderClickHandler).toBeUndefined()
   })
 
   it('does not auto-fit to markers when center is provided', async () => {


### PR DESCRIPTION
## Summary
- Spiderfied avatar markers on the map could not be clicked to open their profile popup
- Root cause: `L.DomEvent.stopPropagation` on marker elements prevented Leaflet from firing its `'click'` event, so `marker.openPopup()` never ran
- Fix: combine `stopPropagation` and `openPopup()` into a single DOM click handler, with proper cleanup on unspiderfy

## Test plan
- [x] Verified in live browser: spiderfied marker click now opens popup
- [x] Verified non-spiderfied markers still work
- [x] Verified spider does not collapse when clicking a child marker
- [x] Added unit tests for spiderfied click handler and cleanup
- [x] All existing spider tests pass (6/6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)