### PR TITLE
feat(browse): unify map endpoints into single clustered response

### DIFF
--- a/.changeset/unified-map-clusters.md
+++ b/.changeset/unified-map-clusters.md
@@ -1,0 +1,6 @@
+---
+'@opencupid/frontend': minor
+'@opencupid/backend': minor
+---
+
+Unify map browse endpoints into single clustered response with mixed profile+post clustering (#1284)

--- a/apps/backend/src/__tests__/routes/browse.route.spec.ts
+++ b/apps/backend/src/__tests__/routes/browse.route.spec.ts
@@ -1,14 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { MockFastify, MockReply } from '../../test-utils/fastify'
 
-const mockFindInBounds = vi.fn()
-
-vi.mock('@/services/browse.service', () => ({
-  BrowseService: {
-    getInstance: () => ({ findInBounds: mockFindInBounds }),
-  },
-}))
-
 import browseRoutes from '../../api/routes/browse.route'
 
 let fastify: MockFastify
@@ -26,68 +18,20 @@ beforeEach(async () => {
   await browseRoutes(fastify as any, {})
 })
 
-describe('GET /bounds', () => {
-  it('returns 400 when bounds params are missing', async () => {
+// ────────────────────────────────────────────────────────────────────
+// Deprecated shim — /browse/bounds replaced by /find/social/map/clusters
+// ────────────────────────────────────────────────────────────────────
+describe('GET /bounds (deprecated shim)', () => {
+  it('returns a static empty response', async () => {
     const handler = fastify.routes['GET /bounds']
-    await handler({ query: {}, session: mockSession, log: { error: vi.fn() } } as any, reply as any)
-    expect(reply.statusCode).toBe(400)
-    expect(reply.payload.success).toBe(false)
-  })
+    await handler({ session: mockSession } as any, reply as any)
 
-  it('returns 400 when any bound param is non-numeric', async () => {
-    const handler = fastify.routes['GET /bounds']
-    await handler(
-      {
-        query: { south: 'abc', north: '47.5', west: '18.0', east: '19.0' },
-        session: mockSession,
-        log: { error: vi.fn() },
-      } as any,
-      reply as any
-    )
-    expect(reply.statusCode).toBe(400)
-  })
-
-  it('returns profiles, posts and tags for valid bounds', async () => {
-    mockFindInBounds.mockResolvedValue({
-      profiles: [{ id: 'p1', publicName: 'Mónika', tags: [] }],
-      posts: [{ id: 'post1', title: 'Cherry harvest' }],
-      tags: [{ id: 't1', name: 'Biokert', slug: 'biokert' }],
-    })
-
-    const handler = fastify.routes['GET /bounds']
-    await handler(
-      {
-        query: { south: '46.5', north: '47.5', west: '18.0', east: '19.0' },
-        session: mockSession,
-        log: { error: vi.fn() },
-      } as any,
-      reply as any
-    )
     expect(reply.statusCode).toBe(200)
-    expect(reply.payload.success).toBe(true)
-    expect(reply.payload.profiles).toHaveLength(1)
-    expect(reply.payload.posts).toHaveLength(1)
-    expect(reply.payload.tags).toHaveLength(1)
-    expect(mockFindInBounds).toHaveBeenCalledWith(
-      'profile-123',
-      { south: 46.5, north: 47.5, west: 18.0, east: 19.0 },
-      'en'
-    )
-  })
-
-  it('returns 500 when service throws', async () => {
-    mockFindInBounds.mockRejectedValue(new Error('DB error'))
-
-    const handler = fastify.routes['GET /bounds']
-    await handler(
-      {
-        query: { south: '46.5', north: '47.5', west: '18.0', east: '19.0' },
-        session: mockSession,
-        log: { error: vi.fn() },
-      } as any,
-      reply as any
-    )
-    expect(reply.statusCode).toBe(500)
-    expect(reply.payload.success).toBe(false)
+    expect(reply.payload).toEqual({
+      success: true,
+      profiles: [],
+      posts: [],
+      tags: [],
+    })
   })
 })

--- a/apps/backend/src/__tests__/routes/findProfile.cluster.route.spec.ts
+++ b/apps/backend/src/__tests__/routes/findProfile.cluster.route.spec.ts
@@ -35,6 +35,12 @@ vi.mock('../../api/mappers/profile.mappers', () => ({
   })),
 }))
 
+vi.mock('../../api/mappers/tag.mappers', () => ({
+  mapProfileTagsTranslated: vi.fn((tags: any[]) =>
+    tags.map((t: any) => ({ id: t.id, name: t.name, slug: t.slug }))
+  ),
+}))
+
 import findProfileRoutes from '../../api/routes/findProfile.route'
 import { MockFastify, MockReply } from '../../test-utils/fastify'
 import { ClusterService } from '@/services/cluster.service'
@@ -73,15 +79,28 @@ describe('GET /social/map/clusters', () => {
 
   const validQuery = { south: '45.0', north: '48.0', west: '16.0', east: '23.0', zoom: '10' }
 
-  it('returns features for valid bounds and zoom', async () => {
-    const mockFeatures = [{ type: 'Feature', geometry: { type: 'Point', coordinates: [19, 47] } }]
-    mockGetOrBuildClusters.mockResolvedValue(mockFeatures)
+  it('returns features and tags for valid bounds and zoom', async () => {
+    const mockFeatures = [
+      {
+        type: 'point',
+        kind: 'profile',
+        id: 'p1',
+        lat: 47,
+        lon: 19,
+        publicName: 'Alice',
+        image: null,
+        highlighted: false,
+      },
+    ]
+    const mockTags = [{ id: 't1', name: 'Bio', slug: 'bio' }]
+    mockGetOrBuildClusters.mockResolvedValue({ features: mockFeatures, tags: mockTags })
 
     await handler()({ session: mockSession, query: validQuery, log: { error: vi.fn() } }, reply)
 
     expect(reply.statusCode).toBe(200)
     expect(reply.payload.success).toBe(true)
     expect(reply.payload.features).toEqual(mockFeatures)
+    expect(reply.payload.tags).toBeDefined()
     expect(mockGetOrBuildClusters).toHaveBeenCalledWith(
       'profile-123',
       [16.0, 45.0, 23.0, 48.0],
@@ -91,7 +110,7 @@ describe('GET /social/map/clusters', () => {
   })
 
   it('forwards parsed tagIds to the cluster service', async () => {
-    mockGetOrBuildClusters.mockResolvedValue([])
+    mockGetOrBuildClusters.mockResolvedValue({ features: [], tags: [] })
 
     await handler()(
       {
@@ -139,7 +158,18 @@ describe('GET /social/map/clusters/leaves', () => {
   const handler = () => fastify.routes['GET /social/map/clusters/leaves']
 
   it('returns features for valid clusterId', async () => {
-    const mockFeatures = [{ type: 'Feature', geometry: { type: 'Point', coordinates: [19, 47] } }]
+    const mockFeatures = [
+      {
+        type: 'point',
+        kind: 'profile',
+        id: 'p1',
+        lat: 47,
+        lon: 19,
+        publicName: 'Alice',
+        image: null,
+        highlighted: false,
+      },
+    ]
     mockGetLeaves.mockReturnValue(mockFeatures)
 
     await handler()(

--- a/apps/backend/src/__tests__/routes/findProfile.route.spec.ts
+++ b/apps/backend/src/__tests__/routes/findProfile.route.spec.ts
@@ -1,13 +1,12 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 
-const mockFindSocialProfilesInBounds = vi.fn()
 const mockFindMutualMatchIds = vi.fn()
 const mockFindNewProfilesAnywhere = vi.fn()
 
 vi.mock('@/services/profileMatch.service', () => ({
   ProfileMatchService: {
     getInstance: () => ({
-      findSocialProfilesInBounds: mockFindSocialProfilesInBounds,
+      findSocialProfilesInBounds: vi.fn(),
       findMutualMatchIds: mockFindMutualMatchIds,
       findNewProfilesAnywhere: mockFindNewProfilesAnywhere,
     }),
@@ -17,7 +16,7 @@ vi.mock('@/services/profileMatch.service', () => ({
 vi.mock('@/services/cluster.service', () => ({
   ClusterService: {
     getInstance: () => ({
-      getOrBuildClusters: vi.fn(),
+      getOrBuildClusters: vi.fn().mockResolvedValue({ features: [], tags: [] }),
       getLeaves: vi.fn(),
     }),
   },
@@ -45,6 +44,12 @@ vi.mock('../../api/mappers/profile.mappers', () => ({
   })),
 }))
 
+vi.mock('../../api/mappers/tag.mappers', () => ({
+  mapProfileTagsTranslated: vi.fn((tags: any[]) =>
+    tags.map((t: any) => ({ id: t.id, name: t.name, slug: t.slug }))
+  ),
+}))
+
 import findProfileRoutes from '../../api/routes/findProfile.route'
 import { MockFastify, MockReply } from '../../test-utils/fastify'
 
@@ -67,164 +72,17 @@ afterEach(() => {
   vi.clearAllMocks()
 })
 
-describe('GET /social/map/bounds', () => {
+// ────────────────────────────────────────────────────────────────────
+// Deprecated shim — /social/map/bounds replaced by /social/map/clusters
+// ────────────────────────────────────────────────────────────────────
+describe('GET /social/map/bounds (deprecated shim)', () => {
   const handler = () => fastify.routes['GET /social/map/bounds']
 
-  it('returns profiles within bounds', async () => {
-    const mockProfiles = [
-      {
-        id: 'p1',
-        publicName: 'Alice',
-        lat: 47.5,
-        lon: 19.0,
-        country: 'HU',
-        cityName: 'Budapest',
-        profileImages: [],
-        tags: [],
-      },
-    ]
-    mockFindSocialProfilesInBounds.mockResolvedValue(mockProfiles)
-
-    await handler()(
-      {
-        session: mockSession,
-        query: { south: '45.0', north: '48.0', west: '16.0', east: '23.0' },
-        log: { error: vi.fn() },
-      },
-      reply
-    )
+  it('returns a static empty profiles array', async () => {
+    await handler()({ session: mockSession }, reply)
 
     expect(reply.statusCode).toBe(200)
-    expect(reply.payload.success).toBe(true)
-    expect(reply.payload.profiles).toHaveLength(1)
-    expect(mockFindSocialProfilesInBounds).toHaveBeenCalledWith(
-      'profile-123',
-      { south: 45.0, north: 48.0, west: 16.0, east: 23.0 },
-      [],
-      [{ updatedAt: 'desc' }]
-    )
-  })
-
-  it('parses comma-separated tagIds and forwards them to the service', async () => {
-    mockFindSocialProfilesInBounds.mockResolvedValue([])
-
-    await handler()(
-      {
-        session: mockSession,
-        query: {
-          south: '45.0',
-          north: '48.0',
-          west: '16.0',
-          east: '23.0',
-          tagIds: 'cabcdef01,cabcdef02,cabcdef03',
-        },
-        log: { error: vi.fn() },
-      },
-      reply
-    )
-
-    expect(reply.statusCode).toBe(200)
-    expect(mockFindSocialProfilesInBounds).toHaveBeenCalledWith(
-      'profile-123',
-      { south: 45.0, north: 48.0, west: 16.0, east: 23.0 },
-      ['cabcdef01', 'cabcdef02', 'cabcdef03'],
-      [{ updatedAt: 'desc' }]
-    )
-  })
-
-  it('treats an empty tagIds string as no filter', async () => {
-    mockFindSocialProfilesInBounds.mockResolvedValue([])
-
-    await handler()(
-      {
-        session: mockSession,
-        query: { south: '45.0', north: '48.0', west: '16.0', east: '23.0', tagIds: '' },
-        log: { error: vi.fn() },
-      },
-      reply
-    )
-
-    expect(mockFindSocialProfilesInBounds).toHaveBeenCalledWith(
-      'profile-123',
-      expect.any(Object),
-      [],
-      expect.any(Array)
-    )
-  })
-
-  it('returns 400 when more than 5 tagIds are supplied', async () => {
-    await handler()(
-      {
-        session: mockSession,
-        query: {
-          south: '45.0',
-          north: '48.0',
-          west: '16.0',
-          east: '23.0',
-          tagIds: 'cabcdef01,cabcdef02,cabcdef03,cabcdef04,cabcdef05,cabcdef06',
-        },
-        log: { error: vi.fn() },
-      },
-      reply
-    )
-
-    expect(reply.statusCode).toBe(400)
-    expect(mockFindSocialProfilesInBounds).not.toHaveBeenCalled()
-  })
-
-  it('returns 400 when a tagId fails the shape check', async () => {
-    await handler()(
-      {
-        session: mockSession,
-        query: {
-          south: '45.0',
-          north: '48.0',
-          west: '16.0',
-          east: '23.0',
-          tagIds: "valid12345,'; DROP TABLE profile; --",
-        },
-        log: { error: vi.fn() },
-      },
-      reply
-    )
-
-    expect(reply.statusCode).toBe(400)
-    expect(mockFindSocialProfilesInBounds).not.toHaveBeenCalled()
-  })
-
-  it('returns 400 when bounds params are missing', async () => {
-    await handler()({ session: mockSession, query: {}, log: { error: vi.fn() } }, reply)
-
-    expect(reply.statusCode).toBe(400)
-    expect(mockFindSocialProfilesInBounds).not.toHaveBeenCalled()
-  })
-
-  it('returns 403 when social is not active', async () => {
-    await handler()(
-      {
-        session: { ...mockSession, profile: { ...mockSession.profile, isSocialActive: false } },
-        query: { south: '45.0', north: '48.0', west: '16.0', east: '23.0' },
-      },
-      reply
-    )
-
-    expect(reply.statusCode).toBe(403)
-    expect(mockFindSocialProfilesInBounds).not.toHaveBeenCalled()
-  })
-
-  it('returns 500 on service error', async () => {
-    mockFindSocialProfilesInBounds.mockRejectedValue(new Error('DB error'))
-
-    await handler()(
-      {
-        session: mockSession,
-        query: { south: '45.0', north: '48.0', west: '16.0', east: '23.0' },
-        log: { error: vi.fn() },
-      },
-      reply
-    )
-
-    expect(reply.statusCode).toBe(500)
+    expect(reply.payload).toEqual({ success: true, profiles: [] })
   })
 })
 

--- a/apps/backend/src/__tests__/services/cluster.service.spec.ts
+++ b/apps/backend/src/__tests__/services/cluster.service.spec.ts
@@ -86,7 +86,9 @@ describe('ClusterService', () => {
   let service: ClusterService
 
   beforeEach(() => {
-    service = new ClusterService()
+    // Reset singleton so each test gets a fresh instance
+    ;(ClusterService as any).instance = undefined
+    service = ClusterService.getInstance({} as any)
     vi.clearAllMocks()
     mockFindAllWithLocation.mockResolvedValue([])
   })

--- a/apps/backend/src/__tests__/services/cluster.service.spec.ts
+++ b/apps/backend/src/__tests__/services/cluster.service.spec.ts
@@ -12,6 +12,16 @@ vi.mock('@/services/profileMatch.service', () => ({
   },
 }))
 
+const mockFindAllWithLocation = vi.fn()
+
+vi.mock('@/services/post.service', () => ({
+  PostService: {
+    getInstance: () => ({
+      findAllWithLocation: mockFindAllWithLocation,
+    }),
+  },
+}))
+
 vi.mock('@/lib/appconfig', () => ({
   appConfig: {},
 }))
@@ -27,6 +37,7 @@ vi.mock('@/services/image.service', () => ({
 }))
 
 import { ClusterService } from '@/services/cluster.service'
+import type { PointFeature } from '@shared/zod/map/cluster.dto'
 
 const makeProfile = (id: string, lat: number, lon: number, name = 'User') => ({
   id,
@@ -43,7 +54,32 @@ const makeProfile = (id: string, lat: number, lon: number, name = 'User') => ({
       storagePath: `images/${id}/photo`,
     },
   ],
-  tags: [],
+  tags: [
+    {
+      id: `tag-${id}`,
+      slug: `tag-${id}`,
+      name: `Tag ${id}`,
+      translations: [{ name: `Tag ${id}`, locale: 'en' }],
+    },
+  ],
+})
+
+const makePost = (id: string, lat: number, lon: number, content = 'A post') => ({
+  id,
+  content,
+  type: 'OFFER',
+  lat,
+  lon,
+  postedBy: {
+    publicName: 'PostAuthor',
+    profileImages: [
+      {
+        id: `post-img-${id}`,
+        blurhash: 'LBG^x3',
+        storagePath: `images/post-${id}/photo`,
+      },
+    ],
+  },
 })
 
 describe('ClusterService', () => {
@@ -52,33 +88,54 @@ describe('ClusterService', () => {
   beforeEach(() => {
     service = new ClusterService()
     vi.clearAllMocks()
+    mockFindAllWithLocation.mockResolvedValue([])
   })
 
   describe('buildIndex', () => {
-    it('builds a supercluster index from filtered profiles', async () => {
+    it('builds a supercluster index from profiles and posts', async () => {
       const profiles = [
         makeProfile('p1', 47.5, 19.0, 'Alice'),
         makeProfile('p2', 48.2, 16.3, 'Bob'),
         makeProfile('p3', 47.6, 19.1, 'Carol'),
       ]
+      const posts = [makePost('post1', 47.55, 19.05)]
       mockFindSocialProfilesWithLocation.mockResolvedValue(profiles)
       mockFindMutualMatchIds.mockResolvedValue(['p2'])
+      mockFindAllWithLocation.mockResolvedValue(posts)
 
       await service.buildIndex('viewer-1')
 
-      const features = service.getClusters('viewer-1', [16.0, 47.0, 20.0, 49.0], 12)
-      expect(features).toHaveLength(3)
+      const { features } = service.getClusters('viewer-1', [16.0, 47.0, 20.0, 49.0], 12)
+      expect(features).toHaveLength(4)
 
-      const points = features.filter((f) => f.type === 'point')
-      expect(points).toHaveLength(3)
+      const isPoint = (f: any): f is PointFeature => f.type === 'point'
+      const profilePoints = features.filter(isPoint).filter((f) => f.kind === 'profile')
+      expect(profilePoints).toHaveLength(3)
 
-      const bob = points.find((p) => p.id === 'p2')
+      const postPoints = features.filter(isPoint).filter((f) => f.kind === 'post')
+      expect(postPoints).toHaveLength(1)
+      expect(postPoints[0]!.postContent).toBe('A post')
+      expect(postPoints[0]!.postType).toBe('OFFER')
+
+      const bob = profilePoints.find((p) => p.id === 'p2')
       expect(bob).toBeDefined()
       expect(bob!.highlighted).toBe(true)
       expect(bob!.publicName).toBe('Bob')
 
-      const alice = points.find((p) => p.id === 'p1')
+      const alice = profilePoints.find((p) => p.id === 'p1')
       expect(alice!.highlighted).toBe(false)
+    })
+
+    it('derives tags from profiles and returns them', async () => {
+      const profiles = [makeProfile('p1', 47.5, 19.0), makeProfile('p2', 48.2, 16.3)]
+      mockFindSocialProfilesWithLocation.mockResolvedValue(profiles)
+      mockFindMutualMatchIds.mockResolvedValue([])
+
+      await service.buildIndex('viewer-1')
+
+      const { tags } = service.getClusters('viewer-1', [16.0, 47.0, 20.0, 49.0], 12)
+      expect(tags).toHaveLength(2)
+      expect(tags.map((t) => t.id).sort()).toEqual(['tag-p1', 'tag-p2'])
     })
 
     it('produces clusters at low zoom levels', async () => {
@@ -88,7 +145,7 @@ describe('ClusterService', () => {
 
       await service.buildIndex('viewer-1')
 
-      const features = service.getClusters('viewer-1', [-180, -90, 180, 90], 2)
+      const { features } = service.getClusters('viewer-1', [-180, -90, 180, 90], 2)
       const clusters = features.filter((f) => f.type === 'cluster')
       expect(clusters.length).toBeGreaterThanOrEqual(1)
 
@@ -99,12 +156,13 @@ describe('ClusterService', () => {
   })
 
   describe('getClusters', () => {
-    it('returns empty array when no index exists and builds on demand', async () => {
+    it('returns empty features and tags when no index exists and builds on demand', async () => {
       mockFindSocialProfilesWithLocation.mockResolvedValue([])
       mockFindMutualMatchIds.mockResolvedValue([])
 
-      const features = await service.getOrBuildClusters('viewer-1', [0, 0, 10, 10], 5)
+      const { features, tags } = await service.getOrBuildClusters('viewer-1', [0, 0, 10, 10], 5)
       expect(features).toEqual([])
+      expect(tags).toEqual([])
       expect(mockFindSocialProfilesWithLocation).toHaveBeenCalledWith('viewer-1', [])
     })
   })
@@ -117,7 +175,7 @@ describe('ClusterService', () => {
 
       await service.buildIndex('viewer-1')
 
-      const features = service.getClusters('viewer-1', [-180, -90, 180, 90], 2)
+      const { features } = service.getClusters('viewer-1', [-180, -90, 180, 90], 2)
       const cluster = features.find((f) => f.type === 'cluster')
       if (cluster) {
         const zoom = service.getExpansionZoom('viewer-1', cluster.id)
@@ -127,19 +185,39 @@ describe('ClusterService', () => {
   })
 
   describe('getLeaves', () => {
-    it('returns point features for a cluster', async () => {
+    it('returns point features with kind for a cluster', async () => {
       const profiles = [makeProfile('p1', 47.5, 19.0), makeProfile('p2', 47.5001, 19.0001)]
       mockFindSocialProfilesWithLocation.mockResolvedValue(profiles)
       mockFindMutualMatchIds.mockResolvedValue([])
 
       await service.buildIndex('viewer-1')
 
-      const features = service.getClusters('viewer-1', [-180, -90, 180, 90], 2)
+      const { features } = service.getClusters('viewer-1', [-180, -90, 180, 90], 2)
       const cluster = features.find((f) => f.type === 'cluster')
       if (cluster) {
         const leaves = service.getLeaves('viewer-1', cluster.id)
         expect(leaves).toHaveLength(2)
         expect(leaves.every((l) => l.type === 'point')).toBe(true)
+        expect(leaves.every((l) => l.kind === 'profile')).toBe(true)
+      }
+    })
+
+    it('returns mixed profile and post leaves', async () => {
+      const profiles = [makeProfile('p1', 47.5, 19.0)]
+      const posts = [makePost('post1', 47.5001, 19.0001)]
+      mockFindSocialProfilesWithLocation.mockResolvedValue(profiles)
+      mockFindMutualMatchIds.mockResolvedValue([])
+      mockFindAllWithLocation.mockResolvedValue(posts)
+
+      await service.buildIndex('viewer-1')
+
+      const { features } = service.getClusters('viewer-1', [-180, -90, 180, 90], 2)
+      const cluster = features.find((f) => f.type === 'cluster')
+      if (cluster) {
+        const leaves = service.getLeaves('viewer-1', cluster.id)
+        expect(leaves).toHaveLength(2)
+        const kinds = leaves.map((l) => l.kind).sort()
+        expect(kinds).toEqual(['post', 'profile'])
       }
     })
   })
@@ -150,10 +228,10 @@ describe('ClusterService', () => {
       mockFindMutualMatchIds.mockResolvedValue([])
 
       await service.buildIndex('viewer-1')
-      expect(service.getClusters('viewer-1', [-180, -90, 180, 90], 5)).toHaveLength(1)
+      expect(service.getClusters('viewer-1', [-180, -90, 180, 90], 5).features).toHaveLength(1)
 
       service.evict('viewer-1')
-      expect(service.getClusters('viewer-1', [-180, -90, 180, 90], 5)).toEqual([])
+      expect(service.getClusters('viewer-1', [-180, -90, 180, 90], 5).features).toEqual([])
     })
   })
 })

--- a/apps/backend/src/api/routes/browse.route.ts
+++ b/apps/backend/src/api/routes/browse.route.ts
@@ -1,38 +1,25 @@
 import { FastifyPluginAsync } from 'fastify'
-import { sendError } from '../helpers'
-import { BrowseService } from '@/services/browse.service'
-import { BoundsQuerySchema } from '@zod/dto/bounds.dto'
 import type { BrowseBoundsResponse } from '@zod/apiResponse.dto'
 
+// ────────────────────────────────────────────────────────────────────
+// DEPRECATED SHIM — /browse/bounds retired
+// ────────────────────────────────────────────────────────────────────
+// Browse map data is now served by the unified cluster endpoint at
+// GET /find/social/map/clusters (which returns features + tags).
+// This endpoint is kept solely so stale frontends do not break.
+//
+// TODO(cleanup): remove this route and the BrowseBoundsResponse type
+// once all clients have been updated and dashboards confirm no traffic.
+// ────────────────────────────────────────────────────────────────────
+
 const browseRoutes: FastifyPluginAsync = async (fastify) => {
-  const browseService = BrowseService.getInstance(fastify.prisma)
-
   /**
-   * GET /bounds
-   * Returns profiles, posts, and available tags within a geographic bounding box.
-   * Tags are derived from profile results only.
+   * @deprecated GET /bounds — replaced by GET /find/social/map/clusters.
+   * Returns a static empty response. Kept for stale client compatibility only.
    */
-  fastify.get('/bounds', { onRequest: [fastify.authenticate] }, async (req, reply) => {
-    const parsed = BoundsQuerySchema.safeParse(req.query)
-    if (!parsed.success) {
-      return sendError(
-        reply,
-        400,
-        'Missing or invalid bounds parameters (south, north, west, east)'
-      )
-    }
-
-    const viewerProfileId = req.session.profileId
-    const locale = req.session.lang
-
-    try {
-      const result = await browseService.findInBounds(viewerProfileId, parsed.data, locale)
-      const response: BrowseBoundsResponse = { success: true, ...result }
-      return reply.code(200).send(response)
-    } catch (err) {
-      req.log.error(err)
-      return sendError(reply, 500, 'Failed to fetch browse data')
-    }
+  fastify.get('/bounds', { onRequest: [fastify.authenticate] }, async (_req, reply) => {
+    const response: BrowseBoundsResponse = { success: true, profiles: [], posts: [], tags: [] }
+    return reply.code(200).send(response)
   })
 }
 

--- a/apps/backend/src/api/routes/findProfile.route.ts
+++ b/apps/backend/src/api/routes/findProfile.route.ts
@@ -16,6 +16,7 @@ import type { SocialMatchFilterDTO } from '@zod/match/filters.dto'
 
 import { MAP_MAX_ZOOM } from '@shared/maps'
 import { mapProfileToPublic } from '../mappers/profile.mappers'
+import { mapProfileTagsTranslated } from '../mappers/tag.mappers'
 
 // Pagination query schema for infinite scrolling
 const PaginationQuerySchema = z.object({
@@ -68,11 +69,7 @@ function parseTagIds(raw: unknown): string[] | null {
 const findProfileRoutes: FastifyPluginAsync = async (fastify) => {
   // instantiate services
   const profileMatchService = ProfileMatchService.getInstance()
-  const clusterService = ClusterService.getInstance()
-
-  const BoundsWithTagsQuerySchema = BoundsQuerySchema.extend({
-    tagIds: z.string().optional(),
-  })
+  const clusterService = ClusterService.getInstance(fastify.prisma)
 
   const ClusterQuerySchema = BoundsQuerySchema.extend({
     zoom: z.coerce.number().int().min(0).max(MAP_MAX_ZOOM),
@@ -85,52 +82,14 @@ const findProfileRoutes: FastifyPluginAsync = async (fastify) => {
   })
 
   /**
-   * GET /social/map/bounds
-   * Returns social profiles strictly within the given geographic bounding box,
-   * optionally filtered by a comma-separated list of tag IDs.
-   * @query {number} south - Required south latitude
-   * @query {number} north - Required north latitude
-   * @query {number} west - Required west longitude
-   * @query {number} east - Required east longitude
-   * @query {string} [tagIds] - Optional comma-separated tag IDs
-   * @returns {GetProfilesResponse}
+   * @deprecated GET /social/map/bounds — replaced by /social/map/clusters.
+   * Returns a static empty response. Kept for stale client compatibility only.
+   * TODO(cleanup): remove once all clients have been updated and dashboards
+   * confirm no traffic is hitting this path.
    */
-  fastify.get('/social/map/bounds', { onRequest: [fastify.authenticate] }, async (req, reply) => {
-    if (!req.session.profile.isSocialActive) {
-      return sendForbiddenError(reply)
-    }
-
-    const parsed = BoundsWithTagsQuerySchema.safeParse(req.query)
-    if (!parsed.success) {
-      return sendError(
-        reply,
-        400,
-        'Missing or invalid bounds parameters (south, north, west, east)'
-      )
-    }
-
-    const myProfileId = req.session.profileId
-    const locale = req.session.lang
-    const { tagIds: rawTagIds, ...bounds } = parsed.data
-    const tagIds = parseTagIds(rawTagIds)
-    if (tagIds === null) {
-      return sendError(reply, 400, `Invalid tagIds (max ${MAX_TAG_IDS}, alphanumeric only)`)
-    }
-
-    try {
-      const profiles = await profileMatchService.findSocialProfilesInBounds(
-        myProfileId,
-        bounds,
-        tagIds,
-        [{ updatedAt: 'desc' }]
-      )
-      const mappedProfiles = profiles.map((p) => mapProfileToPublic(p, false, locale))
-      const response: GetProfilesResponse = { success: true, profiles: mappedProfiles }
-      return reply.code(200).send(response)
-    } catch (err) {
-      req.log.error(err)
-      return sendError(reply, 500, 'Failed to fetch bounded map profiles')
-    }
+  fastify.get('/social/map/bounds', { onRequest: [fastify.authenticate] }, async (_req, reply) => {
+    const response: GetProfilesResponse = { success: true, profiles: [] }
+    return reply.code(200).send(response)
   })
 
   /**
@@ -163,13 +122,14 @@ const findProfileRoutes: FastifyPluginAsync = async (fastify) => {
     }
 
     try {
-      const features = await clusterService.getOrBuildClusters(
+      const { features, tags: rawTags } = await clusterService.getOrBuildClusters(
         req.session.profileId,
         bbox,
         zoom,
         tagIds
       )
-      return reply.code(200).send({ success: true, features })
+      const tags = mapProfileTagsTranslated(rawTags, req.session.lang)
+      return reply.code(200).send({ success: true, features, tags })
     } catch (err) {
       req.log.error(err)
       return sendError(reply, 500, 'Failed to fetch clusters')

--- a/apps/backend/src/api/routes/findProfile.route.ts
+++ b/apps/backend/src/api/routes/findProfile.route.ts
@@ -102,7 +102,7 @@ const findProfileRoutes: FastifyPluginAsync = async (fastify) => {
    * @query {number} east - Bounding box east longitude
    * @query {number} zoom - Map zoom level (0–12)
    * @query {string} [tagIds] - Optional comma-separated tag IDs
-   * @returns {{ success: true, features: MapFeature[] }}
+   * @returns {{ success: true, features: MapFeature[], tags: PublicTag[] }}
    */
   fastify.get('/social/map/clusters', { onRequest: [fastify.authenticate] }, async (req, reply) => {
     if (!req.session.profile.isSocialActive) {

--- a/apps/backend/src/services/browse.service.ts
+++ b/apps/backend/src/services/browse.service.ts
@@ -9,6 +9,11 @@ import type { PublicPostWithProfile } from '@zod/post/post.dto'
 import type { PublicTag } from '@zod/tag/tag.dto'
 import type { Bounds } from '@zod/dto/bounds.dto'
 
+/**
+ * @deprecated Browse map data is now served by the unified cluster endpoint
+ * (ClusterService). This service has no active callers.
+ * TODO(cleanup): remove together with the /browse/bounds route shim.
+ */
 export class BrowseService {
   private static instance: BrowseService
 

--- a/apps/backend/src/services/cluster.service.ts
+++ b/apps/backend/src/services/cluster.service.ts
@@ -40,26 +40,27 @@ function buildCacheKey(profileId: string, tagIds: string[]): string {
 export class ClusterService {
   private indexes = new Map<string, CachedIndex>()
   private static instance: ClusterService
-  private prisma: PrismaClient | null = null
+
+  private constructor(private readonly prisma: PrismaClient) {}
 
   static getInstance(prisma?: PrismaClient): ClusterService {
     if (!ClusterService.instance) {
-      ClusterService.instance = new ClusterService()
-    }
-    if (prisma && !ClusterService.instance.prisma) {
-      ClusterService.instance.prisma = prisma
+      if (!prisma) {
+        throw new Error('ClusterService requires PrismaClient on first instantiation')
+      }
+      ClusterService.instance = new ClusterService(prisma)
     }
     return ClusterService.instance
   }
 
   async buildIndex(profileId: string, tagIds: string[] = []): Promise<void> {
     const profileMatchService = ProfileMatchService.getInstance()
-    const postService = PostService.getInstance()
+    const postService = PostService.getInstance(this.prisma)
 
     const [profiles, matchIds, posts] = await Promise.all([
       profileMatchService.findSocialProfilesWithLocation(profileId, tagIds),
       profileMatchService.findMutualMatchIds(profileId),
-      postService.findAllWithLocation(),
+      postService.findAllWithLocation(profileId),
     ])
 
     const matchSet = new Set(matchIds)

--- a/apps/backend/src/services/cluster.service.ts
+++ b/apps/backend/src/services/cluster.service.ts
@@ -1,22 +1,29 @@
 import Supercluster from 'supercluster'
 import type { Feature, Point } from 'geojson'
+import type { PrismaClient } from '@prisma/client'
 import { ProfileMatchService } from './profileMatch.service'
+import { PostService } from './post.service'
 import { ImageService } from './image.service'
 import type { ClusterFeature, PointFeature, MapFeature } from '@shared/zod/map/cluster.dto'
+import type { TagWithTranslations } from '@shared/zod/tag/tag.db'
 import { MAP_MAX_ZOOM } from '@shared/maps'
 const CLUSTER_RADIUS = 40
 const INDEX_TTL_MS = 30 * 60 * 1000 // 30 minutes
 const INDEX_MAX_SIZE = 200
 
 interface PointProperties {
+  kind: 'profile' | 'post'
   id: string
   publicName: string
   image: { blurhash?: string | null; url?: string } | null
   highlighted: boolean
+  postContent?: string
+  postType?: string
 }
 
 interface CachedIndex {
   index: Supercluster<PointProperties, Supercluster.AnyProps>
+  tags: TagWithTranslations[]
   updatedAt: Date
 }
 
@@ -33,25 +40,32 @@ function buildCacheKey(profileId: string, tagIds: string[]): string {
 export class ClusterService {
   private indexes = new Map<string, CachedIndex>()
   private static instance: ClusterService
+  private prisma: PrismaClient | null = null
 
-  static getInstance(): ClusterService {
+  static getInstance(prisma?: PrismaClient): ClusterService {
     if (!ClusterService.instance) {
       ClusterService.instance = new ClusterService()
+    }
+    if (prisma && !ClusterService.instance.prisma) {
+      ClusterService.instance.prisma = prisma
     }
     return ClusterService.instance
   }
 
   async buildIndex(profileId: string, tagIds: string[] = []): Promise<void> {
     const profileMatchService = ProfileMatchService.getInstance()
+    const postService = PostService.getInstance()
 
-    const [profiles, matchIds] = await Promise.all([
+    const [profiles, matchIds, posts] = await Promise.all([
       profileMatchService.findSocialProfilesWithLocation(profileId, tagIds),
       profileMatchService.findMutualMatchIds(profileId),
+      postService.findAllWithLocation(),
     ])
 
     const matchSet = new Set(matchIds)
+    const imageService = ImageService.getInstance()
 
-    const features: Feature<Point, PointProperties>[] = profiles
+    const profileFeatures: Feature<Point, PointProperties>[] = profiles
       .filter((p) => p.lat != null && p.lon != null)
       .map((p) => ({
         type: 'Feature' as const,
@@ -60,19 +74,55 @@ export class ClusterService {
           coordinates: [p.lon!, p.lat!],
         },
         properties: {
+          kind: 'profile' as const,
           id: p.id,
           publicName: p.publicName ?? '',
           image: p.profileImages?.[0]
             ? {
                 blurhash: p.profileImages[0].blurhash ?? null,
-                url: ImageService.getInstance()
-                  .getImageUrls(p.profileImages[0])
-                  .find((v) => v.size === 'thumb')?.url,
+                url: imageService.getImageUrls(p.profileImages[0]).find((v) => v.size === 'thumb')
+                  ?.url,
               }
             : null,
           highlighted: matchSet.has(p.id),
         },
       }))
+
+    const postFeatures: Feature<Point, PointProperties>[] = posts
+      .filter((p) => p.lat != null && p.lon != null)
+      .map((p) => ({
+        type: 'Feature' as const,
+        geometry: {
+          type: 'Point' as const,
+          coordinates: [p.lon!, p.lat!],
+        },
+        properties: {
+          kind: 'post' as const,
+          id: p.id,
+          publicName: p.postedBy?.publicName ?? '',
+          image: p.postedBy?.profileImages?.[0]
+            ? {
+                blurhash: p.postedBy.profileImages[0].blurhash ?? null,
+                url: imageService
+                  .getImageUrls(p.postedBy.profileImages[0])
+                  .find((v) => v.size === 'thumb')?.url,
+              }
+            : null,
+          highlighted: false,
+          postContent: p.content?.substring(0, 50),
+          postType: p.type,
+        },
+      }))
+
+    // Collect unique tags from profiles (raw, translated at request time)
+    const tagMap = new Map<string, TagWithTranslations>()
+    for (const profile of profiles) {
+      for (const tag of profile.tags ?? []) {
+        if (!tagMap.has(tag.id)) {
+          tagMap.set(tag.id, tag as TagWithTranslations)
+        }
+      }
+    }
 
     const index = new Supercluster<PointProperties, Supercluster.AnyProps>({
       radius: CLUSTER_RADIUS,
@@ -80,8 +130,12 @@ export class ClusterService {
       minPoints: 2,
     })
 
-    index.load(features)
-    this.indexes.set(buildCacheKey(profileId, tagIds), { index, updatedAt: new Date() })
+    index.load([...profileFeatures, ...postFeatures])
+    this.indexes.set(buildCacheKey(profileId, tagIds), {
+      index,
+      tags: Array.from(tagMap.values()),
+      updatedAt: new Date(),
+    })
   }
 
   getClusters(
@@ -89,13 +143,16 @@ export class ClusterService {
     bbox: [number, number, number, number],
     zoom: number,
     tagIds: string[] = []
-  ): MapFeature[] {
+  ): { features: MapFeature[]; tags: TagWithTranslations[] } {
     const key = buildCacheKey(profileId, tagIds)
     const cached = this.indexes.get(key)
-    if (!cached) return []
+    if (!cached) return { features: [], tags: [] }
 
     const raw = cached.index.getClusters(bbox, Math.round(zoom))
-    return raw.map((f) => this.mapFeature(f, key))
+    return {
+      features: raw.map((f) => this.mapFeature(f, key)),
+      tags: cached.tags,
+    }
   }
 
   async getOrBuildClusters(
@@ -103,7 +160,7 @@ export class ClusterService {
     bbox: [number, number, number, number],
     zoom: number,
     tagIds: string[] = []
-  ): Promise<MapFeature[]> {
+  ): Promise<{ features: MapFeature[]; tags: TagWithTranslations[] }> {
     this.pruneIndexes()
     const key = buildCacheKey(profileId, tagIds)
     if (!this.indexes.has(key)) {
@@ -125,12 +182,16 @@ export class ClusterService {
     const leaves = cached.index.getLeaves(clusterId, Infinity, 0)
     return leaves.map((f) => ({
       type: 'point' as const,
+      kind: f.properties.kind,
       id: f.properties.id,
       lat: f.geometry.coordinates[1],
       lon: f.geometry.coordinates[0],
       publicName: f.properties.publicName,
       image: f.properties.image,
       highlighted: f.properties.highlighted,
+      ...(f.properties.kind === 'post'
+        ? { postContent: f.properties.postContent, postType: f.properties.postType }
+        : {}),
     }))
   }
 
@@ -198,12 +259,16 @@ export class ClusterService {
     const props = f.properties as PointProperties
     return {
       type: 'point',
+      kind: props.kind,
       id: props.id,
       lat: f.geometry.coordinates[1],
       lon: f.geometry.coordinates[0],
       publicName: props.publicName,
       image: props.image,
       highlighted: props.highlighted,
+      ...(props.kind === 'post'
+        ? { postContent: props.postContent, postType: props.postType }
+        : {}),
     } satisfies PointFeature
   }
 }

--- a/apps/backend/src/services/post.service.ts
+++ b/apps/backend/src/services/post.service.ts
@@ -196,24 +196,27 @@ export class PostService {
         isDeleted: false,
         isVisible: true,
         ...(type ? { type } : {}),
-        OR: [
-          {
-            lat: { gte: bounds.south, lte: bounds.north },
-            lon: { gte: bounds.west, lte: bounds.east },
-          },
-          {
-            lat: null,
-            postedBy: {
-              lat: { gte: bounds.south, lte: bounds.north },
-              lon: { gte: bounds.west, lte: bounds.east },
-            },
-          },
-        ],
+        lat: { gte: bounds.south, lte: bounds.north },
+        lon: { gte: bounds.west, lte: bounds.east },
       },
       ...postedByInclude,
       orderBy: { createdAt: 'desc' },
       take: limit,
       skip: offset,
+    })
+  }
+
+  async findAllWithLocation(limit = 500) {
+    return this.prisma.post.findMany({
+      where: {
+        isDeleted: false,
+        isVisible: true,
+        lat: { not: null },
+        lon: { not: null },
+      },
+      ...postedByInclude,
+      orderBy: { createdAt: 'desc' },
+      take: limit,
     })
   }
 

--- a/apps/backend/src/services/post.service.ts
+++ b/apps/backend/src/services/post.service.ts
@@ -1,6 +1,7 @@
 import { PrismaClient, PostType, Prisma } from '@prisma/client'
 import type { CreatePostPayload, UpdatePostPayload } from '@zod/post/post.dto'
 import { conversationContextInclude } from '@/db/includes/profileIncludes'
+import { blocklistWhereClause } from '@/db/includes/blocklistWhereClause'
 
 const postedByInclude = {
   include: {
@@ -206,13 +207,14 @@ export class PostService {
     })
   }
 
-  async findAllWithLocation(limit = 500) {
+  async findAllWithLocation(viewerProfileId: string, limit = 500) {
     return this.prisma.post.findMany({
       where: {
         isDeleted: false,
         isVisible: true,
         lat: { not: null },
         lon: { not: null },
+        postedBy: blocklistWhereClause(viewerProfileId),
       },
       ...postedByInclude,
       orderBy: { createdAt: 'desc' },

--- a/apps/frontend/src/features/browse/composables/__tests__/useBrowseViewModel.spec.ts
+++ b/apps/frontend/src/features/browse/composables/__tests__/useBrowseViewModel.spec.ts
@@ -24,88 +24,102 @@ describe('useBrowseViewModel', () => {
     vi.clearAllMocks()
   })
 
-  it('fetches posts and tags on bounds change', async () => {
-    mockGet.mockResolvedValue({
-      data: {
-        success: true,
-        profiles: [],
-        posts: [
-          {
-            id: 'clpost00000000000000001',
-            content: 'Cherry harvest',
-            type: 'OFFER',
-            createdAt: new Date().toISOString(),
-            updatedAt: new Date().toISOString(),
-            postedById: 'p1',
-            country: 'HU',
-            cityName: 'Bp',
-            lat: 47.1,
-            lon: 18.6,
-            location: { lat: 47.1, lon: 18.6, country: 'HU', cityName: 'Bp' },
-            postedBy: { id: 'p1', publicName: 'Mónika', profileImages: [] },
-          },
-        ],
-        tags: [{ id: 't1', name: 'Biokert', slug: 'biokert' }],
+  it('derives profile and post POIs from cluster features', () => {
+    const store = useFindProfileStore()
+    store.clusterFeatures = [
+      {
+        type: 'point',
+        kind: 'profile',
+        id: 'p1',
+        lat: 47.1,
+        lon: 18.6,
+        publicName: 'Alice',
+        image: null,
+        highlighted: false,
       },
-    })
+      {
+        type: 'point',
+        kind: 'post',
+        id: 'post1',
+        lat: 47.2,
+        lon: 18.7,
+        publicName: 'Bob',
+        image: null,
+        highlighted: false,
+        postContent: 'Cherry harvest',
+        postType: 'OFFER',
+      },
+      {
+        type: 'cluster',
+        id: 1,
+        lat: 47.3,
+        lon: 18.8,
+        count: 5,
+        expansionZoom: 8,
+      },
+    ]
 
     const vm = useBrowseViewModel()
-    const store = useFindProfileStore()
-    await store.fetchPostsAndTags(mockBounds)
 
-    expect(mockGet).toHaveBeenCalledWith(
-      '/browse/bounds',
-      expect.objectContaining({ params: mockBounds })
-    )
+    expect(vm.profilePois.value).toHaveLength(1)
+    expect(vm.profilePois.value[0]!.type).toBe('profile')
+    expect(vm.profilePois.value[0]!.id).toBe('p1')
+
     expect(vm.postPois.value).toHaveLength(1)
     expect(vm.postPois.value[0]!.type).toBe('post')
-    expect(vm.availableTags.value).toHaveLength(1)
+    expect(vm.postPois.value[0]!.title).toBe('Cherry harvest')
+
+    expect(vm.allPois.value).toHaveLength(2)
+    expect(vm.clusters.value).toHaveLength(1)
   })
 
-  it('filters out posts without location', async () => {
+  it('populates tags from cluster response', async () => {
+    const mockTags = [{ id: 'cltagabc000000000000001', name: 'Biokert', slug: 'biokert' }]
     mockGet.mockResolvedValue({
       data: {
         success: true,
-        profiles: [],
-        posts: [
+        features: [
           {
-            id: 'clpost00000000000000001',
-            content: 'Has loc',
-            type: 'OFFER',
-            createdAt: new Date().toISOString(),
-            updatedAt: new Date().toISOString(),
-            postedById: 'p1',
-            country: 'HU',
-            cityName: null,
-            lat: 47,
-            lon: 18,
-            location: { lat: 47, lon: 18, country: 'HU' },
-            postedBy: { id: 'p1', publicName: 'Test', profileImages: [] },
-          },
-          {
-            id: 'clpost00000000000000002',
-            content: 'No loc',
-            type: 'OFFER',
-            createdAt: new Date().toISOString(),
-            updatedAt: new Date().toISOString(),
-            postedById: 'p2',
-            country: null,
-            cityName: null,
-            lat: null,
-            lon: null,
-            location: null,
-            postedBy: { id: 'p2', publicName: 'Test2', profileImages: [] },
+            type: 'point',
+            kind: 'post',
+            id: 'post1',
+            lat: 47.1,
+            lon: 18.6,
+            publicName: 'Author',
+            image: null,
+            highlighted: false,
+            postContent: 'Has loc',
+            postType: 'OFFER',
           },
         ],
-        tags: [],
+        tags: mockTags,
       },
     })
 
     const store = useFindProfileStore()
-    await store.fetchPostsAndTags(mockBounds)
+    await store.findClustersForMapBounds(mockBounds, 10)
 
     const vm = useBrowseViewModel()
-    expect(vm.postPois.value).toHaveLength(1)
-    expect(vm.postPois.value[0]!.id).toBe('clpost00000000000000001')
+    expect(vm.availableTags.value).toHaveLength(1)
+    expect(vm.availableTags.value[0]!.name).toBe('Biokert')
+  })
+
+  it('excludes cluster features from POI lists', () => {
+    const store = useFindProfileStore()
+    store.clusterFeatures = [
+      {
+        type: 'cluster',
+        id: 1,
+        lat: 47.5,
+        lon: 19.0,
+        count: 10,
+        expansionZoom: 6,
+      },
+    ]
+
+    const vm = useBrowseViewModel()
+    expect(vm.profilePois.value).toHaveLength(0)
+    expect(vm.postPois.value).toHaveLength(0)
+    expect(vm.allPois.value).toHaveLength(0)
   })
 })

--- a/apps/frontend/src/features/browse/composables/useBrowseViewModel.ts
+++ b/apps/frontend/src/features/browse/composables/useBrowseViewModel.ts
@@ -89,7 +89,11 @@ export function useBrowseViewModel() {
     await findProfileStore.fetchBounds(bounds, zoom)
   }
 
-  const fetchPopupData = (id: string | number) => findProfileStore.fetchProfileForPopup(String(id))
+  const fetchPopupData = (id: string | number) => {
+    const poi = allPois.value.find((p) => p.id === id)
+    if (poi?.type === 'post') return Promise.resolve(null)
+    return findProfileStore.fetchProfileForPopup(String(id))
+  }
 
   return {
     viewerProfile,

--- a/apps/frontend/src/features/browse/composables/useBrowseViewModel.ts
+++ b/apps/frontend/src/features/browse/composables/useBrowseViewModel.ts
@@ -6,15 +6,15 @@ import { useFindProfileStore } from '@/features/browse/stores/findProfileStore'
 import { useOwnerProfileStore } from '@/features/myprofile/stores/ownerProfileStore'
 
 /**
- * View-model for the browse map. Reads cluster + post data from
- * findProfileStore, maps DTOs to map-layer types, and provides
- * unified bounds handling and selection state.
+ * View-model for the browse map. Reads cluster data from findProfileStore,
+ * maps DTOs to map-layer types, and provides unified bounds handling and
+ * selection state. Both profile and post POIs derive from the cluster
+ * features — a single data source for the entire map.
  */
 export function useBrowseViewModel() {
   const findProfileStore = useFindProfileStore()
   const ownerStore = useOwnerProfileStore()
-  const { clusterFeatures, postPois, availableTags, isLoadingPosts, isLoading } =
-    storeToRefs(findProfileStore)
+  const { clusterFeatures, availableTags, isLoading } = storeToRefs(findProfileStore)
 
   const viewerProfile = computed(() => ownerStore.profile)
 
@@ -30,11 +30,9 @@ export function useBrowseViewModel() {
       }))
   )
 
-  // TODO type wrangling - what type are we converting into?
-  // this belongs to the pinia store, or better yet, into the backend
   const profilePois = computed<MapPoi[]>(() =>
     clusterFeatures.value
-      .filter((f): f is PointFeature => f.type === 'point')
+      .filter((f): f is PointFeature => f.type === 'point' && f.kind === 'profile')
       .map((p) => ({
         id: p.id,
         title: p.publicName,
@@ -44,6 +42,21 @@ export function useBrowseViewModel() {
           : undefined,
         highlighted: p.highlighted,
         type: 'profile',
+        source: p,
+      }))
+  )
+
+  const postPois = computed<MapPoi[]>(() =>
+    clusterFeatures.value
+      .filter((f): f is PointFeature => f.type === 'point' && f.kind === 'post')
+      .map((p) => ({
+        id: p.id,
+        title: p.postContent ?? '',
+        location: { lat: p.lat, lon: p.lon },
+        image: p.image?.url
+          ? { blurhash: p.image.blurhash, variants: [{ size: 'thumb', url: p.image.url }] }
+          : undefined,
+        type: 'post',
         source: p,
       }))
   )
@@ -59,6 +72,7 @@ export function useBrowseViewModel() {
     return (
       features.length === 1 &&
       first?.type === 'point' &&
+      first.kind === 'profile' &&
       first.id === viewerProfile.value?.id
     )
   })
@@ -75,8 +89,7 @@ export function useBrowseViewModel() {
     await findProfileStore.fetchBounds(bounds, zoom)
   }
 
-  const fetchPopupData = (id: string | number) =>
-    findProfileStore.fetchProfileForPopup(String(id))
+  const fetchPopupData = (id: string | number) => findProfileStore.fetchProfileForPopup(String(id))
 
   return {
     viewerProfile,
@@ -86,7 +99,6 @@ export function useBrowseViewModel() {
     allPois,
     availableTags,
     isLoading,
-    isLoadingPosts,
     haveResults,
     isNoOneAround,
     activePoi,

--- a/apps/frontend/src/features/browse/stores/__tests__/findProfileStore.spec.ts
+++ b/apps/frontend/src/features/browse/stores/__tests__/findProfileStore.spec.ts
@@ -27,7 +27,7 @@ describe('findProfileStore.refetchBounds', () => {
   })
 
   it('re-fetches clusters when lastMapBounds is set', async () => {
-    mockGet.mockResolvedValue({ data: { success: true, features: [] } })
+    mockGet.mockResolvedValue({ data: { success: true, features: [], tags: [] } })
     store.lastMapBounds = bounds
 
     await store.refetchBounds()
@@ -63,11 +63,12 @@ describe('findClustersForMapBounds', () => {
     vi.clearAllMocks()
   })
 
-  it('fetches clusters from the cluster endpoint with bounds and zoom', async () => {
+  it('fetches clusters and tags from the cluster endpoint', async () => {
     const mockFeatures = [
       { type: 'cluster', id: 1, lat: 47.5, lon: 19.0, count: 5, expansionZoom: 8 },
       {
         type: 'point',
+        kind: 'profile',
         id: 'p1',
         lat: 48.2,
         lon: 16.3,
@@ -76,7 +77,8 @@ describe('findClustersForMapBounds', () => {
         highlighted: false,
       },
     ]
-    mockGet.mockResolvedValue({ data: { success: true, features: mockFeatures } })
+    const mockTags = [{ id: 'cltagabc000000000000001', name: 'Biokert', slug: 'biokert' }]
+    mockGet.mockResolvedValue({ data: { success: true, features: mockFeatures, tags: mockTags } })
 
     const bounds = { south: 47, north: 49, west: 16, east: 20 }
     await store.findClustersForMapBounds(bounds, 6)
@@ -94,10 +96,12 @@ describe('findClustersForMapBounds', () => {
       })
     )
     expect(store.clusterFeatures).toHaveLength(2)
+    expect(store.availableTags).toHaveLength(1)
+    expect(store.availableTags[0]!.name).toBe('Biokert')
   })
 
   it('always refetches on zoom change even if bounds are cached', async () => {
-    mockGet.mockResolvedValue({ data: { success: true, features: [] } })
+    mockGet.mockResolvedValue({ data: { success: true, features: [], tags: [] } })
 
     const bounds = { south: 47, north: 49, west: 16, east: 20 }
 
@@ -115,14 +119,14 @@ describe('findClustersForMapBounds', () => {
       resolveFirst = r
     })
     mockGet.mockImplementationOnce(() => firstCall)
-    mockGet.mockResolvedValueOnce({ data: { success: true, features: [] } })
+    mockGet.mockResolvedValueOnce({ data: { success: true, features: [], tags: [] } })
 
     const bounds = { south: 47, north: 49, west: 16, east: 20 }
 
     const p1 = store.findClustersForMapBounds(bounds, 6)
     const p2 = store.findClustersForMapBounds(bounds, 7)
 
-    resolveFirst!({ data: { success: true, features: [] } })
+    resolveFirst!({ data: { success: true, features: [], tags: [] } })
     await Promise.all([p1, p2])
 
     expect(store.clusterFeatures).toEqual([])

--- a/apps/frontend/src/features/browse/stores/findProfileStore.ts
+++ b/apps/frontend/src/features/browse/stores/findProfileStore.ts
@@ -2,14 +2,8 @@ import { defineStore } from 'pinia'
 import { CanceledError } from 'axios'
 import { api, safeApiCall } from '@/lib/api'
 import type { PublicProfile } from '@zod/profile/profile.dto'
-import type {
-  BrowseBoundsResponse,
-  GetMatchIdsResponse,
-  GetPublicProfileResponse,
-} from '@zod/apiResponse.dto'
-import { PublicPostWithProfileSchema } from '@zod/post/post.dto'
+import type { GetMatchIdsResponse, GetPublicProfileResponse } from '@zod/apiResponse.dto'
 import type { PublicTag } from '@zod/tag/tag.dto'
-import type { MapPoi } from '@/features/map/types/map.types'
 import { ClusterMapResponseSchema, type MapFeature } from '@shared/zod/map/cluster.dto'
 import { storeSuccess, storeError, type StoreVoidSuccess, type StoreError } from '@/store/helpers'
 import { bus } from '@/lib/bus'
@@ -18,7 +12,6 @@ import type { MapBounds } from '@/features/map/types/map.types'
 import { boundsContain, padBounds } from '../utils/boundsUtils'
 
 let clusterAbortController: AbortController | null = null
-let postAbortController: AbortController | null = null
 let lastZoom = 7
 let cachedClusterZoom: number | null = null
 let cachedClusterBounds: MapBounds | null = null
@@ -69,9 +62,7 @@ type FindProfileStoreState = {
   matchedProfileIds: Set<string>
   lastMapBounds: MapBounds | null
   isLoading: boolean
-  postPois: MapPoi[]
   availableTags: PublicTag[]
-  isLoadingPosts: boolean
 }
 
 export const useFindProfileStore = defineStore('findProfile', {
@@ -80,9 +71,7 @@ export const useFindProfileStore = defineStore('findProfile', {
     matchedProfileIds: new Set<string>(),
     lastMapBounds: null,
     isLoading: false,
-    postPois: [] as MapPoi[],
     availableTags: [] as PublicTag[],
-    isLoadingPosts: false,
   }),
 
   actions: {
@@ -127,7 +116,9 @@ export const useFindProfileStore = defineStore('findProfile', {
           })
         )
 
-        this.clusterFeatures = ClusterMapResponseSchema.parse(res.data).features
+        const parsed = ClusterMapResponseSchema.parse(res.data)
+        this.clusterFeatures = parsed.features
+        this.availableTags = parsed.tags
         cachedClusterBounds = paddedBounds
         cachedClusterZoom = zoom
         cachedClusterTagSig = sig
@@ -146,59 +137,14 @@ export const useFindProfileStore = defineStore('findProfile', {
       }
     },
 
-    async fetchPostsAndTags(bounds: MapBounds): Promise<StoreVoidSuccess | StoreError> {
-      if (postAbortController) postAbortController.abort()
-      const controller = new AbortController()
-      postAbortController = controller
-
-      this.isLoadingPosts = true
-      try {
-        const res = await safeApiCall(() =>
-          api.get<BrowseBoundsResponse>('/browse/bounds', {
-            params: bounds,
-            signal: controller.signal,
-          })
-        )
-
-        if (!res.data.success) return storeError(new Error('Browse bounds request failed'))
-
-        // TODO: move post → MapPoi mapping to the backend (browse/bounds endpoint)
-        // so the frontend receives a uniform MapPoi[] shape, same as profiles.
-        const posts = PublicPostWithProfileSchema.array().parse(res.data.posts)
-        this.postPois = posts
-          .filter((p) => p.location?.lat != null && p.location?.lon != null)
-          .map((p) => ({
-            id: p.id,
-            title: p.content?.substring(0, 50) ?? '',
-            location: { lat: p.location!.lat!, lon: p.location!.lon! },
-            image: p.postedBy?.profileImages?.[0],
-            type: 'post',
-            source: p,
-          }))
-
-        this.availableTags = res.data.tags
-        return storeSuccess()
-      } catch (error: any) {
-        if (error instanceof CanceledError) return storeSuccess()
-        return storeError(error, 'Failed to fetch posts and tags')
-      } finally {
-        if (postAbortController === controller) {
-          this.isLoadingPosts = false
-        }
-      }
-    },
-
     /**
      * Unified bounds handler — deduplicates viewport, then fetches
-     * clusters and posts in parallel.
+     * clusters (including posts and tags) in a single request.
      */
     async fetchBounds(bounds: MapBounds, zoom: number): Promise<void> {
       if (sameViewport(this.lastMapBounds, lastZoom, bounds, zoom)) return
       lastZoom = zoom
-      await Promise.all([
-        this.findClustersForMapBounds(bounds, zoom),
-        this.fetchPostsAndTags(bounds),
-      ])
+      await this.findClustersForMapBounds(bounds, zoom)
     },
 
     async fetchProfileForPopup(profileId: string): Promise<PublicProfile | null> {
@@ -233,10 +179,7 @@ export const useFindProfileStore = defineStore('findProfile', {
     async refetchBounds(): Promise<void> {
       invalidateBoundsCache()
       if (this.lastMapBounds) {
-        await Promise.all([
-          this.findClustersForMapBounds(this.lastMapBounds, lastZoom),
-          this.fetchPostsAndTags(this.lastMapBounds),
-        ])
+        await this.findClustersForMapBounds(this.lastMapBounds, lastZoom)
       }
     },
 
@@ -245,18 +188,12 @@ export const useFindProfileStore = defineStore('findProfile', {
         clusterAbortController.abort()
         clusterAbortController = null
       }
-      if (postAbortController) {
-        postAbortController.abort()
-        postAbortController = null
-      }
       invalidateBoundsCache()
       this.clusterFeatures = []
       this.matchedProfileIds = new Set()
       this.lastMapBounds = null
       this.isLoading = false
-      this.postPois = []
       this.availableTags = []
-      this.isLoadingPosts = false
     },
   },
 })

--- a/apps/frontend/src/features/browse/views/__tests__/BrowseProfiles.spec.ts
+++ b/apps/frontend/src/features/browse/views/__tests__/BrowseProfiles.spec.ts
@@ -70,7 +70,6 @@ const vmState = {
   viewerProfile: ref<Record<string, any>>({ isSocialActive: true }),
   isNoOneAround: ref(false),
   isLoading: ref(false),
-  isLoadingPosts: ref(false),
   haveResults: ref(true),
   clusters: ref([]),
   allPois: ref([]),

--- a/apps/frontend/src/features/posts/components/PostMapPopup.vue
+++ b/apps/frontend/src/features/posts/components/PostMapPopup.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
-import type { PublicPostWithProfile } from '@zod/post/post.dto'
+import type { PointFeature } from '@shared/zod/map/cluster.dto'
 
-defineProps<{ item: PublicPostWithProfile }>()
+defineProps<{ item: PointFeature }>()
 defineEmits<{ (e: 'click', id: string): void }>()
 </script>
 
@@ -9,7 +9,9 @@ defineEmits<{ (e: 'click', id: string): void }>()
   <div
     class="post-map-popup cursor-pointer p-3 user-select-none"
     @click="$emit('click', item.id)"
-  >{{ item.content.substring(0, 120) }}</div>
+  >
+    {{ (item.postContent ?? '').substring(0, 120) }}
+  </div>
 </template>
 
 <style scoped>

--- a/packages/shared/zod/map/cluster.dto.ts
+++ b/packages/shared/zod/map/cluster.dto.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod'
+import { PublicTagSchema } from '../tag/tag.dto'
 
 export const ClusterFeatureSchema = z.object({
   type: z.literal('cluster'),
@@ -11,6 +12,7 @@ export const ClusterFeatureSchema = z.object({
 
 export const PointFeatureSchema = z.object({
   type: z.literal('point'),
+  kind: z.enum(['profile', 'post']),
   id: z.string(),
   lat: z.number(),
   lon: z.number(),
@@ -22,6 +24,8 @@ export const PointFeatureSchema = z.object({
     })
     .nullable(),
   highlighted: z.boolean(),
+  postContent: z.string().optional(),
+  postType: z.string().optional(),
 })
 
 export const MapFeatureSchema = z.discriminatedUnion('type', [
@@ -32,6 +36,7 @@ export const MapFeatureSchema = z.discriminatedUnion('type', [
 export const ClusterMapResponseSchema = z.object({
   success: z.literal(true),
   features: z.array(MapFeatureSchema),
+  tags: z.array(PublicTagSchema),
 })
 
 export type ClusterFeature = z.infer<typeof ClusterFeatureSchema>


### PR DESCRIPTION
## Summary

- **Unified map endpoint**: Merges `/find/social/map/clusters` and `/browse/bounds` into a single request that returns mixed profile+post clusters + tags
- **Mixed clustering**: Posts flow through the same Supercluster index as profiles, so they cluster together at low zoom levels instead of rendering as a separate POI layer
- **Removed erroneous fallback**: `PostService.findInBounds()` had an `OR` clause falling back to author location for posts without `lat`/`lon` — posts now use their own location only
- **Deprecated dead endpoints**: `/find/social/map/bounds` (zero callers) and `/browse/bounds` converted to static shims for stale client compatibility
- **Frontend simplification**: Single HTTP request, single abort controller, single loading state. Both `profilePois` and `postPois` now derive from `clusterFeatures` via `kind` discriminator

## Test plan

- [x] `pnpm type-check` — all packages pass
- [x] `pnpm lint` — clean
- [x] `pnpm test` — 1,034 tests green (489 backend + 545 frontend)
- [ ] Manual: browse map shows clusters that include both profiles and posts
- [ ] Manual: zoom in to expand clusters into individual profile + post markers
- [ ] Manual: clicking post marker shows PostMapPopup, profile marker shows ProfileMapCard
- [ ] Manual: tag filter chips populate and filter correctly
- [ ] Manual: Network tab shows single `/find/social/map/clusters` per viewport change (no `/browse/bounds`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)