### PR TITLE
refactor: align service prisma pattern, simplify PostService

### DIFF
--- a/.changeset/service-prisma-cleanup.md
+++ b/.changeset/service-prisma-cleanup.md
@@ -1,0 +1,5 @@
+---
+'@opencupid/backend': patch
+---
+
+Align PostService and ClusterService with module-level prisma import pattern, simplify PostService.update(), remove erroneous findNearby OR fallback (#1285, #1286)

--- a/apps/backend/src/__tests__/services/cluster.service.spec.ts
+++ b/apps/backend/src/__tests__/services/cluster.service.spec.ts
@@ -88,7 +88,7 @@ describe('ClusterService', () => {
   beforeEach(() => {
     // Reset singleton so each test gets a fresh instance
     ;(ClusterService as any).instance = undefined
-    service = ClusterService.getInstance({} as any)
+    service = ClusterService.getInstance()
     vi.clearAllMocks()
     mockFindAllWithLocation.mockResolvedValue([])
   })

--- a/apps/backend/src/__tests__/services/post.service.spec.ts
+++ b/apps/backend/src/__tests__/services/post.service.spec.ts
@@ -1,22 +1,28 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
-import { PostService } from '../../services/post.service'
 
-const mockPost = {
-  post: {
-    create: vi.fn(),
-    findFirst: vi.fn(),
-    findMany: vi.fn(),
-    update: vi.fn(),
+const { mockPost } = vi.hoisted(() => ({
+  mockPost: {
+    post: {
+      create: vi.fn(),
+      findFirst: vi.fn(),
+      findMany: vi.fn(),
+      update: vi.fn(),
+    },
   },
-}
+}))
+
+vi.mock('@/lib/prisma', () => ({
+  prisma: mockPost,
+}))
+
+import { PostService } from '../../services/post.service'
 
 let service: PostService
 
 beforeEach(() => {
   vi.clearAllMocks()
-  // Reset singleton so each test gets a fresh instance with our mock
   ;(PostService as any).instance = undefined
-  service = PostService.getInstance(mockPost as any)
+  service = PostService.getInstance()
 })
 
 const basePost = {
@@ -152,7 +158,7 @@ describe('PostService.update', () => {
     )
   })
 
-  it('does not include location fields when not provided', async () => {
+  it('passes undefined for location fields when not provided', async () => {
     mockPost.post.findFirst.mockResolvedValue(basePost)
     mockPost.post.update.mockResolvedValue({ ...basePost, content: 'updated' })
 
@@ -162,10 +168,10 @@ describe('PostService.update', () => {
 
     const updateCall = mockPost.post.update.mock.calls[0][0]
     expect(updateCall.data).toHaveProperty('content', 'updated')
-    expect(updateCall.data).not.toHaveProperty('country')
-    expect(updateCall.data).not.toHaveProperty('cityName')
-    expect(updateCall.data).not.toHaveProperty('lat')
-    expect(updateCall.data).not.toHaveProperty('lon')
+    expect(updateCall.data.country).toBeUndefined()
+    expect(updateCall.data.cityName).toBeUndefined()
+    expect(updateCall.data.lat).toBeUndefined()
+    expect(updateCall.data.lon).toBeUndefined()
   })
 
   it('allows clearing location by setting fields to null', async () => {
@@ -216,28 +222,19 @@ describe('PostService.update', () => {
 })
 
 describe('PostService.findNearby', () => {
-  it('builds OR query with post location and profile fallback', async () => {
+  it('queries posts by their own lat/lon within bounding box', async () => {
     mockPost.post.findMany.mockResolvedValue([])
 
     await service.findNearby(52.52, 13.405, 50)
 
     const call = mockPost.post.findMany.mock.calls[0][0]
-    expect(call.where).toHaveProperty('OR')
-    expect(call.where.OR).toHaveLength(2)
-
-    // First clause: posts with their own location
-    const postLocationClause = call.where.OR[0]
-    expect(postLocationClause).toHaveProperty('lat')
-    expect(postLocationClause).toHaveProperty('lon')
-    expect(postLocationClause.lat).toHaveProperty('gte')
-    expect(postLocationClause.lat).toHaveProperty('lte')
-
-    // Second clause: posts without location, fallback to profile
-    const profileFallbackClause = call.where.OR[1]
-    expect(profileFallbackClause).toHaveProperty('lat', null)
-    expect(profileFallbackClause).toHaveProperty('postedBy')
-    expect(profileFallbackClause.postedBy.lat).toHaveProperty('gte')
-    expect(profileFallbackClause.postedBy.lon).toHaveProperty('lte')
+    expect(call.where).toHaveProperty('lat')
+    expect(call.where).toHaveProperty('lon')
+    expect(call.where.lat).toHaveProperty('gte')
+    expect(call.where.lat).toHaveProperty('lte')
+    expect(call.where.lon).toHaveProperty('gte')
+    expect(call.where.lon).toHaveProperty('lte')
+    expect(call.where).not.toHaveProperty('OR')
   })
 
   it('calculates correct bounding box', async () => {
@@ -253,12 +250,11 @@ describe('PostService.findNearby', () => {
     const expectedLonRange = radius / (111.0 * Math.cos((lat * Math.PI) / 180))
 
     const call = mockPost.post.findMany.mock.calls[0][0]
-    const postClause = call.where.OR[0]
 
-    expect(postClause.lat.gte).toBeCloseTo(lat - expectedLatRange, 5)
-    expect(postClause.lat.lte).toBeCloseTo(lat + expectedLatRange, 5)
-    expect(postClause.lon.gte).toBeCloseTo(lon - expectedLonRange, 5)
-    expect(postClause.lon.lte).toBeCloseTo(lon + expectedLonRange, 5)
+    expect(call.where.lat.gte).toBeCloseTo(lat - expectedLatRange, 5)
+    expect(call.where.lat.lte).toBeCloseTo(lat + expectedLatRange, 5)
+    expect(call.where.lon.gte).toBeCloseTo(lon - expectedLonRange, 5)
+    expect(call.where.lon.lte).toBeCloseTo(lon + expectedLonRange, 5)
   })
 
   it('applies type filter when provided', async () => {

--- a/apps/backend/src/api/routes/findProfile.route.ts
+++ b/apps/backend/src/api/routes/findProfile.route.ts
@@ -69,7 +69,7 @@ function parseTagIds(raw: unknown): string[] | null {
 const findProfileRoutes: FastifyPluginAsync = async (fastify) => {
   // instantiate services
   const profileMatchService = ProfileMatchService.getInstance()
-  const clusterService = ClusterService.getInstance(fastify.prisma)
+  const clusterService = ClusterService.getInstance()
 
   const ClusterQuerySchema = BoundsQuerySchema.extend({
     zoom: z.coerce.number().int().min(0).max(MAP_MAX_ZOOM),

--- a/apps/backend/src/api/routes/post.route.ts
+++ b/apps/backend/src/api/routes/post.route.ts
@@ -21,7 +21,7 @@ import type {
 import { mapDbPostToOwner, mapDbPostToPublic, mapDbPostToDetail } from '../mappers/post.mappers'
 
 const postRoutes: FastifyPluginAsync = async (fastify) => {
-  const postService = PostService.getInstance(fastify.prisma)
+  const postService = PostService.getInstance()
 
   /**
    * POST /

--- a/apps/backend/src/services/browse.service.ts
+++ b/apps/backend/src/services/browse.service.ts
@@ -39,7 +39,7 @@ export class BrowseService {
     tags: PublicTag[]
   }> {
     const profileMatchService = ProfileMatchService.getInstance()
-    const postService = PostService.getInstance(this.prisma)
+    const postService = PostService.getInstance()
 
     const [rawProfiles, rawPosts] = await Promise.all([
       profileMatchService.findSocialProfilesInBounds(

--- a/apps/backend/src/services/cluster.service.ts
+++ b/apps/backend/src/services/cluster.service.ts
@@ -40,6 +40,8 @@ export class ClusterService {
   private indexes = new Map<string, CachedIndex>()
   private static instance: ClusterService
 
+  private constructor() {}
+
   static getInstance(): ClusterService {
     if (!ClusterService.instance) {
       ClusterService.instance = new ClusterService()

--- a/apps/backend/src/services/cluster.service.ts
+++ b/apps/backend/src/services/cluster.service.ts
@@ -1,6 +1,5 @@
 import Supercluster from 'supercluster'
 import type { Feature, Point } from 'geojson'
-import type { PrismaClient } from '@prisma/client'
 import { ProfileMatchService } from './profileMatch.service'
 import { PostService } from './post.service'
 import { ImageService } from './image.service'
@@ -41,21 +40,16 @@ export class ClusterService {
   private indexes = new Map<string, CachedIndex>()
   private static instance: ClusterService
 
-  private constructor(private readonly prisma: PrismaClient) {}
-
-  static getInstance(prisma?: PrismaClient): ClusterService {
+  static getInstance(): ClusterService {
     if (!ClusterService.instance) {
-      if (!prisma) {
-        throw new Error('ClusterService requires PrismaClient on first instantiation')
-      }
-      ClusterService.instance = new ClusterService(prisma)
+      ClusterService.instance = new ClusterService()
     }
     return ClusterService.instance
   }
 
   async buildIndex(profileId: string, tagIds: string[] = []): Promise<void> {
     const profileMatchService = ProfileMatchService.getInstance()
-    const postService = PostService.getInstance(this.prisma)
+    const postService = PostService.getInstance()
 
     const [profiles, matchIds, posts] = await Promise.all([
       profileMatchService.findSocialProfilesWithLocation(profileId, tagIds),

--- a/apps/backend/src/services/post.service.ts
+++ b/apps/backend/src/services/post.service.ts
@@ -1,7 +1,8 @@
-import { PrismaClient, PostType, Prisma } from '@prisma/client'
+import { PostType, Prisma } from '@prisma/client'
 import type { CreatePostPayload, UpdatePostPayload } from '@zod/post/post.dto'
 import { conversationContextInclude } from '@/db/includes/profileIncludes'
 import { blocklistWhereClause } from '@/db/includes/blocklistWhereClause'
+import { prisma } from '@/lib/prisma'
 
 const postedByInclude = {
   include: {
@@ -31,24 +32,16 @@ export type PostWithProfileAndContext = Prisma.PostGetPayload<
 
 export class PostService {
   private static instance: PostService
-  private prisma: PrismaClient
 
-  private constructor(prisma: PrismaClient) {
-    this.prisma = prisma
-  }
-
-  public static getInstance(prisma?: PrismaClient): PostService {
+  static getInstance(): PostService {
     if (!PostService.instance) {
-      if (!prisma) {
-        throw new Error('PostService requires PrismaClient on first instantiation')
-      }
-      PostService.instance = new PostService(prisma)
+      PostService.instance = new PostService()
     }
     return PostService.instance
   }
 
   async create(profileId: string, data: CreatePostPayload) {
-    return this.prisma.post.create({
+    return prisma.post.create({
       data: {
         content: data.content,
         type: data.type,
@@ -63,7 +56,7 @@ export class PostService {
   }
 
   async findById(id: string) {
-    return this.prisma.post.findFirst({
+    return prisma.post.findFirst({
       where: { id, isDeleted: false },
       ...postedByInclude,
     })
@@ -73,7 +66,7 @@ export class PostService {
     id: string,
     viewerProfileId: string
   ): Promise<PostWithProfileAndContext | null> {
-    const post = await this.prisma.post.findFirst({
+    const post = await prisma.post.findFirst({
       where: { id, isDeleted: false },
       ...postedByWithConversationInclude(viewerProfileId),
     })
@@ -97,7 +90,7 @@ export class PostService {
   ) {
     const { type, limit = 20, offset = 0, includeInvisible = false } = options
 
-    return this.prisma.post.findMany({
+    return prisma.post.findMany({
       where: {
         postedById: profileId,
         isDeleted: false,
@@ -120,7 +113,7 @@ export class PostService {
   ) {
     const { type, limit = 20, offset = 0 } = options
 
-    return this.prisma.post.findMany({
+    return prisma.post.findMany({
       where: {
         isDeleted: false,
         isVisible: true,
@@ -154,26 +147,13 @@ export class PostService {
     const minLon = lon - lonRange
     const maxLon = lon + lonRange
 
-    return this.prisma.post.findMany({
+    return prisma.post.findMany({
       where: {
         isDeleted: false,
         isVisible: true,
         ...(type ? { type } : {}),
-        OR: [
-          // Posts with their own location
-          {
-            lat: { gte: minLat, lte: maxLat },
-            lon: { gte: minLon, lte: maxLon },
-          },
-          // Posts without location — fall back to profile location
-          {
-            lat: null,
-            postedBy: {
-              lat: { gte: minLat, lte: maxLat },
-              lon: { gte: minLon, lte: maxLon },
-            },
-          },
-        ],
+        lat: { gte: minLat, lte: maxLat },
+        lon: { gte: minLon, lte: maxLon },
       },
       ...postedByInclude,
       orderBy: { createdAt: 'desc' },
@@ -192,7 +172,7 @@ export class PostService {
   ) {
     const { type, limit = 100, offset = 0 } = options
 
-    return this.prisma.post.findMany({
+    return prisma.post.findMany({
       where: {
         isDeleted: false,
         isVisible: true,
@@ -208,7 +188,7 @@ export class PostService {
   }
 
   async findAllWithLocation(viewerProfileId: string, limit = 500) {
-    return this.prisma.post.findMany({
+    return prisma.post.findMany({
       where: {
         isDeleted: false,
         isVisible: true,
@@ -233,7 +213,7 @@ export class PostService {
     const oneWeekAgo = new Date()
     oneWeekAgo.setDate(oneWeekAgo.getDate() - 7)
 
-    return this.prisma.post.findMany({
+    return prisma.post.findMany({
       where: {
         isDeleted: false,
         isVisible: true,
@@ -249,7 +229,7 @@ export class PostService {
 
   async update(id: string, profileId: string, data: UpdatePostPayload) {
     // Only allow owner to update
-    const post = await this.prisma.post.findFirst({
+    const post = await prisma.post.findFirst({
       where: { id, postedById: profileId, isDeleted: false },
     })
 
@@ -257,16 +237,16 @@ export class PostService {
       return null
     }
 
-    return this.prisma.post.update({
+    return prisma.post.update({
       where: { id },
       data: {
-        ...(data.content !== undefined && { content: data.content }),
-        ...(data.type !== undefined && { type: data.type }),
-        ...(data.isVisible !== undefined && { isVisible: data.isVisible }),
-        ...(data.country !== undefined && { country: data.country }),
-        ...(data.cityName !== undefined && { cityName: data.cityName }),
-        ...(data.lat !== undefined && { lat: data.lat }),
-        ...(data.lon !== undefined && { lon: data.lon }),
+        content: data.content,
+        type: data.type,
+        isVisible: data.isVisible,
+        country: data.country,
+        cityName: data.cityName,
+        lat: data.lat,
+        lon: data.lon,
         updatedAt: new Date(),
       },
       ...postedByInclude,
@@ -275,7 +255,7 @@ export class PostService {
 
   async delete(id: string, profileId: string) {
     // Only allow owner to delete
-    const post = await this.prisma.post.findFirst({
+    const post = await prisma.post.findFirst({
       where: { id, postedById: profileId, isDeleted: false },
     })
 
@@ -283,7 +263,7 @@ export class PostService {
       return null
     }
 
-    return this.prisma.post.update({
+    return prisma.post.update({
       where: { id },
       data: {
         isDeleted: true,

--- a/apps/backend/src/services/post.service.ts
+++ b/apps/backend/src/services/post.service.ts
@@ -33,6 +33,8 @@ export type PostWithProfileAndContext = Prisma.PostGetPayload<
 export class PostService {
   private static instance: PostService
 
+  private constructor() {}
+
   static getInstance(): PostService {
     if (!PostService.instance) {
       PostService.instance = new PostService()


### PR DESCRIPTION
## Summary

- **#1285**: Switch `PostService` and `ClusterService` from constructor-injected `PrismaClient` to module-level `import { prisma } from '@/lib/prisma'`, aligning with the 12 other services in the codebase. Removes prisma threading through `getInstance()` calls.
- **#1286**: Remove redundant `undefined` guards in `PostService.update()` — Prisma already skips `undefined` fields in updates.
- **Bonus**: Remove erroneous `OR` fallback to author location in `PostService.findNearby()` (same bug as the `findInBounds` fix in #1284).

Net: **-25 lines** (71 added, 96 removed).

Depends on #1284 (unified map clusters). Merge #1284 first.

Closes #1285
Closes #1286

## Test plan

- [x] `pnpm type-check` passes
- [x] `pnpm lint` clean
- [x] `pnpm test` — 1,034 tests green (489 backend + 545 frontend)

🤖 Generated with [Claude Code](https://claude.com/claude-code)