### PR TITLE
fix: enable Colibri WebSocket for Jitsi video call TCP fallback

### DIFF
--- a/.changeset/brave-clouds-dance.md
+++ b/.changeset/brave-clouds-dance.md
@@ -1,0 +1,5 @@
+---
+'@opencupid/ingress': patch
+---
+
+Enable Colibri WebSocket on JVB for TCP fallback when UDP media transport fails

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -93,6 +93,8 @@ services:
       - ENABLE_AUTH=0
       - ENABLE_GUESTS=1
       - ENABLE_XMPP_WEBSOCKET=1
+      - ENABLE_COLIBRI_WEBSOCKET=1
+      - COLIBRI_WEBSOCKET_JVB_LOOKUP_NAME=jitsi-jvb
       - PUBLIC_URL=https://meet.${DOMAIN}
       - XMPP_DOMAIN=meet.jitsi
       - XMPP_AUTH_DOMAIN=auth.meet.jitsi
@@ -157,6 +159,9 @@ services:
       - JVB_BREWERY_MUC=jvbbrewery
       - JVB_PORT=10000
       - JVB_ADVERTISE_IPS=${JVB_ADVERTISE_IPS}
+      - COLIBRI_WEBSOCKET_ENABLED=true
+      - COLIBRI_WEBSOCKET_DOMAIN=meet.${DOMAIN}
+      - COLIBRI_WEBSOCKET_SERVER_ID=default-id
       - TZ=UTC
     depends_on:
       - jitsi-prosody


### PR DESCRIPTION
## Summary

- **Bug**: Jitsi video calls fail for Android Chrome — room opens but video stream never connects. Desktop Firefox works fine on the same network.
- **Root cause**: JVB only offers UDP transport (port 10000) with no TCP fallback. Android Chrome's ICE agent fails to establish a UDP media path and stays stuck in `Running` until timeout → `Terminated`. Confirmed across 8+ call attempts in server logs — the Android endpoint (`Alvis-Av0`) never achieves a single ICE pair validation.
- **Fix**: Enable Colibri WebSocket on `jitsi-jvb` and `jitsi-web` so clients can fall back to `wss://meet.<domain>/colibri-ws/` (TCP/443) when UDP fails. The ingress already has the `/colibri-ws` proxy location configured.

## Changes

- `jitsi-jvb`: Added `COLIBRI_WEBSOCKET_ENABLED`, `COLIBRI_WEBSOCKET_DOMAIN`, `COLIBRI_WEBSOCKET_SERVER_ID` env vars to enable the JVB WebSocket listener
- `jitsi-web`: Added `ENABLE_COLIBRI_WEBSOCKET` and `COLIBRI_WEBSOCKET_JVB_LOOKUP_NAME` so the jitsi-web nginx proxies `/colibri-ws/` to the JVB

## Test plan

- [ ] Deploy to production (requires `docker compose pull` + `up -d --no-deps` for jitsi-jvb and jitsi-web)
- [ ] Verify JVB logs no longer show `ColibriWebSocketService: WebSockets are not enabled`
- [ ] Initiate a video call between Android Chrome and desktop browser
- [ ] Confirm both parties get video/audio streams
- [ ] Verify desktop-to-desktop calls still work (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)