### PR TITLE
fix: debounce offline detection to avoid false positives on app-switch

### DIFF
--- a/.changeset/gentle-waves-drift.md
+++ b/.changeset/gentle-waves-drift.md
@@ -1,0 +1,5 @@
+---
+'@opencupid/frontend': patch
+---
+
+Debounce offline detection to prevent false-positive error overlay on app-switch

--- a/apps/frontend/src/lib/__tests__/api.spec.ts
+++ b/apps/frontend/src/lib/__tests__/api.spec.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach, afterAll } from 'vitest'
+import { AxiosHeaders } from 'axios'
 import { getVersionInfo, api } from '../api'
 import packageJson from '../../../package.json'
 
@@ -19,13 +20,41 @@ vi.stubGlobal('__APP_CONFIG__', {
 })
 afterAll(() => vi.unstubAllGlobals())
 
+let originalAdapter: any
+
 describe('api error handling', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    vi.restoreAllMocks()
     vi.useFakeTimers()
+    originalAdapter = api.defaults.adapter
   })
 
-  afterEach(() => {
+  afterEach(async () => {
+    // Reset module-level offline state: first flush pending debounce to let it fire,
+    // then make a successful request to clear isOffline
+    const successAdapter = vi.fn().mockResolvedValue({
+      status: 200,
+      data: {},
+      headers: {},
+      config: {},
+      statusText: 'OK',
+    })
+    api.defaults.adapter = successAdapter
+    // Flush debounce (3s) so it fires and isOffline becomes true
+    vi.advanceTimersByTime(3000)
+    // Let any microtasks from timer callbacks settle
+    await vi.advanceTimersByTimeAsync(0)
+    // Make a successful request to reset isOffline back to false
+    try {
+      await api.get('/reset')
+    } catch {
+      // ignore
+    }
+    // Flush retry mechanism timers (10s)
+    vi.advanceTimersByTime(15000)
+    await vi.advanceTimersByTimeAsync(0)
+    api.defaults.adapter = originalAdapter
     vi.useRealTimers()
   })
 
@@ -139,5 +168,63 @@ describe('api error handling', () => {
       params: { v: packageJson.version },
       timeout: 5000,
     })
+  })
+
+  it('debounces offline detection — emits api:offline only after delay', async () => {
+    const mockAdapter = vi.fn().mockRejectedValue({
+      code: 'ERR_NETWORK',
+      config: { headers: new AxiosHeaders() },
+      isAxiosError: true,
+    })
+    api.defaults.adapter = mockAdapter
+
+    try {
+      await api.get('/test')
+    } catch {
+      // expected
+    }
+
+    // Not emitted immediately
+    expect(mockEmit).not.toHaveBeenCalledWith('api:offline')
+
+    // Emitted after the debounce period
+    vi.advanceTimersByTime(3000)
+    expect(mockEmit).toHaveBeenCalledWith('api:offline')
+  })
+
+  it('cancels offline transition when a successful response arrives during debounce', async () => {
+    let callCount = 0
+    const mockAdapter = vi.fn().mockImplementation((config: any) => {
+      callCount++
+      if (callCount === 1) {
+        return Promise.reject({
+          code: 'ERR_NETWORK',
+          config: { ...config, headers: config.headers || new AxiosHeaders() },
+          isAxiosError: true,
+        })
+      }
+      return Promise.resolve({
+        status: 200,
+        data: { ok: true },
+        headers: {},
+        config,
+        statusText: 'OK',
+      })
+    })
+    api.defaults.adapter = mockAdapter
+
+    // First request fails — starts the debounce
+    try {
+      await api.get('/test')
+    } catch {
+      // expected
+    }
+
+    // Second request succeeds before debounce fires — cancels offline transition
+    await api.get('/test')
+
+    vi.advanceTimersByTime(3000)
+
+    expect(mockEmit).not.toHaveBeenCalledWith('api:offline')
   })
 })

--- a/apps/frontend/src/lib/api.ts
+++ b/apps/frontend/src/lib/api.ts
@@ -27,6 +27,7 @@ const ERROR_CODES = [
 
 let isOffline = false
 let retryTimeoutId: NodeJS.Timeout | null = null
+let offlineDebounceId: NodeJS.Timeout | null = null
 let waitForRecovery: (() => void)[] = []
 
 export const isApiOnline = () =>
@@ -75,6 +76,11 @@ export async function getVersionInfo(options?: { timeout?: number }): Promise<Ve
 
 api.interceptors.response.use(
   (response) => {
+    if (offlineDebounceId) {
+      clearTimeout(offlineDebounceId)
+      offlineDebounceId = null
+    }
+
     if (isOffline) {
       isOffline = false
       bus.emit('api:online')
@@ -159,13 +165,16 @@ api.interceptors.response.use(
       }
     }
 
-    // Network error handling
+    // Network error handling — debounce to avoid false positives from app-switching
     const isNetworkError = !error.response || ERROR_CODES.includes(error.code)
 
-    if (isNetworkError && !isOffline) {
-      isOffline = true
-      bus.emit('api:offline')
-      startRetryMechanism()
+    if (isNetworkError && !isOffline && !offlineDebounceId) {
+      offlineDebounceId = setTimeout(() => {
+        offlineDebounceId = null
+        isOffline = true
+        bus.emit('api:offline')
+        startRetryMechanism()
+      }, 3000)
     }
 
     return Promise.reject(error)


### PR DESCRIPTION
## Summary
- Adds a 3-second debounce before emitting `api:offline` on network errors
- If a successful API response arrives during the debounce window, the offline transition is cancelled
- Prevents the error overlay from flashing briefly when users switch between apps (especially noticeable on slower mobile devices and PWA)

## Test plan
- [ ] On mobile/PWA: switch away from app and back — no offline overlay should appear
- [ ] Kill the backend server — offline overlay should appear after ~3 seconds
- [ ] Restart backend — overlay should dismiss on recovery
- [ ] Verify existing offline/online detection still works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)