### PR TITLE
fix: UX dropdown improvements

### DIFF
--- a/apps/frontend/src/features/shared/components/TagExplorer.vue
+++ b/apps/frontend/src/features/shared/components/TagExplorer.vue
@@ -39,7 +39,7 @@ const handleTagCloudSelect = (tag: PopularTag) => {
     v-model="model"
     :taggable="true"
     :close-on-select="true"
-    open-direction="top"
+    open-direction="bottom"
     :required="true"
     :initialOptions="popularTags"
     :hint="tagCloudHint"

--- a/apps/frontend/src/features/shared/profileform/LanguageSelector.vue
+++ b/apps/frontend/src/features/shared/profileform/LanguageSelector.vue
@@ -47,7 +47,7 @@ const selectHeight = computed(() => {
       v-model="languagesComputed"
       v-bind="attrs"
       :options="languageOptions"
-      :close-on-select="false"
+      :close-on-select="true"
       :clear-on-select="true"
       :multiple="true"
       :searchable="true"


### PR DESCRIPTION
## Summary
- Change `TagExplorer` dropdown to open downward (was `top`, now `bottom`)
- Enable `close-on-select` for `LanguageSelector` multi-select (better UX when picking languages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)