### PR TITLE
fix: panel layout spacing in DatingPrefs, EditPostDialog, and Settings

### DIFF
--- a/.changeset/calm-panels-align.md
+++ b/.changeset/calm-panels-align.md
@@ -1,0 +1,5 @@
+---
+'@opencupid/frontend': patch
+---
+
+Fix panel layout spacing in DatingPrefs, EditPostDialog, and Settings views

--- a/apps/frontend/src/features/myprofile/components/DatingPrefs.vue
+++ b/apps/frontend/src/features/myprofile/components/DatingPrefs.vue
@@ -23,7 +23,7 @@ async function handleSave() {
 </script>
 
 <template>
-  <div class="d-flex flex-column h-100">
+  <div class="d-flex flex-column h-100 w-100 p-2">
     <section class="form-wrapper p-2 w-100 flex-grow-1 overflow-auto hide-scrollbar py-3 ">
       <BTabs
         variant="warning"

--- a/apps/frontend/src/features/posts/components/EditPostDialog.vue
+++ b/apps/frontend/src/features/posts/components/EditPostDialog.vue
@@ -84,7 +84,7 @@ const handleSubmit = async () => {
 <template>
   <BForm
     @submit.prevent="handleSubmit"
-    class="w-100"
+    class="w-100 p-2 mt-2"
   >
     <PostIt
       class="position-relative p-2"

--- a/apps/frontend/src/features/settings/components/Settings.vue
+++ b/apps/frontend/src/features/settings/components/Settings.vue
@@ -52,7 +52,7 @@ function handleLogout() {
 </script>
 
 <template>
-  <div class="px-3 py-3 h-100 d-flex flex-column justify-content-center">
+  <div class="px-3 p-md-5 h-100 w-100 d-flex flex-column justify-content-center">
     <fieldset class="d-flex align-items-center mb-3">
       <IconGlobe class="svg-icon svg-icon-lg me-2" />
       <LanguageSelectorDropdown size="md" />


### PR DESCRIPTION
## Summary
- Adds missing `w-100` and `p-2` utility classes to **DatingPrefs** so the form fills the panel width with proper padding
- Adds `p-2 mt-2` spacing to **EditPostDialog** form to prevent content from touching panel edges
- Switches **Settings** from fixed `py-3` to responsive `p-md-5` padding and adds `w-100` for consistent full-width layout

## Test plan
- [ ] Open DatingPrefs panel on desktop and mobile — verify it fills the width with even padding
- [ ] Open EditPostDialog — verify form has breathing room from edges
- [ ] Open Settings page on desktop (md+) and mobile — verify responsive padding adjusts correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)