### PR TITLE
refactor: remove explicit envsubst variable list

### DIFF
--- a/.changeset/quiet-shells-glow.md
+++ b/.changeset/quiet-shells-glow.md
@@ -1,0 +1,5 @@
+---
+'@opencupid/frontend': patch
+---
+
+Remove explicit envsubst variable list so new config vars no longer need manual sync (#1181)

--- a/apps/frontend/config.template.js
+++ b/apps/frontend/config.template.js
@@ -1,6 +1,7 @@
 // config.template.js — runtime configuration injected by docker-entrypoint.sh.
 // IMPORTANT: only expose values safe to be public in the browser.
-// envsubst substitutes ${VAR} placeholders at container startup.
+// envsubst substitutes all ${VAR} placeholders at container startup.
+// Adding a new var here is all that's needed — no other file to update.
 window.__APP_CONFIG__ = {
   API_BASE_URL: '${API_BASE_URL}',
   FRONTEND_URL: '${FRONTEND_URL}',

--- a/apps/frontend/docker-entrypoint.sh
+++ b/apps/frontend/docker-entrypoint.sh
@@ -2,12 +2,10 @@
 set -eu
 
 # 1. Substitute OG placeholders in index.html
-envsubst '${OG_TITLE} ${OG_DESCRIPTION} ${OG_IMAGE} ${OG_URL} ${OG_TYPE} ${SITE_NAME}' \
-  < /var/www/index.html > /var/www/index.html.tmp
+envsubst < /var/www/index.html > /var/www/index.html.tmp
 mv /var/www/index.html.tmp /var/www/index.html
 
 # 2. Generate config.js from committed template
-envsubst '${API_BASE_URL} ${FRONTEND_URL} ${WS_BASE_URL} ${MEDIA_URL_BASE} ${NODE_ENV} ${VAPID_PUBLIC_KEY} ${SENTRY_DSN} ${SITE_NAME} ${JITSI_DOMAIN} ${VOICE_MESSAGE_MAX_DURATION} ${MAP_TILE_URL} ${MAP_ATTRIBUTION} ${GEOCODING_ALLOWED_COUNTRIES}' \
-  < /var/www/config.template.js > /var/www/config.js
+envsubst < /var/www/config.template.js > /var/www/config.js
 
 exec nginx -g "daemon off;"


### PR DESCRIPTION
## Summary
- Removes the hardcoded variable list from `envsubst` calls in `apps/frontend/docker-entrypoint.sh` so that **all** `${VAR}` placeholders are substituted automatically
- Adding a new runtime config var to `config.template.js` (or `index.html`) is now all that's needed — no second file to update
- Prevents the class of silent production bugs seen in #954 and #1180

Closes #1181

## Test plan
- [ ] Build the frontend Docker image and verify `config.js` is correctly generated with all env vars substituted
- [ ] Verify `index.html` OG meta tags are substituted correctly
- [ ] Confirm no stray `${...}` literals remain in the served files

🤖 Generated with [Claude Code](https://claude.com/claude-code)