### PR TITLE
feat: add splash screen for improved first paint

### DIFF
--- a/.changeset/warm-splash-screen.md
+++ b/.changeset/warm-splash-screen.md
@@ -1,0 +1,5 @@
+---
+'@opencupid/frontend': minor
+---
+
+Add splash screen with logo and gradient background for improved first paint experience

--- a/apps/frontend/index.html
+++ b/apps/frontend/index.html
@@ -62,7 +62,31 @@
     />
   </head>
 
-  <body>
+  <body
+    style="
+      margin: 0;
+      min-height: 100dvh;
+      background: linear-gradient(170deg, #dbc49c 0%, #e8d5b5 40%, #faf4ea 100%);
+      background-attachment: fixed;
+    "
+  >
+    <div
+      id="splash"
+      style="
+        position: fixed;
+        inset: 0;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        z-index: 9999;
+      "
+    >
+      <img
+        src="/assets/logo.png"
+        alt=""
+        style="width: 25%; max-width: 200px; opacity: 0.8"
+      />
+    </div>
     <div
       id="app"
       class="d-flex flex-column h-100"

--- a/apps/frontend/src/app.ts
+++ b/apps/frontend/src/app.ts
@@ -70,4 +70,5 @@ export async function bootstrapApp() {
   await router.isReady()
 
   app.mount('#app')
+  document.getElementById('splash')?.remove()
 }

--- a/apps/frontend/src/main.ts
+++ b/apps/frontend/src/main.ts
@@ -19,6 +19,7 @@ if (shouldShowLandingPage(window.location.pathname, !!localStorage.getItem('toke
     appUseI18n(app)
 
     app.mount('#app')
+    document.getElementById('splash')?.remove()
     // Preload full app silently in background
     nextTick(() => {
       import('./app')


### PR DESCRIPTION
## Summary
- Add a splash screen to `index.html` with the app logo centered on the warm gradient background, visible before any JS loads
- Splash div is removed after Vue mounts via `document.getElementById('splash')?.remove()` in both entry points (`main.ts` and `app.ts`)

## Test plan
- [x] Verified in browser: splash shows on load, disappears after Vue mounts
- [x] No logo jumping or overlap with app content

🤖 Generated with [Claude Code](https://claude.com/claude-code)