### PR TITLE
Fix admin CSP data image handling

### DIFF
--- a/.changeset/admin-csp-img-src-data.md
+++ b/.changeset/admin-csp-img-src-data.md
@@ -1,0 +1,5 @@
+---
+'@opencupid/ingress': patch
+---
+
+Allow `data:` images in the admin CSP to prevent avatar and placeholder image violations.

--- a/apps/ingress/conf.d/https.conf.tmpl
+++ b/apps/ingress/conf.d/https.conf.tmpl
@@ -184,7 +184,10 @@ server {
 
   # Security headers for admin
   header_filter_by_lua_block {
-    set_security_headers("connect-src 'self'")
+    set_security_headers(
+      "img-src 'self' data: blob:"
+      .. "; connect-src 'self'"
+    )
   }
 
   location /api/ {


### PR DESCRIPTION
## Summary
- allow `data:` and `blob:` image sources in the admin ingress CSP
- add a changeset for the ingress package
- keep the admin host's existing `connect-src 'self'` restriction

