### PR TITLE
fix: mark map ready on tileerror so markers appear when tiles fail

### DIFF
--- a/.changeset/gentle-tiles-ready.md
+++ b/.changeset/gentle-tiles-ready.md
@@ -1,0 +1,5 @@
+---
+'@opencupid/frontend': patch
+---
+
+Fix map markers not appearing when tile loading fails (bad API key, network error)

--- a/apps/frontend/src/features/shared/components/osmPoiMap/OsmPoiMap.vue
+++ b/apps/frontend/src/features/shared/components/osmPoiMap/OsmPoiMap.vue
@@ -171,7 +171,16 @@ function initBaseLayer(map: LMap): void {
     `https://api.maptiler.com/maps/dataviz/{z}/{x}/{y}.png?key=${__APP_CONFIG__.MAPTILER_API_KEY}`,
     { maxZoom: 14, attribution: '© MapTiler © OpenStreetMap contributors' }
   ).addTo(map)
-  tileLayer.once('load', () => onMapReady())
+  // Mark map ready on first successful load OR first tile error — whichever
+  // comes first. Without the tileerror fallback, a bad API key or network
+  // failure would prevent markers from ever appearing.
+  const readyOnce = () => {
+    tileLayer.off('load', readyOnce)
+    tileLayer.off('tileerror', readyOnce)
+    onMapReady()
+  }
+  tileLayer.once('load', readyOnce)
+  tileLayer.once('tileerror', readyOnce)
 }
 
 // --- clusters + spider hover region ----------------------------------------

--- a/apps/frontend/src/features/shared/components/osmPoiMap/__tests__/OsmPoiMap.spec.ts
+++ b/apps/frontend/src/features/shared/components/osmPoiMap/__tests__/OsmPoiMap.spec.ts
@@ -99,9 +99,11 @@ vi.mock('leaflet', () => {
   const tileLayerProto = {
     addTo: vi.fn().mockReturnThis(),
     once: vi.fn(function (this: any, _event: string, cb: () => void) {
-      cb()
+      // Simulate immediate tile load for the first listener only
+      if (_event === 'load') cb()
       return this
     }),
+    off: vi.fn().mockReturnThis(),
   }
   const tileLayer = vi.fn(() => ({ ...tileLayerProto }))
 
@@ -146,7 +148,6 @@ vi.mock('leaflet.markercluster/dist/MarkerCluster.Default.css', () => ({}))
 vi.mock('@/features/images/composables/useBlurhashDataUrl', () => ({
   blurhashToDataUrl: (hash: string) => `data:image/png;blurhash=${hash}`,
 }))
-
 
 import { mount, flushPromises } from '@vue/test-utils'
 import OsmPoiMap from '../OsmPoiMap.vue'
@@ -348,6 +349,27 @@ describe('OsmPoiMap', () => {
     const [url] = (L.tileLayer as any).mock.calls[0]
     expect(url).toContain('maptiler.com/maps/dataviz')
     expect(url).toContain('{z}/{x}/{y}.png')
+  })
+
+  it('marks map ready on tileerror when tiles fail to load', async () => {
+    // Override tileLayer mock: only fire tileerror, never load
+    const tileLayerOnce = vi.fn(function (this: any, event: string, cb: () => void) {
+      if (event === 'tileerror') cb()
+      return this
+    })
+    vi.mocked(L.tileLayer).mockReturnValueOnce({
+      addTo: vi.fn().mockReturnValue({
+        once: tileLayerOnce,
+        off: vi.fn().mockReturnThis(),
+      }),
+    } as any)
+
+    const wrapper = await mountMap()
+    await flushPromises()
+
+    // Map should still be ready (markers rendered) despite tile load failure
+    expect(L.marker).toHaveBeenCalledTimes(3)
+    expect(wrapper.emitted('map:ready')).toBeTruthy()
   })
 
   it('calls popup.update() on nextTick after popupopen to re-measure teleported content', async () => {


### PR DESCRIPTION
## Summary
- `onMapReady()` previously only fired on the tile layer's `load` event — if tiles never loaded (invalid API key, network failure), the map never became ready and markers never appeared
- Now listens to both `load` and `tileerror`, firing `onMapReady` on whichever comes first
- Adds test verifying markers render even when tile loading fails

## Test plan
- [x] Existing OsmPoiMap tests pass
- [x] New test: "marks map ready on tileerror when tiles fail to load" — verifies markers render and `map:ready` emits when only `tileerror` fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)