### PR TITLE
fix: auto-accept conversation when matched profiles message

### DIFF
--- a/.changeset/warm-matches-glow.md
+++ b/.changeset/warm-matches-glow.md
@@ -1,0 +1,5 @@
+---
+'@opencupid/backend': patch
+---
+
+Auto-accept conversation when matched profiles send first message

--- a/apps/backend/src/__tests__/services/messaging.service.spec.ts
+++ b/apps/backend/src/__tests__/services/messaging.service.spec.ts
@@ -190,6 +190,91 @@ describe('MessageService.sendOrStartConversation dedup', () => {
   })
 })
 
+describe('MessageService.findOrCreateConversation auto-accept on match', () => {
+  const newMsg = {
+    id: 'm-new',
+    conversationId: 'c1',
+    senderId: 'alice',
+    content: 'hi',
+    messageType: 'text/plain',
+    createdAt: new Date(),
+    sender: { id: 'alice', publicName: 'Alice', profileImages: [] },
+    attachment: null,
+  }
+
+  it('creates conversation as INITIATED when no mutual like exists', async () => {
+    const createdConvo = {
+      id: 'c1',
+      status: 'INITIATED',
+      initiatorProfileId: 'alice',
+      profileAId: 'alice',
+      profileBId: 'bob',
+    }
+
+    const tx: any = {
+      conversation: {
+        findUnique: vi.fn().mockResolvedValue(null),
+        create: vi.fn().mockResolvedValue(createdConvo),
+      },
+      likedProfile: {
+        count: vi.fn().mockResolvedValue(0),
+      },
+      message: {
+        findFirst: vi.fn().mockResolvedValue(null),
+        create: vi.fn().mockResolvedValue(newMsg),
+      },
+    }
+
+    await service.sendOrStartConversation(tx, 'alice', 'bob', 'hi', 'text/plain')
+
+    expect(tx.conversation.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ status: 'INITIATED' }),
+      })
+    )
+  })
+
+  it('creates conversation as ACCEPTED when mutual like exists', async () => {
+    const createdConvo = {
+      id: 'c1',
+      status: 'ACCEPTED',
+      initiatorProfileId: 'alice',
+      profileAId: 'alice',
+      profileBId: 'bob',
+    }
+
+    const tx: any = {
+      conversation: {
+        findUnique: vi.fn().mockResolvedValue(null),
+        create: vi.fn().mockResolvedValue(createdConvo),
+      },
+      likedProfile: {
+        count: vi.fn().mockResolvedValue(2),
+      },
+      message: {
+        findFirst: vi.fn().mockResolvedValue(null),
+        create: vi.fn().mockResolvedValue(newMsg),
+      },
+    }
+
+    await service.sendOrStartConversation(tx, 'alice', 'bob', 'hi', 'text/plain')
+
+    expect(tx.likedProfile.count).toHaveBeenCalledWith({
+      where: {
+        OR: [
+          { fromId: 'alice', toId: 'bob' },
+          { fromId: 'bob', toId: 'alice' },
+        ],
+      },
+    })
+    expect(tx.conversation.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ status: 'ACCEPTED' }),
+      })
+    )
+  })
+})
+
 describe('MessageService.listMessagesForConversation', () => {
   it('fetches latest page in descending order and returns ascending payload', async () => {
     mockPrisma.message.findMany.mockResolvedValue([

--- a/apps/backend/src/services/messaging.service.ts
+++ b/apps/backend/src/services/messaging.service.ts
@@ -324,10 +324,12 @@ export class MessageService {
       return existing
     }
 
-    // No existing conversation → create a new one
+    // No existing conversation → auto-accept if profiles have a mutual like
+    const isMatch = await this.hasMutualLike(tx, profileAId, profileBId)
+
     return tx.conversation.create({
       data: {
-        status: 'INITIATED',
+        status: isMatch ? 'ACCEPTED' : 'INITIATED',
         initiatorProfileId: senderId,
         profileAId,
         profileBId,
@@ -349,6 +351,22 @@ export class MessageService {
         await this.sendOrStartConversation(tx, senderId, recipientProfileId, content, 'text/plain')
       })
     }
+  }
+
+  private async hasMutualLike(
+    tx: Prisma.TransactionClient,
+    profileAId: string,
+    profileBId: string
+  ): Promise<boolean> {
+    const count = await tx.likedProfile.count({
+      where: {
+        OR: [
+          { fromId: profileAId, toId: profileBId },
+          { fromId: profileBId, toId: profileAId },
+        ],
+      },
+    })
+    return count === 2
   }
 
   /**


### PR DESCRIPTION
## Summary
- When two profiles have a mutual like (isMatch), the first message between them now creates the conversation with `status: ACCEPTED` instead of `INITIATED`
- Adds `hasMutualLike()` private method to `MessageService` that checks for bidirectional likes in a single `count()` query
- Complements existing `acceptConversationOnMatch()` which handles the reverse timing (match forms after conversation exists)

## Test plan
- [x] Unit tests: new conversation without mutual like → `INITIATED`
- [x] Unit tests: new conversation with mutual like → `ACCEPTED`
- [ ] Manual: two matched profiles → send first message → verify conversation status is `ACCEPTED`
- [ ] Verify existing `acceptConversationOnMatch` path still works (match after conversation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)