### PR TITLE
fix: decrease font size of message-sent confirmation (#1306)

### DIFF
--- a/.changeset/gentle-birds-swim.md
+++ b/.changeset/gentle-birds-swim.md
@@ -1,0 +1,5 @@
+---
+'@opencupid/frontend': patch
+---
+
+Decrease font size of message-sent confirmation text (#1306)

--- a/apps/frontend/src/features/messaging/components/ContactFormPanel.vue
+++ b/apps/frontend/src/features/messaging/components/ContactFormPanel.vue
@@ -114,9 +114,9 @@ defineExpose({
           class="svg-icon-lg w-100 h-100"
         />
       </div>
-      <h1 class="text-center mb-0">
+      <p class="fs-5 text-center mb-0">
         {{ $t('messaging.message_sent_success') }}
-      </h1>
+      </p>
     </div>
 
     <!-- 2. Waiting for reply — viewer already initiated contact -->


### PR DESCRIPTION
## Summary
- Change the message-sent success text from `<h1>` to `<p class="fs-5">` in `ContactFormPanel.vue`, making it proportional to the 5rem icon above it

Closes #1306

## Test plan
- [ ] Send a message to a profile and verify the confirmation text is smaller and visually balanced with the icon

🤖 Generated with [Claude Code](https://claude.com/claude-code)