### PR TITLE
fix: Vue errors silently lost by Sentry due to errorHandler race

### DIFF
--- a/.changeset/quiet-errors-catch.md
+++ b/.changeset/quiet-errors-catch.md
@@ -1,0 +1,5 @@
+---
+'@opencupid/frontend': patch
+---
+
+Fix Vue errors not being captured by Sentry due to errorHandler race condition

--- a/apps/frontend/src/app.ts
+++ b/apps/frontend/src/app.ts
@@ -27,6 +27,15 @@ import router from './router'
 export async function bootstrapApp() {
   const app = createApp(App)
 
+  // Set errorHandler BEFORE Sentry.init so Sentry wraps it rather than
+  // re-throwing. Without this, @sentry/vue defers captureException to
+  // setTimeout then re-throws — the re-throw escapes Vue's scheduler as an
+  // unhandled promise rejection, racing with globalHandlersIntegration.
+  // The dedupe integration then drops the richer Vue-specific event.
+  app.config.errorHandler = (err, _vm, info) => {
+    console.error(`[Vue error] ${info}:`, err)
+  }
+
   if (__APP_CONFIG__.NODE_ENV !== 'development') {
     Sentry.init({
       app,
@@ -46,11 +55,8 @@ export async function bootstrapApp() {
     })
   }
 
-  app.config.warnHandler = (msg, vm, trace) => {
+  app.config.warnHandler = (msg, _vm, trace) => {
     console.error('Vue warning:', msg, trace)
-    if (msg.includes('computed value is readonly')) {
-      // debugger
-    }
   }
   app.use(createPinia())
   app.use(router)


### PR DESCRIPTION
## Summary
- Set `app.config.errorHandler` **before** `Sentry.init()` so `@sentry/vue` wraps it instead of re-throwing
- Without this, Sentry defers `captureException` to `setTimeout` then re-throws — the re-throw escapes Vue's scheduler as an unhandled promise rejection, racing with `globalHandlersIntegration`. The `dedupeIntegration` then drops the richer Vue-specific event (component name, lifecycle hook, trace)
- Also provides `console.error` logging in dev mode where Sentry is disabled
- Clean up dead `warnHandler` code (unused `vm` param, stale `computed value is readonly` debugger check)

## Test plan
- [ ] Deploy to production and trigger a Vue component error (e.g. via browser console)
- [ ] Verify the error appears in Sentry with Vue component metadata (component name, trace)
- [ ] Verify `[Vue error]` appears in browser console in dev mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)