### PR TITLE
fix(browse): evict cluster cache when blocking a profile

### DIFF
--- a/.changeset/quiet-maps-evict.md
+++ b/.changeset/quiet-maps-evict.md
@@ -1,0 +1,5 @@
+---
+'@opencupid/backend': patch
+---
+
+Evict cluster cache when blocking a profile (#1292)

--- a/apps/backend/src/api/routes/profile.route.ts
+++ b/apps/backend/src/api/routes/profile.route.ts
@@ -40,6 +40,7 @@ import { createDatingPrefsDefaults, DatingPreferencesFormSchema } from '@zod/mat
 import { ProfileService } from '@/services/profile.service'
 import { ProfileMatchService } from '@/services/profileMatch.service'
 import { MessageService } from '../../services/messaging.service'
+import { ClusterService } from '@/services/cluster.service'
 
 const RATE_LIMIT_PROFILE_SCOPES = 1 // max scope toggles per day
 
@@ -58,6 +59,7 @@ const profileRoutes: FastifyPluginAsync = async (fastify) => {
   const profileService = ProfileService.getInstance()
   const profileMatchService = ProfileMatchService.getInstance()
   const messageService = MessageService.getInstance()
+  const clusterService = ClusterService.getInstance()
 
   /**
    * GET /me
@@ -436,6 +438,7 @@ const profileRoutes: FastifyPluginAsync = async (fastify) => {
         return reply.code(400).send({ error: 'Cannot block yourself.' })
       }
       await profileService.blockProfile(profileId, id)
+      clusterService.evict(profileId)
       return reply.code(204).send()
     } catch (error) {
       fastify.log.error(error)


### PR DESCRIPTION
## Summary

- Evict the blocker's cluster cache immediately after `POST /:id/block` succeeds, so blocked profiles no longer appear on the map until the 30-min TTL expires
- Uses the existing `ClusterService.evict()` method which was implemented but never wired up

## Test plan

- [ ] Block a profile while viewing the map — verify the blocked profile disappears on next map pan/zoom (no 30-min wait)
- [ ] Verify `pnpm test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)