### PR TITLE
fix(config): relax SMTP_USER validation to plain string

### DIFF
--- a/.changeset/quiet-smtp-relax.md
+++ b/.changeset/quiet-smtp-relax.md
@@ -1,0 +1,5 @@
+---
+'@opencupid/backend': patch
+---
+
+Relax SMTP_USER config validation to accept non-email usernames (#1299)

--- a/apps/backend/src/lib/appconfig.ts
+++ b/apps/backend/src/lib/appconfig.ts
@@ -20,7 +20,7 @@ export const configSchema = z.object({
 
   SMTP_HOST: z.string(),
   SMTP_PORT: z.coerce.number(),
-  SMTP_USER: z.string().email(),
+  SMTP_USER: z.string(),
   SMTP_PASS: z.string(),
   EMAIL_FROM: z.string(),
 


### PR DESCRIPTION
## Summary
- Relax `SMTP_USER` in `appconfig.ts` from `z.string().email()` to `z.string()` so non-email SMTP usernames (e.g. SendGrid's `apikey`, Mailpit arbitrary strings, API key IDs) pass validation.

## Test plan
- [ ] Backend boots with a non-email `SMTP_USER` value
- [ ] Backend still boots with a valid email `SMTP_USER` value

🤖 Generated with [Claude Code](https://claude.com/claude-code)