### PR TITLE
feat(messaging): ContactFormPanel waiting-for-reply state

### DIFF
--- a/.changeset/gentle-posts-reply.md
+++ b/.changeset/gentle-posts-reply.md
@@ -1,0 +1,6 @@
+---
+'@opencupid/frontend': minor
+'@opencupid/backend': minor
+---
+
+ContactFormPanel: show waiting-for-reply state when user already initiated contact (#1279)

--- a/apps/backend/src/__tests__/services/post.service.spec.ts
+++ b/apps/backend/src/__tests__/services/post.service.spec.ts
@@ -295,7 +295,7 @@ describe('PostService.findById', () => {
   it('returns post when found', async () => {
     mockPost.post.findFirst.mockResolvedValue(basePost)
 
-    const result = await service.findById(basePost.id, basePost.postedById)
+    const result = await service.findById(basePost.id)
 
     expect(result).toEqual(basePost)
   })
@@ -307,12 +307,22 @@ describe('PostService.findById', () => {
 
     expect(result).toBeNull()
   })
+})
+
+describe('PostService.findByIdWithContext', () => {
+  it('returns post with context when found', async () => {
+    mockPost.post.findFirst.mockResolvedValue(basePost)
+
+    const result = await service.findByIdWithContext(basePost.id, basePost.postedById)
+
+    expect(result).toEqual(basePost)
+  })
 
   it('returns null for invisible post when viewer is not owner', async () => {
     const invisiblePost = { ...basePost, isVisible: false }
     mockPost.post.findFirst.mockResolvedValue(invisiblePost)
 
-    const result = await service.findById(invisiblePost.id, 'other-profile-id')
+    const result = await service.findByIdWithContext(invisiblePost.id, 'other-profile-id')
 
     expect(result).toBeNull()
   })

--- a/apps/backend/src/api/mappers/interaction.mappers.ts
+++ b/apps/backend/src/api/mappers/interaction.mappers.ts
@@ -1,5 +1,6 @@
 import {
   type InteractionContext,
+  type ConversationContext,
   type DatingContext,
   DatingContextSchema,
 } from '@zod/interaction/interactionContext.dto'
@@ -34,10 +35,9 @@ function mapDatingContext(profile: DbProfileWithContext): DatingContext {
   }
 }
 
-export function mapInteractionContext(
-  profile: DbProfileWithContext,
-  includeDatingContext: boolean
-): InteractionContext {
+export function mapConversationContext(
+  profile: Pick<DbProfileWithContext, 'id' | 'conversationParticipants'>
+): ConversationContext {
   const participant = profile.conversationParticipants?.[0]
   const conversation = participant?.conversation
   const initiated =
@@ -53,8 +53,17 @@ export function mapInteractionContext(
   return {
     haveConversation: !!conversation && !initiated,
     canMessage,
-    conversationId: canMessage ? (conversation?.id ?? null) : null,
+    conversationId: canMessage || initiated ? (conversation?.id ?? null) : null,
     initiated,
+  }
+}
+
+export function mapInteractionContext(
+  profile: DbProfileWithContext,
+  includeDatingContext: boolean
+): InteractionContext {
+  return {
+    ...mapConversationContext(profile),
     ...(includeDatingContext ? mapDatingContext(profile) : DatingContextSchema.parse({})),
   }
 }

--- a/apps/backend/src/api/mappers/interaction.mappers.ts
+++ b/apps/backend/src/api/mappers/interaction.mappers.ts
@@ -40,15 +40,18 @@ export function mapConversationContext(
 ): ConversationContext {
   const participant = profile.conversationParticipants?.[0]
   const conversation = participant?.conversation
-  const initiated =
-    !!conversation &&
-    conversation.status === 'INITIATED' &&
-    conversation.initiatorProfileId !== profile.id
+
+  // Did the viewer start this conversation? (profile.id is the target,
+  // so initiator !== target means the viewer initiated.)
+  const iStarted = !!conversation && conversation.initiatorProfileId !== profile.id
+
+  // Is the conversation still waiting for the target's first reply?
+  const initiated = iStarted && conversation!.status === 'INITIATED'
 
   const canMessage =
     !conversation || // no conversation exists
-    (initiated && conversation.status === 'ACCEPTED') || // i initiated and they accepted
-    (!initiated && conversation.status !== 'BLOCKED') // they initiated and i didn't block them
+    (iStarted && conversation!.status === 'ACCEPTED') || // i initiated and they accepted
+    (!iStarted && conversation!.status !== 'BLOCKED') // they initiated and i didn't block them
 
   return {
     haveConversation: !!conversation && !initiated,

--- a/apps/backend/src/api/mappers/post.mappers.ts
+++ b/apps/backend/src/api/mappers/post.mappers.ts
@@ -6,6 +6,7 @@ import {
   type PublicPostDetail,
   type OwnerPost,
 } from '@zod/post/post.dto'
+import type { PostWithProfileAndContext } from '@/services/post.service'
 import type { LocationDTO } from '@zod/dto/location.dto'
 import { mapProfileSummary } from './profile.mappers'
 import { mapConversationContext } from './interaction.mappers'
@@ -35,14 +36,14 @@ export function mapDbPostToPublic(
   }
 }
 
-export function mapDbPostToDetail(post: PostWithProfile): PublicPostDetail {
+export function mapDbPostToDetail(post: PostWithProfileAndContext): PublicPostDetail {
   const { postedBy, ...rest } = post
   return {
     ...PublicPostSchema.parse(rest),
     isOwn: false,
     postedBy: {
       ...mapProfileSummary(postedBy),
-      ...mapConversationContext(postedBy as any),
+      ...mapConversationContext(postedBy),
     },
     location: extractPostLocation(rest),
   }

--- a/apps/backend/src/api/mappers/post.mappers.ts
+++ b/apps/backend/src/api/mappers/post.mappers.ts
@@ -3,10 +3,12 @@ import {
   PublicPostSchema,
   type PostWithProfile,
   type PublicPostWithProfile,
+  type PublicPostDetail,
   type OwnerPost,
 } from '@zod/post/post.dto'
 import type { LocationDTO } from '@zod/dto/location.dto'
 import { mapProfileSummary } from './profile.mappers'
+import { mapConversationContext } from './interaction.mappers'
 
 function extractPostLocation(post: Record<string, unknown>): LocationDTO | null {
   if (!post.country && !post.cityName && post.lat == null && post.lon == null) {
@@ -29,6 +31,19 @@ export function mapDbPostToPublic(
     ...PublicPostSchema.parse(rest),
     isOwn: post.postedById === viewerProfileId,
     postedBy: mapProfileSummary(postedBy),
+    location: extractPostLocation(rest),
+  }
+}
+
+export function mapDbPostToDetail(post: PostWithProfile): PublicPostDetail {
+  const { postedBy, ...rest } = post
+  return {
+    ...PublicPostSchema.parse(rest),
+    isOwn: false,
+    postedBy: {
+      ...mapProfileSummary(postedBy),
+      ...mapConversationContext(postedBy as any),
+    },
     location: extractPostLocation(rest),
   }
 }

--- a/apps/backend/src/api/routes/post.route.ts
+++ b/apps/backend/src/api/routes/post.route.ts
@@ -62,7 +62,7 @@ const postRoutes: FastifyPluginAsync = async (fastify) => {
    * Returns a single post by ID. Returns owner view (with visibility metadata)
    * when the viewer is the post author, public view otherwise.
    * @param {string} id - Post ID (CUID)
-   * @returns {{ success, post: OwnerPost | PublicPostWithProfile }}
+   * @returns {{ success, post: OwnerPost | PublicPostDetail }}
    */
   fastify.get('/:id', { onRequest: [fastify.authenticate] }, async (req, reply) => {
     const { id } = PostParamsSchema.parse(req.params)

--- a/apps/backend/src/api/routes/post.route.ts
+++ b/apps/backend/src/api/routes/post.route.ts
@@ -69,7 +69,7 @@ const postRoutes: FastifyPluginAsync = async (fastify) => {
     const viewerProfileId = req.session.profileId
 
     try {
-      const raw = await postService.findById(id, viewerProfileId)
+      const raw = await postService.findByIdWithContext(id, viewerProfileId)
       if (!raw) {
         return sendError(reply, 404, 'Post not found')
       }

--- a/apps/backend/src/api/routes/post.route.ts
+++ b/apps/backend/src/api/routes/post.route.ts
@@ -18,7 +18,7 @@ import type {
   UpdatePostResponse,
   DeletePostResponse,
 } from '@zod/apiResponse.dto'
-import { mapDbPostToOwner, mapDbPostToPublic } from '../mappers/post.mappers'
+import { mapDbPostToOwner, mapDbPostToPublic, mapDbPostToDetail } from '../mappers/post.mappers'
 
 const postRoutes: FastifyPluginAsync = async (fastify) => {
   const postService = PostService.getInstance(fastify.prisma)
@@ -59,9 +59,10 @@ const postRoutes: FastifyPluginAsync = async (fastify) => {
 
   /**
    * GET /:id
-   * Returns a single post by ID (owner view with visibility metadata).
+   * Returns a single post by ID. Returns owner view (with visibility metadata)
+   * when the viewer is the post author, public view otherwise.
    * @param {string} id - Post ID (CUID)
-   * @returns {{ success, post: OwnerPost }}
+   * @returns {{ success, post: OwnerPost | PublicPostWithProfile }}
    */
   fastify.get('/:id', { onRequest: [fastify.authenticate] }, async (req, reply) => {
     const { id } = PostParamsSchema.parse(req.params)
@@ -73,7 +74,8 @@ const postRoutes: FastifyPluginAsync = async (fastify) => {
         return sendError(reply, 404, 'Post not found')
       }
 
-      const post = mapDbPostToOwner(raw)
+      const post =
+        raw.postedById === viewerProfileId ? mapDbPostToOwner(raw) : mapDbPostToDetail(raw)
 
       return reply.code(200).send({ success: true, post })
     } catch (err) {

--- a/apps/backend/src/services/post.service.ts
+++ b/apps/backend/src/services/post.service.ts
@@ -1,5 +1,6 @@
 import { PrismaClient, PostType, Prisma } from '@prisma/client'
 import type { CreatePostPayload, UpdatePostPayload } from '@zod/post/post.dto'
+import { conversationContextInclude } from '@/db/includes/profileIncludes'
 
 const postedByInclude = {
   include: {
@@ -10,6 +11,17 @@ const postedByInclude = {
     },
   },
 }
+
+const postedByWithConversationInclude = (viewerProfileId: string) => ({
+  include: {
+    postedBy: {
+      include: {
+        profileImages: true,
+        ...conversationContextInclude(viewerProfileId),
+      },
+    },
+  },
+})
 
 export class PostService {
   private static instance: PostService
@@ -45,13 +57,17 @@ export class PostService {
   }
 
   async findById(id: string, viewerProfileId?: string) {
+    const include = viewerProfileId
+      ? postedByWithConversationInclude(viewerProfileId)
+      : postedByInclude
+
     const post = await this.prisma.post.findFirst({
       where: {
         id,
         isDeleted: false,
         ...(viewerProfileId ? {} : { isVisible: true }),
       },
-      ...postedByInclude,
+      ...include,
     })
 
     // If viewer is not the owner, only return visible posts

--- a/apps/backend/src/services/post.service.ts
+++ b/apps/backend/src/services/post.service.ts
@@ -10,18 +10,23 @@ const postedByInclude = {
       },
     },
   },
-}
+} satisfies Prisma.PostFindFirstArgs
 
-const postedByWithConversationInclude = (viewerProfileId: string) => ({
-  include: {
-    postedBy: {
-      include: {
-        profileImages: true,
-        ...conversationContextInclude(viewerProfileId),
+const postedByWithConversationInclude = (viewerProfileId: string) =>
+  ({
+    include: {
+      postedBy: {
+        include: {
+          profileImages: true,
+          ...conversationContextInclude(viewerProfileId),
+        },
       },
     },
-  },
-})
+  }) satisfies Prisma.PostFindFirstArgs
+
+export type PostWithProfileAndContext = Prisma.PostGetPayload<
+  ReturnType<typeof postedByWithConversationInclude>
+>
 
 export class PostService {
   private static instance: PostService
@@ -56,22 +61,24 @@ export class PostService {
     })
   }
 
-  async findById(id: string, viewerProfileId?: string) {
-    const include = viewerProfileId
-      ? postedByWithConversationInclude(viewerProfileId)
-      : postedByInclude
+  async findById(id: string) {
+    return this.prisma.post.findFirst({
+      where: { id, isDeleted: false },
+      ...postedByInclude,
+    })
+  }
 
+  async findByIdWithContext(
+    id: string,
+    viewerProfileId: string
+  ): Promise<PostWithProfileAndContext | null> {
     const post = await this.prisma.post.findFirst({
-      where: {
-        id,
-        isDeleted: false,
-        ...(viewerProfileId ? {} : { isVisible: true }),
-      },
-      ...include,
+      where: { id, isDeleted: false },
+      ...postedByWithConversationInclude(viewerProfileId),
     })
 
-    // If viewer is not the owner, only return visible posts
-    if (viewerProfileId !== post?.postedById && !post?.isVisible) {
+    // Non-owners can only see visible posts
+    if (post && post.postedById !== viewerProfileId && !post.isVisible) {
       return null
     }
 

--- a/apps/frontend/src/features/browse/composables/__tests__/useBrowseViewModel.spec.ts
+++ b/apps/frontend/src/features/browse/composables/__tests__/useBrowseViewModel.spec.ts
@@ -31,8 +31,16 @@ describe('useBrowseViewModel', () => {
         profiles: [],
         posts: [
           {
-            id: 'post1',
+            id: 'clpost00000000000000001',
             content: 'Cherry harvest',
+            type: 'OFFER',
+            createdAt: new Date().toISOString(),
+            updatedAt: new Date().toISOString(),
+            postedById: 'p1',
+            country: 'HU',
+            cityName: 'Bp',
+            lat: 47.1,
+            lon: 18.6,
             location: { lat: 47.1, lon: 18.6, country: 'HU', cityName: 'Bp' },
             postedBy: { id: 'p1', publicName: 'Mónika', profileImages: [] },
           },
@@ -61,12 +69,33 @@ describe('useBrowseViewModel', () => {
         profiles: [],
         posts: [
           {
-            id: 'post1',
+            id: 'clpost00000000000000001',
             content: 'Has loc',
+            type: 'OFFER',
+            createdAt: new Date().toISOString(),
+            updatedAt: new Date().toISOString(),
+            postedById: 'p1',
+            country: 'HU',
+            cityName: null,
+            lat: 47,
+            lon: 18,
             location: { lat: 47, lon: 18, country: 'HU' },
-            postedBy: null,
+            postedBy: { id: 'p1', publicName: 'Test', profileImages: [] },
           },
-          { id: 'post2', content: 'No loc', location: null, postedBy: null },
+          {
+            id: 'clpost00000000000000002',
+            content: 'No loc',
+            type: 'OFFER',
+            createdAt: new Date().toISOString(),
+            updatedAt: new Date().toISOString(),
+            postedById: 'p2',
+            country: null,
+            cityName: null,
+            lat: null,
+            lon: null,
+            location: null,
+            postedBy: { id: 'p2', publicName: 'Test2', profileImages: [] },
+          },
         ],
         tags: [],
       },
@@ -77,6 +106,6 @@ describe('useBrowseViewModel', () => {
 
     const vm = useBrowseViewModel()
     expect(vm.postPois.value).toHaveLength(1)
-    expect(vm.postPois.value[0]!.id).toBe('post1')
+    expect(vm.postPois.value[0]!.id).toBe('clpost00000000000000001')
   })
 })

--- a/apps/frontend/src/features/browse/stores/findProfileStore.ts
+++ b/apps/frontend/src/features/browse/stores/findProfileStore.ts
@@ -7,7 +7,7 @@ import type {
   GetMatchIdsResponse,
   GetPublicProfileResponse,
 } from '@zod/apiResponse.dto'
-import type { PublicPostWithProfile } from '@zod/post/post.dto'
+import { PublicPostWithProfileSchema } from '@zod/post/post.dto'
 import type { PublicTag } from '@zod/tag/tag.dto'
 import type { MapPoi } from '@/features/map/types/map.types'
 import { ClusterMapResponseSchema, type MapFeature } from '@shared/zod/map/cluster.dto'
@@ -52,12 +52,7 @@ function tagIdsParam(tagIds: string[]): string | undefined {
   return tagIds.length > 0 ? tagIds.join(',') : undefined
 }
 
-function sameViewport(
-  a: MapBounds | null,
-  aZoom: number,
-  b: MapBounds,
-  bZoom: number
-): boolean {
+function sameViewport(a: MapBounds | null, aZoom: number, b: MapBounds, bZoom: number): boolean {
   return (
     aZoom === bZoom &&
     a !== null &&
@@ -157,7 +152,9 @@ export const useFindProfileStore = defineStore('findProfile', {
       }
     },
 
-    async fetchPostsAndTags(bounds: MapBounds): Promise<void> {
+    async fetchPostsAndTags(
+      bounds: MapBounds
+    ): Promise<StoreResponse<StoreVoidSuccess | StoreError>> {
       if (postAbortController) postAbortController.abort()
       const controller = new AbortController()
       postAbortController = controller
@@ -171,9 +168,12 @@ export const useFindProfileStore = defineStore('findProfile', {
           })
         )
 
-        if (!res.data.success) return
+        if (!res.data.success) return storeError(new Error('Browse bounds request failed'))
 
-        this.postPois = (res.data.posts as PublicPostWithProfile[])
+        // TODO: move post → MapPoi mapping to the backend (browse/bounds endpoint)
+        // so the frontend receives a uniform MapPoi[] shape, same as profiles.
+        const posts = PublicPostWithProfileSchema.array().parse(res.data.posts)
+        this.postPois = posts
           .filter((p) => p.location?.lat != null && p.location?.lon != null)
           .map((p) => ({
             id: p.id,
@@ -185,8 +185,10 @@ export const useFindProfileStore = defineStore('findProfile', {
           }))
 
         this.availableTags = res.data.tags
-      } catch (err: any) {
-        if (err?.code === 'ERR_CANCELED') return
+        return storeSuccess()
+      } catch (error: any) {
+        if (error instanceof CanceledError) return storeSuccess()
+        return storeError(error, 'Failed to fetch posts and tags')
       } finally {
         if (postAbortController === controller) {
           this.isLoadingPosts = false
@@ -212,7 +214,9 @@ export const useFindProfileStore = defineStore('findProfile', {
       if (cached) return cached
 
       try {
-        const res = await api.get<GetPublicProfileResponse>(`/profiles/${profileId}`)
+        const res = await safeApiCall(() =>
+          api.get<GetPublicProfileResponse>(`/profiles/${profileId}`)
+        )
         const profile = res.data.profile
         if (popupCache.size >= POPUP_CACHE_MAX) {
           const firstKey = popupCache.keys().next().value!

--- a/apps/frontend/src/features/browse/stores/findProfileStore.ts
+++ b/apps/frontend/src/features/browse/stores/findProfileStore.ts
@@ -11,13 +11,7 @@ import { PublicPostWithProfileSchema } from '@zod/post/post.dto'
 import type { PublicTag } from '@zod/tag/tag.dto'
 import type { MapPoi } from '@/features/map/types/map.types'
 import { ClusterMapResponseSchema, type MapFeature } from '@shared/zod/map/cluster.dto'
-import {
-  storeSuccess,
-  storeError,
-  type StoreVoidSuccess,
-  type StoreResponse,
-  type StoreError,
-} from '@/store/helpers'
+import { storeSuccess, storeError, type StoreVoidSuccess, type StoreError } from '@/store/helpers'
 import { bus } from '@/lib/bus'
 import { useBrowseFiltersStore } from './browseFiltersStore'
 import type { MapBounds } from '@/features/map/types/map.types'
@@ -95,7 +89,7 @@ export const useFindProfileStore = defineStore('findProfile', {
     async findClustersForMapBounds(
       bounds: MapBounds,
       zoom: number
-    ): Promise<StoreResponse<StoreVoidSuccess | StoreError>> {
+    ): Promise<StoreVoidSuccess | StoreError> {
       // Supercluster requires integer zoom; Leaflet can report fractional values
       // during fitBounds or mid-animation.
       zoom = Math.round(zoom)
@@ -152,9 +146,7 @@ export const useFindProfileStore = defineStore('findProfile', {
       }
     },
 
-    async fetchPostsAndTags(
-      bounds: MapBounds
-    ): Promise<StoreResponse<StoreVoidSuccess | StoreError>> {
+    async fetchPostsAndTags(bounds: MapBounds): Promise<StoreVoidSuccess | StoreError> {
       if (postAbortController) postAbortController.abort()
       const controller = new AbortController()
       postAbortController = controller

--- a/apps/frontend/src/features/browse/views/BrowseProfiles.vue
+++ b/apps/frontend/src/features/browse/views/BrowseProfiles.vue
@@ -3,6 +3,8 @@ import { computed, onActivated, onMounted, provide, ref, toRef, watch } from 'vu
 import { storeToRefs } from 'pinia'
 import { useRouter } from 'vue-router'
 
+import { useToast } from 'vue-toastification'
+import { useI18n } from 'vue-i18n'
 import { useBootstrap } from '@/lib/bootstrap'
 import { useOwnerProfileStore } from '@/features/myprofile/stores/ownerProfileStore'
 import { useBrowseViewModel } from '../composables/useBrowseViewModel'
@@ -69,6 +71,8 @@ provide('viewerProfile', toRef(viewerProfile))
 
 // ── Route-driven detail panel ──────────────────────────────────────
 const router = useRouter()
+const toast = useToast()
+const { t } = useI18n()
 const ownerProfileStore = useOwnerProfileStore()
 const postStore = usePostStore()
 
@@ -103,6 +107,10 @@ watch(
       const result = await postStore.fetchPublicPost(d.id)
       if (result.success && result.data) {
         panel.show(PostFullView, { post: result.data.post })
+      } else {
+        toast.error(t('posts.error_load'))
+        panel.close()
+        router.replace({ name: 'Browse' })
       }
     }
   },

--- a/apps/frontend/src/features/browse/views/BrowseProfiles.vue
+++ b/apps/frontend/src/features/browse/views/BrowseProfiles.vue
@@ -24,7 +24,7 @@ import MapIcon from '@/features/posts/components/MapIcon.vue'
 import PostMapPopup from '@/features/posts/components/PostMapPopup.vue'
 import PostFullView from '@/features/posts/components/PostFullView.vue'
 import OwnerDrawerControls from '../components/OwnerDrawerControls.vue'
-import type { PublicPostWithProfile } from '@zod/post/post.dto'
+import { usePostStore } from '@/features/posts/stores/postStore'
 import type { GeoPoint } from '@zod/dto/location.dto'
 
 // Component name must be 'AppShell' for KeepAlive to identify it correctly
@@ -70,6 +70,7 @@ provide('viewerProfile', toRef(viewerProfile))
 // ── Route-driven detail panel ──────────────────────────────────────
 const router = useRouter()
 const ownerProfileStore = useOwnerProfileStore()
+const postStore = usePostStore()
 
 const { detail } = useDetailRouteState()
 const panel = useDetailPanel()
@@ -90,16 +91,19 @@ watch(
 
 // Drive the global detail panel from the route.
 watch(
-  [detail, activePoi],
-  ([d, poi]) => {
+  detail,
+  async (d) => {
     if (!d) {
       panel.close()
       return
     }
     if (d.type === 'profile') {
       panel.show(PublicProfileView, { profileId: d.id })
-    } else if (d.type === 'post' && poi) {
-      panel.show(PostFullView, { post: poi.source as PublicPostWithProfile })
+    } else if (d.type === 'post') {
+      const result = await postStore.fetchPublicPost(d.id)
+      if (result.success && result.data) {
+        panel.show(PostFullView, { post: result.data.post })
+      }
     }
   },
   { immediate: true }

--- a/apps/frontend/src/features/browse/views/BrowseProfiles.vue
+++ b/apps/frontend/src/features/browse/views/BrowseProfiles.vue
@@ -108,7 +108,7 @@ watch(
       if (result.success && result.data) {
         panel.show(PostFullView, { post: result.data.post })
       } else {
-        toast.error(t('posts.error_load'))
+        toast.error(t('posts.messages.error_load'))
         panel.close()
         router.replace({ name: 'Browse' })
       }

--- a/apps/frontend/src/features/browse/views/__tests__/BrowseProfiles.spec.ts
+++ b/apps/frontend/src/features/browse/views/__tests__/BrowseProfiles.spec.ts
@@ -95,6 +95,13 @@ vi.mock('@/features/browse/stores/findProfileStore', () => ({
   }),
 }))
 
+vi.mock('@/features/posts/stores/postStore', () => ({
+  usePostStore: () => ({
+    fetchPublicPost: vi.fn().mockResolvedValue({ success: false }),
+    fetchOwnerPost: vi.fn().mockResolvedValue({ success: false }),
+  }),
+}))
+
 vi.mock('@/assets/icons/interface/target-2.svg', () => ({
   default: { template: '<svg class="icon-target" />' },
 }))

--- a/apps/frontend/src/features/messaging/components/ContactFormPanel.vue
+++ b/apps/frontend/src/features/messaging/components/ContactFormPanel.vue
@@ -42,9 +42,10 @@ const sentMessages = ref<MessageDTO[]>([])
 
 onMounted(async () => {
   if (!isWaitingForReply || !props.recipientProfile.conversationId) return
-  sentMessages.value = await messageStore.fetchMessagesForConversation(
-    props.recipientProfile.conversationId
-  )
+  const result = await messageStore.fetchMessages(props.recipientProfile.conversationId)
+  if (result.success && result.data) {
+    sentMessages.value = result.data.messages
+  }
 })
 
 const emit = defineEmits<{
@@ -134,9 +135,9 @@ defineExpose({
           class="mb-2"
         />
       </div>
-        <div class="form-hint  mb-3">
-          {{ $t('messaging.already_sent_waiting') }}
-        </div>
+      <div class="form-hint mb-3">
+        {{ $t('messaging.already_sent_waiting') }}
+      </div>
     </div>
 
     <!-- 3. Default: pre-send form -->

--- a/apps/frontend/src/features/messaging/components/ContactFormPanel.vue
+++ b/apps/frontend/src/features/messaging/components/ContactFormPanel.vue
@@ -1,12 +1,16 @@
 <script setup lang="ts">
-import { onBeforeUnmount, ref, useTemplateRef, watchEffect } from 'vue'
+import { onBeforeUnmount, onMounted, ref, useTemplateRef, watchEffect } from 'vue'
 import { useElementSize } from '@vueuse/core'
 
 import type { MessageRecipient } from '@zod/profile/profile.dto'
+import type { ConversationContext } from '@zod/interaction/interactionContext.dto'
+import type { MessageDTO } from '@zod/messaging/messaging.dto'
 
 import SendMessageForm from './SendMessageForm.vue'
+import MessageBubble from './MessageBubble.vue'
 import IconMessage from '@/assets/icons/interface/message.svg'
 import { useMessageSentState } from '@/features/publicprofile/composables/useMessageSentState'
+import { useMessageStore } from '../stores/messageStore'
 
 defineOptions({ name: 'ContactFormPanel' })
 
@@ -21,14 +25,27 @@ defineOptions({ name: 'ContactFormPanel' })
  * so sizing is dictated by the consumer — no `size` prop.
  */
 
-withDefaults(
+const props = withDefaults(
   defineProps<{
-    recipientProfile: MessageRecipient
+    recipientProfile: MessageRecipient & Partial<ConversationContext>
     showTags?: boolean
     noResize?: boolean
   }>(),
   { showTags: false, noResize: true }
 )
+
+const isWaitingForReply =
+  props.recipientProfile.initiated === true && props.recipientProfile.canMessage === false
+
+const messageStore = useMessageStore()
+const sentMessages = ref<MessageDTO[]>([])
+
+onMounted(async () => {
+  if (!isWaitingForReply || !props.recipientProfile.conversationId) return
+  sentMessages.value = await messageStore.fetchMessagesForConversation(
+    props.recipientProfile.conversationId
+  )
+})
 
 const emit = defineEmits<{
   (e: 'sent'): void
@@ -82,21 +99,9 @@ defineExpose({
     class="w-100 h-100 d-flex flex-column"
     :style="latchedHeight > 0 ? { minHeight: `${latchedHeight}px` } : undefined"
   >
+    <!-- 1. Transient success confirmation after a fresh send -->
     <div
-      v-if="!messageSent"
-      ref="formRef"
-    >
-      <SendMessageForm
-        ref="messageInput"
-        :recipient-profile="recipientProfile"
-        :conversation-id="null"
-        :show-tags="showTags"
-        :no-resize="noResize"
-        @message:sent="onMessageSent"
-      />
-    </div>
-    <div
-      v-else
+      v-if="messageSent"
       class="flex-grow-1 d-flex flex-column align-items-center justify-content-center text-success"
     >
       <div
@@ -111,6 +116,42 @@ defineExpose({
       <h1 class="text-center mb-0">
         {{ $t('messaging.message_sent_success') }}
       </h1>
+    </div>
+
+    <!-- 2. Waiting for reply — viewer already initiated contact -->
+    <div
+      v-else-if="isWaitingForReply"
+      class="flex-grow-1 d-flex flex-column align-items-center justify-content-center"
+    >
+      <div
+        v-if="sentMessages.length"
+        class="w-100 d-flex flex-column align-items-end px-2"
+      >
+        <MessageBubble
+          v-for="msg in sentMessages"
+          :key="msg.id"
+          :message="msg"
+          class="mb-2"
+        />
+      </div>
+        <div class="form-hint  mb-3">
+          {{ $t('messaging.already_sent_waiting') }}
+        </div>
+    </div>
+
+    <!-- 3. Default: pre-send form -->
+    <div
+      v-else
+      ref="formRef"
+    >
+      <SendMessageForm
+        ref="messageInput"
+        :recipient-profile="recipientProfile"
+        :conversation-id="null"
+        :show-tags="showTags"
+        :no-resize="noResize"
+        @message:sent="onMessageSent"
+      />
     </div>
   </div>
 </template>

--- a/apps/frontend/src/features/messaging/components/MessageBubble.vue
+++ b/apps/frontend/src/features/messaging/components/MessageBubble.vue
@@ -1,0 +1,54 @@
+<script setup lang="ts">
+import { type MessageDTO } from '@zod/messaging/messaging.dto'
+import VoiceMessage from './VoiceMessage.vue'
+import { renderMessage } from '@/lib/renderMessage'
+
+defineProps<{
+  message: MessageDTO
+}>()
+</script>
+
+<template>
+  <div
+    class="message-bubble text-wrap user-select-none"
+    :class="{
+      'bg-info align-self-start': !message.isMine,
+      'bg-secondary align-self-end': message.isMine,
+    }"
+  >
+    <!-- Voice message -->
+    <VoiceMessage
+      v-if="message.messageType === 'audio/voice' && message.attachment"
+      :attachment="message.attachment"
+      :is-mine="message.isMine"
+    />
+
+    <!-- Text message -->
+    <div
+      v-else
+      class="message-text"
+    >
+      <span v-html="renderMessage(message.content)" />
+    </div>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+.message-bubble {
+  max-width: 60%;
+  border-radius: 15px;
+  word-break: break-word;
+  padding: 0.25rem 0.5rem;
+  font-size: 0.9rem;
+  color: white;
+}
+
+.message-text p {
+  margin: 0 0 0 1rem;
+}
+
+.message-text :deep(a) {
+  color: inherit;
+  text-decoration: underline;
+}
+</style>

--- a/apps/frontend/src/features/messaging/components/MessageList.vue
+++ b/apps/frontend/src/features/messaging/components/MessageList.vue
@@ -1,8 +1,7 @@
 <script setup lang="ts">
 import { type MessageDTO } from '@zod/messaging/messaging.dto'
 import { nextTick, ref, watch } from 'vue'
-import VoiceMessage from './VoiceMessage.vue'
-import { renderMessage } from '@/lib/renderMessage'
+import MessageBubble from './MessageBubble.vue'
 
 const props = defineProps<{
   messages: MessageDTO[]
@@ -89,49 +88,11 @@ const handleScroll = () => {
     >
       {{ $t('messaging.loading_older_messages') }}
     </div>
-    <div
+    <MessageBubble
       v-for="msg in messages"
       :key="msg.id"
-      class="message mb-2 me-2 text-wrap animate__animated animate__zoomIn user-select-none"
-      :class="{
-        'bg-info align-self-start': !msg.isMine,
-        'bg-secondary align-self-end': msg.isMine,
-      }"
-    >
-      <!-- Voice message -->
-      <VoiceMessage
-        v-if="msg.messageType === 'audio/voice' && msg.attachment"
-        :attachment="msg.attachment"
-        :is-mine="msg.isMine"
-      />
-
-      <!-- Text message -->
-      <div
-        v-else
-        class="message-text"
-      >
-        <span v-html="renderMessage(msg.content)" />
-      </div>
-    </div>
+      :message="msg"
+      class="mb-2 me-2 animate__animated animate__zoomIn"
+    />
   </div>
 </template>
-
-<style lang="scss" scoped>
-.message {
-  max-width: 60%;
-  border-radius: 15px;
-  word-break: break-word;
-  padding: 0.25rem 0.5rem;
-  font-size: 0.9rem;
-  color: white;
-}
-
-.message-text p {
-  margin: 0 0 0 1rem;
-}
-
-.message-text :deep(a) {
-  color: inherit;
-  text-decoration: underline;
-}
-</style>

--- a/apps/frontend/src/features/messaging/components/SendMessageForm.vue
+++ b/apps/frontend/src/features/messaging/components/SendMessageForm.vue
@@ -20,6 +20,7 @@ import { useMessageStore } from '../stores/messageStore'
 const toast = useToast()
 
 const messageStore = useMessageStore()
+messageStore.error = null
 
 const props = withDefaults(
   defineProps<{

--- a/apps/frontend/src/features/messaging/components/__tests__/ContactFormPanel.spec.ts
+++ b/apps/frontend/src/features/messaging/components/__tests__/ContactFormPanel.spec.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { mount, flushPromises } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
 
 import type { MessageRecipient } from '@zod/profile/profile.dto'
 
@@ -46,6 +47,7 @@ const globalConfig = {
 
 describe('ContactFormPanel', () => {
   beforeEach(() => {
+    setActivePinia(createPinia())
     vi.useFakeTimers()
   })
 

--- a/apps/frontend/src/features/messaging/components/__tests__/ContactFormPanel.spec.ts
+++ b/apps/frontend/src/features/messaging/components/__tests__/ContactFormPanel.spec.ts
@@ -32,11 +32,29 @@ vi.mock('@/assets/icons/interface/message.svg', () => ({
   default: { template: '<span class="icon-message-stub" />' },
 }))
 
+vi.mock('@/features/messaging/components/MessageBubble.vue', () => ({
+  default: {
+    name: 'MessageBubble',
+    props: ['message'],
+    template: '<div class="message-bubble-stub">{{ message.content }}</div>',
+  },
+}))
+
 import ContactFormPanel from '../ContactFormPanel.vue'
+import { useMessageStore } from '../../stores/messageStore'
 
 const recipient = {
   id: 'recipient-1',
   publicName: 'Recipient',
+} as unknown as MessageRecipient
+
+const waitingRecipient = {
+  id: 'recipient-1',
+  publicName: 'Recipient',
+  initiated: true,
+  canMessage: false,
+  conversationId: 'conv-1',
+  haveConversation: false,
 } as unknown as MessageRecipient
 
 const globalConfig = {
@@ -75,6 +93,40 @@ describe('ContactFormPanel', () => {
 
     expect(wrapper.find('.send-message-form-stub').exists()).toBe(false)
     expect(wrapper.text()).toContain('messaging.message_sent_success')
+  })
+
+  it('renders waiting-for-reply state when initiated && !canMessage', async () => {
+    const store = useMessageStore()
+    vi.spyOn(store, 'fetchMessages').mockResolvedValue({
+      success: true,
+      data: {
+        messages: [
+          {
+            id: 'msg-1',
+            conversationId: 'conv-1',
+            senderId: 'me',
+            content: 'Hello!',
+            messageType: 'text/plain',
+            createdAt: new Date(),
+            sender: { id: 'me', publicName: 'Me', profileImages: [] },
+            isMine: true,
+          },
+        ],
+      },
+    } as any)
+
+    const wrapper = mount(ContactFormPanel, {
+      props: { recipientProfile: waitingRecipient },
+      global: globalConfig,
+    })
+
+    await flushPromises()
+
+    expect(wrapper.find('.send-message-form-stub').exists()).toBe(false)
+    expect(wrapper.text()).toContain('messaging.already_sent_waiting')
+    expect(wrapper.find('.message-bubble-stub').exists()).toBe(true)
+    expect(wrapper.text()).toContain('Hello!')
+    expect(wrapper.emitted('sent')).toBeUndefined()
   })
 
   it('emits `sent` after the 3s success window elapses', async () => {

--- a/apps/frontend/src/features/messaging/stores/messageStore.ts
+++ b/apps/frontend/src/features/messaging/stores/messageStore.ts
@@ -123,6 +123,28 @@ export const useMessageStore = defineStore('message', {
         })
     },
 
+    async fetchMessages(
+      conversationId: string,
+      options?: { take?: number; cursor?: string }
+    ): Promise<StoreResponse<{ messages: MessageInConversation[] }>> {
+      try {
+        const res = await safeApiCall(() =>
+          api.get<MessagesResponse>(`/messages/${conversationId}`, {
+            params: {
+              take: options?.take ?? 10,
+              ...(options?.cursor ? { cursor: options.cursor } : {}),
+            },
+          })
+        )
+        if (res.data.success) {
+          return storeSuccess({ messages: res.data.messages })
+        }
+        return storeError(new Error('Failed to fetch messages'))
+      } catch (error: any) {
+        return storeError(error, 'Failed to fetch messages')
+      }
+    },
+
     async fetchMessagesForConversation(
       conversationId: string,
       options?: { cursor?: string; append?: boolean }

--- a/apps/frontend/src/features/posts/components/PostFullView.vue
+++ b/apps/frontend/src/features/posts/components/PostFullView.vue
@@ -20,8 +20,6 @@ const emit = defineEmits<{
   (e: 'delete', post: PublicPostWithProfile | OwnerPost): void
 }>()
 
-
-
 const closeDetailPanel = inject<(() => void) | null>('detailPanelClose', null)
 const handleBack = () => {
   if (closeDetailPanel) closeDetailPanel()

--- a/apps/frontend/src/features/posts/stores/postStore.ts
+++ b/apps/frontend/src/features/posts/stores/postStore.ts
@@ -1,4 +1,5 @@
 import { defineStore } from 'pinia'
+import { CanceledError } from 'axios'
 import { api, safeApiCall } from '@/lib/api'
 import {
   PublicPostWithProfileSchema,
@@ -26,6 +27,7 @@ import { type PostTypeType } from '@zod/generated'
 import { storeSuccess, storeError, type StoreResponse } from '@/store/helpers'
 import type { MapBounds } from '@/features/map/types/map.types'
 
+let publicPostAbortController: AbortController | null = null
 const PublicPostWithProfileArraySchema = PublicPostWithProfileSchema.array()
 const OwnerPostArraySchema = OwnerPostSchema.array()
 type StorePostResponse = StoreResponse<{ post: OwnerPost }>
@@ -175,11 +177,18 @@ export const usePostStore = defineStore('posts', {
     },
 
     async fetchPublicPost(id: string): Promise<StoreResponse<{ post: PublicPostDetail }>> {
+      if (publicPostAbortController) publicPostAbortController.abort()
+      const controller = new AbortController()
+      publicPostAbortController = controller
+
       try {
-        const res = await safeApiCall(() => api.get<PublicPostDetailResponse>(`/posts/${id}`))
+        const res = await safeApiCall(() =>
+          api.get<PublicPostDetailResponse>(`/posts/${id}`, { signal: controller.signal })
+        )
         const post = PublicPostDetailSchema.parse(res.data.post)
         return storeSuccess({ post })
       } catch (error: any) {
+        if (error instanceof CanceledError) return storeSuccess()
         return storeError(error, 'Failed to fetch post')
       }
     },

--- a/apps/frontend/src/features/posts/stores/postStore.ts
+++ b/apps/frontend/src/features/posts/stores/postStore.ts
@@ -17,6 +17,7 @@ import type {
   PostsResponse,
   MyPostsResponse,
   PostResponse,
+  PublicPostDetailResponse,
   CreatePostResponse,
   UpdatePostResponse,
   DeletePostResponse,
@@ -175,7 +176,7 @@ export const usePostStore = defineStore('posts', {
 
     async fetchPublicPost(id: string): Promise<StoreResponse<{ post: PublicPostDetail }>> {
       try {
-        const res = await safeApiCall(() => api.get<PostResponse>(`/posts/${id}`))
+        const res = await safeApiCall(() => api.get<PublicPostDetailResponse>(`/posts/${id}`))
         const post = PublicPostDetailSchema.parse(res.data.post)
         return storeSuccess({ post })
       } catch (error: any) {

--- a/apps/frontend/src/features/posts/stores/postStore.ts
+++ b/apps/frontend/src/features/posts/stores/postStore.ts
@@ -2,8 +2,10 @@ import { defineStore } from 'pinia'
 import { api, safeApiCall } from '@/lib/api'
 import {
   PublicPostWithProfileSchema,
+  PublicPostDetailSchema,
   OwnerPostSchema,
   type PublicPostWithProfile,
+  type PublicPostDetail,
   type OwnerPost,
   type CreatePostPayload,
   type UpdatePostPayload,
@@ -160,11 +162,21 @@ export const usePostStore = defineStore('posts', {
       }
     },
 
-    async fetchPost(id: string): Promise<StorePostResponse> {
+    async fetchOwnerPost(id: string): Promise<StorePostResponse> {
       try {
         const res = await safeApiCall(() => api.get<PostResponse>(`/posts/${id}`))
         const post = OwnerPostSchema.parse(res.data.post)
         this.currentPost = post
+        return storeSuccess({ post })
+      } catch (error: any) {
+        return storeError(error, 'Failed to fetch post')
+      }
+    },
+
+    async fetchPublicPost(id: string): Promise<StoreResponse<{ post: PublicPostDetail }>> {
+      try {
+        const res = await safeApiCall(() => api.get<PostResponse>(`/posts/${id}`))
+        const post = PublicPostDetailSchema.parse(res.data.post)
         return storeSuccess({ post })
       } catch (error: any) {
         return storeError(error, 'Failed to fetch post')

--- a/apps/frontend/src/store/helpers.ts
+++ b/apps/frontend/src/store/helpers.ts
@@ -59,6 +59,11 @@ export function storeError(error: unknown, fallbackMessage = 'Request failed'): 
     }
   }
 
+  // Handle plain Error instances
+  else if (error instanceof Error) {
+    message = error.message
+  }
+
   //   // TODO hook this up to a global debug flag
   if (__APP_CONFIG__.NODE_ENV === 'development') console.error(message, status, message)
 

--- a/packages/shared/i18n/en.json
+++ b/packages/shared/i18n/en.json
@@ -191,6 +191,7 @@
     "welcome_message": "Welcome to {siteName}!\nI am Mookie, your host.\nThis is a place for us to connect, meet new people, and find like-minded souls. I hope you enjoy your stay here.\nHappy connecting!\n- Mookie"
   },
   "messaging": {
+    "already_sent_waiting": "You have already sent them a message. Once they answer, you can continue the conversation.",
     "block_member": "Block member",
     "block_report_unmatch": "Block/report/unmatch",
     "block_user_ok": "Block {name}",

--- a/packages/shared/i18n/hu.json
+++ b/packages/shared/i18n/hu.json
@@ -195,6 +195,7 @@
     "welcome_message": "Üdv a {siteName} oldalon !\nMookie vagyok, a házigazda.\nEz egy olyan hely, ahol kapcsolatba léphetünk, új emberekkel találkozhatunk, és megtalálhatjuk a hasonlóan gondolkodó lelkeket. Remélem, jól fogod érezni magad itt.\nSzép kapcsolódásokat!\n\n- Mookie"
   },
   "messaging": {
+    "already_sent_waiting": "Már küldtél nekik üzenetet. Amint válaszolnak, folytathatod a beszélgetést.",
     "block_member": "Tag letiltása",
     "block_report_unmatch": "Letiltás/jelentés",
     "block_user_ok": "{name} letiltása",

--- a/packages/shared/zod/apiResponse.dto.ts
+++ b/packages/shared/zod/apiResponse.dto.ts
@@ -29,7 +29,7 @@ import {
   type ReceivedLike,
 } from './interaction/interaction.dto'
 
-import type { OwnerPost, PublicPostWithProfile } from '@zod/post/post.dto'
+import type { OwnerPost, PublicPostWithProfile, PublicPostDetail } from '@zod/post/post.dto'
 
 export type GetProfileSummariesResponse = ApiSuccess<{ profiles: ProfileSummary[] }>
 
@@ -102,6 +102,7 @@ export type CaptchaChallengeResponse = ApiSuccess<any> // altcha challenge shape
 export type PostsResponse = ApiSuccess<{ posts: PublicPostWithProfile[] }>
 export type MyPostsResponse = ApiSuccess<{ posts: OwnerPost[] }>
 export type PostResponse = ApiSuccess<{ post: OwnerPost }>
+export type PublicPostDetailResponse = ApiSuccess<{ post: PublicPostDetail }>
 export type CreatePostResponse = ApiSuccess<{ post: OwnerPost }>
 export type UpdatePostResponse = ApiSuccess<{ post: OwnerPost }>
 export type DeletePostResponse = ApiSuccess<{}>

--- a/packages/shared/zod/post/post.dto.ts
+++ b/packages/shared/zod/post/post.dto.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod'
 import { PostSchema, PostTypeSchema } from '../generated'
 import { ProfileSummarySchema } from '../profile/profile.dto'
+import { ConversationContextSchema } from '../interaction/interactionContext.dto'
 import { DbMinimalProfileSchema } from '../profile/profile.db'
 import { LocationSchema } from '@zod/dto/location.dto'
 
@@ -52,6 +53,15 @@ export const PublicPostWithProfileSchema = PublicPostSchema.extend({
   isOwn: z.boolean().default(false),
 })
 export type PublicPostWithProfile = z.infer<typeof PublicPostWithProfileSchema>
+
+// Detail view for a single post (GET /posts/:id for non-owners)
+// Extends PublicPostWithProfile with conversation context on postedBy
+export const PublicPostDetailSchema = PublicPostSchema.extend({
+  postedBy: ProfileSummarySchema.merge(ConversationContextSchema),
+  location: LocationSchema.nullable().optional(),
+  isOwn: z.boolean().default(false),
+})
+export type PublicPostDetail = z.infer<typeof PublicPostDetailSchema>
 
 // Create post payload (from client to API)
 export const CreatePostPayloadSchema = z.object({

--- a/packages/shared/zod/post/post.dto.ts
+++ b/packages/shared/zod/post/post.dto.ts
@@ -56,10 +56,8 @@ export type PublicPostWithProfile = z.infer<typeof PublicPostWithProfileSchema>
 
 // Detail view for a single post (GET /posts/:id for non-owners)
 // Extends PublicPostWithProfile with conversation context on postedBy
-export const PublicPostDetailSchema = PublicPostSchema.extend({
+export const PublicPostDetailSchema = PublicPostWithProfileSchema.extend({
   postedBy: ProfileSummarySchema.merge(ConversationContextSchema),
-  location: LocationSchema.nullable().optional(),
-  isOwn: z.boolean().default(false),
 })
 export type PublicPostDetail = z.infer<typeof PublicPostDetailSchema>
 


### PR DESCRIPTION
## Summary
- **ContactFormPanel** now shows a "waiting for reply" state (sent message + informational notice) when the viewer has already initiated contact (`initiated && !canMessage`), preventing the confusing 403 error on duplicate sends (#1279)
- **Backend `GET /posts/:id`** returns conversation context (`initiated`, `canMessage`, `conversationId`) on `postedBy` for non-owner viewers via new `PublicPostDetailSchema`
- **Extracted `MessageBubble`** component from `MessageList` for DRY reuse of message rendering (voice + text)
- **Fixed post detail panel** not opening on direct `/posts/:postId` navigation (always fetches via `fetchPublicPost` now)
- **Fixed `LocalizedTimeAgo`** prop type warning by parsing browse/bounds posts through Zod (`z.coerce.date()`)
- **Fixed stale `messageStore.error`** persisting across navigations by clearing on `SendMessageForm` mount
- **Minor improvements:** `findProfileStore.fetchPostsAndTags` now uses `storeError`/`storeSuccess` pattern, `fetchProfileForPopup` wrapped in `safeApiCall`, renamed `fetchPost` → `fetchOwnerPost`

## Test plan
- [ ] Navigate directly to `/posts/:postId` — detail panel opens with correct public view (profile thumbnail, message button)
- [ ] Click message icon on a post where contact was already initiated — shows "waiting for reply" state with sent message bubble, no error overlay
- [ ] Click message icon on a post with no prior contact — shows normal send form
- [ ] Send a message successfully — shows success confirmation, then closes
- [ ] Open post detail via map marker click — same behavior as direct URL navigation
- [ ] Verify no `LocalizedTimeAgo` prop warnings in console
- [ ] Inbox messaging still works (MessageList uses extracted MessageBubble)

Closes #1279

🤖 Generated with [Claude Code](https://claude.com/claude-code)