### PR TITLE
fix(map): prevent Sentry Replay stack overflow on iOS

### DIFF
--- a/.changeset/gentle-maps-breathe.md
+++ b/.changeset/gentle-maps-breathe.md
@@ -1,0 +1,5 @@
+---
+'@opencupid/frontend': patch
+---
+
+Fix Sentry Replay stack overflow on iOS by excluding Leaflet map from DOM serialization (#1281)

--- a/apps/frontend/src/features/map/components/OsmPoiMap.vue
+++ b/apps/frontend/src/features/map/components/OsmPoiMap.vue
@@ -49,7 +49,7 @@ defineExpose({ flyToMarker })
     />
     <div
       ref="mapEl"
-      class="osm-poi-map"
+      class="osm-poi-map sentry-block"
       :class="{ 'opacity-50': !isMapReady }"
     />
 


### PR DESCRIPTION
## Summary
- Add `sentry-block` class to the Leaflet map container to exclude it from Sentry Replay's rrweb DOM serialization
- Fixes `RangeError: Maximum call stack size exceeded` on iOS WebKit (Chrome Mobile iOS) caused by rrweb recursively walking Leaflet's deeply nested DOM tree during map zoom

## Root cause
v0.48.0 changed `initSentry` from fire-and-forget to `await`, guaranteeing Replay is active before user interaction. On iOS WebKit (stack limit ~250–500 frames vs V8's ~10,000+), Replay's recursive DOM serializer overflows when processing Leaflet's pane/marker/icon subtree during rapid map zoom.

Closes #1281

## Test plan
- [x] All 545 frontend tests pass
- [ ] Deploy to staging, browse map on iOS Safari/Chrome — verify no RangeError in GlitchTip
- [ ] Verify session replays still capture non-map pages correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)