### PR TITLE
feat: add HMR support for i18n translation files

### DIFF
--- a/.changeset/warm-owls-flash.md
+++ b/.changeset/warm-owls-flash.md
@@ -1,0 +1,5 @@
+---
+'@opencupid/frontend': patch
+---
+
+Add HMR support for i18n JSON files (no full page reloads on translation edits)

--- a/apps/frontend/src/lib/tolgee.ts
+++ b/apps/frontend/src/lib/tolgee.ts
@@ -19,8 +19,28 @@ export const staticData: TolgeeStaticData = {
   hu: hu as TolgeeStaticData[string],
 }
 
-export const tolgee = Tolgee().use(DevTools()).use(FormatIcu()).init({
-  language: 'en',
-  staticData,
-  availableLanguages,
-})
+// Preserve the Tolgee singleton across HMR updates so translation edits
+// are reflected without a full page reload.
+export const tolgee: ReturnType<ReturnType<typeof Tolgee>['init']> =
+  import.meta.hot?.data?.tolgee ??
+  Tolgee().use(DevTools()).use(FormatIcu()).init({
+    language: 'en',
+    staticData,
+    availableLanguages,
+  })
+
+if (import.meta.hot?.data) {
+  import.meta.hot.data.tolgee = tolgee
+
+  // Accept each locale JSON dependency directly so Vite hands us the
+  // freshly-updated module, avoiding a stale closure over the top-level imports.
+  import.meta.hot.accept('@shared/i18n/en.json', (freshEn) => {
+    if (!freshEn) return
+    tolgee.addStaticData({ en: freshEn.default as TolgeeStaticData[string] })
+  })
+
+  import.meta.hot.accept('@shared/i18n/hu.json', (freshHu) => {
+    if (!freshHu) return
+    tolgee.addStaticData({ hu: freshHu.default as TolgeeStaticData[string] })
+  })
+}


### PR DESCRIPTION
## Summary
- Preserve the Tolgee singleton across Vite HMR updates so editing locale JSON files hot-reloads translations without a full page refresh
- Handles both the eagerly imported `en.json` (via `import.meta.hot.accept`) and lazily glob-imported locale files (via per-path accept handlers)
- Extracted from #1139 per review feedback to keep PRs focused

## Test plan
- [ ] Run `pnpm dev`, edit `packages/shared/i18n/en.json` — verify translation updates in browser without full reload
- [ ] Edit `packages/shared/i18n/hu.json`, switch to Hungarian — verify HMR picks up the change
- [ ] Verify no regressions in normal page load with translations

🤖 Generated with [Claude Code](https://claude.com/claude-code)