### PR TITLE
chore: update i18n translation files

### DIFF
--- a/.changeset/quiet-words-translate.md
+++ b/.changeset/quiet-words-translate.md
@@ -1,0 +1,5 @@
+---
+'@opencupid/frontend': patch
+---
+
+Update i18n translation files with new keys and sorted entries

--- a/packages/shared/i18n/en.json
+++ b/packages/shared/i18n/en.json
@@ -239,6 +239,12 @@
       "voice_message_preview": "Voice message"
     }
   },
+  "myprofile": {
+    "prefs": {
+      "cancel": "Nevermind",
+      "save": "Update"
+    }
+  },
   "nav": {
     "browse": "Buddies",
     "bulletin": "Bulletin",
@@ -397,9 +403,9 @@
         "filter_display_label": "Looking in:",
         "locate_button_title": "Set to my location",
         "near_label": "Near...",
-        "search_placeholder": "Search",
         "search_button_title_dating": "Find people",
         "search_button_title_social": "Find people",
+        "search_placeholder": "Search",
         "social_title": "I 'm looking for connections...",
         "tags_label": "Interested in..."
       },
@@ -417,8 +423,6 @@
     },
     "forms": {
       "age_range": "Age range",
-      "tab_posts": "Posts",
-      "tab_profile": "Profile",
       "age_title_display": "I was born in {birthYear}",
       "city_add_placeholder": "Add this as new city",
       "city_deselect_label": "Remove",
@@ -464,6 +468,8 @@
       "pronouns_label": "They refer to me as...",
       "relationship_label": "I am...",
       "save_changes_hint": "Done editing",
+      "tab_posts": "Posts",
+      "tab_profile": "Profile",
       "tag_add_placeholder": "Add this as new tag",
       "tag_no_results": "Can't find anything similar.",
       "tag_search_placeholder": "Search interests..."

--- a/packages/shared/i18n/hu.json
+++ b/packages/shared/i18n/hu.json
@@ -243,6 +243,12 @@
       "voice_message_preview": "Hangüzenet"
     }
   },
+  "myprofile": {
+    "prefs": {
+      "cancel": "Mégsem",
+      "save": "Rendben"
+    }
+  },
   "nav": {
     "browse": "Komakereső",
     "bulletin": "Hirdetőtábla",
@@ -403,9 +409,9 @@
         "near_label": "Errefelé:",
         "search_button_title_dating": "Keresés",
         "search_button_title_social": "Keresés",
+        "search_placeholder": "Keresés",
         "social_title": "Itt keresek...",
-        "tags_label": "Érdeklődési körök...",
-        "search_placeholder": "Keresés"
+        "tags_label": "Érdeklődési körök..."
       },
       "invite_button": "Megosztás",
       "loading_more_profiles": "Egy pillanat...",
@@ -421,8 +427,6 @@
     },
     "forms": {
       "age_range": "Korosztály",
-      "tab_posts": "Bejegyzések",
-      "tab_profile": "Profil",
       "age_title_display": "{birthYear}-ben születtem",
       "city_add_placeholder": "Új város hozzáadása",
       "city_deselect_label": "Eltávolítás",
@@ -462,12 +466,15 @@
       "name_first_name_only": "Csak a keresztnevedet",
       "name_invalid": "Adj meg legalább 3 betűt",
       "name_label": "A keresztnevem...",
+      "preference_kids_label": " ",
       "preview_language": "Előnézeti nyelv",
       "preview_profile": "Profilom előnézete",
       "preview_profile_hint": "Így látják mások a profilomat",
       "pronouns_label": "Úgy hivatkoznak rám, mint...",
       "relationship_label": "Én...",
       "save_changes_hint": "Kész a szerkesztés",
+      "tab_posts": "Hirdetések",
+      "tab_profile": "Profil",
       "tag_add_placeholder": "Új címke",
       "tag_no_results": "Nem találtam hasonlót.",
       "tag_search_placeholder": "Érdeklődési körök..."


### PR DESCRIPTION
## Summary
- Add new `myprofile.prefs` keys (cancel/save) in both EN and HU
- Add missing `preference_kids_label` key in HU
- Sort keys alphabetically in `search` and `forms` sections for consistency
- Remove trailing newlines from JSON files

## Test plan
- [ ] Verify `pnpm test` passes
- [ ] Verify translation keys render correctly in the UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)