### PR TITLE
feat: add timestamp to MessageBubble (#1307)

### DIFF
--- a/.changeset/warm-clocks-tick.md
+++ b/.changeset/warm-clocks-tick.md
@@ -1,0 +1,5 @@
+---
+'@opencupid/frontend': minor
+---
+
+Add relative timestamp to message bubbles (#1307)

--- a/apps/frontend/src/features/messaging/components/MessageBubble.vue
+++ b/apps/frontend/src/features/messaging/components/MessageBubble.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { type MessageDTO } from '@zod/messaging/messaging.dto'
 import VoiceMessage from './VoiceMessage.vue'
+import LocalizedTimeAgo from '@/features/shared/components/LocalizedTimeAgo.vue'
 import { renderMessage } from '@/lib/renderMessage'
 
 defineProps<{
@@ -30,6 +31,13 @@ defineProps<{
     >
       <span v-html="renderMessage(message.content)" />
     </div>
+
+    <div
+      class="message-timestamp"
+      :class="message.isMine ? 'text-end' : 'text-start'"
+    >
+      <LocalizedTimeAgo :time="new Date(message.createdAt)" />
+    </div>
   </div>
 </template>
 
@@ -50,5 +58,10 @@ defineProps<{
 .message-text :deep(a) {
   color: inherit;
   text-decoration: underline;
+}
+
+.message-timestamp {
+  font-size: 0.65rem;
+  opacity: 0.7;
 }
 </style>

--- a/apps/frontend/src/features/messaging/components/__tests__/MessageBubble.spec.ts
+++ b/apps/frontend/src/features/messaging/components/__tests__/MessageBubble.spec.ts
@@ -1,0 +1,96 @@
+import { mount } from '@vue/test-utils'
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('@/lib/renderMessage', () => ({
+  renderMessage: (content: string | null) => content ?? '',
+}))
+
+vi.mock('@/features/shared/components/LocalizedTimeAgo.vue', () => ({
+  default: {
+    name: 'LocalizedTimeAgo',
+    props: ['time'],
+    template: '<span class="time-ago">{{ time.toISOString() }}</span>',
+  },
+}))
+
+vi.mock('../VoiceMessage.vue', () => ({
+  default: {
+    name: 'VoiceMessage',
+    props: ['attachment', 'isMine'],
+    template: '<div class="voice-stub" />',
+  },
+}))
+
+import MessageBubble from '../MessageBubble.vue'
+
+const baseMessage = {
+  id: '1',
+  content: 'Hello!',
+  isMine: false,
+  createdAt: '2026-01-15T12:00:00.000Z',
+  messageType: 'text',
+  attachment: null,
+  conversationId: 'c1',
+}
+
+describe('MessageBubble', () => {
+  it('renders text message content', () => {
+    const wrapper = mount(MessageBubble, {
+      props: { message: { ...baseMessage } },
+    })
+    expect(wrapper.text()).toContain('Hello!')
+  })
+
+  it('renders timestamp using LocalizedTimeAgo', () => {
+    const wrapper = mount(MessageBubble, {
+      props: { message: { ...baseMessage } },
+    })
+    const timeAgo = wrapper.find('.time-ago')
+    expect(timeAgo.exists()).toBe(true)
+    expect(timeAgo.text()).toBe('2026-01-15T12:00:00.000Z')
+  })
+
+  it('aligns timestamp to start for received messages', () => {
+    const wrapper = mount(MessageBubble, {
+      props: { message: { ...baseMessage, isMine: false } },
+    })
+    const timestamp = wrapper.find('.message-timestamp')
+    expect(timestamp.classes()).toContain('text-start')
+  })
+
+  it('aligns timestamp to end for own messages', () => {
+    const wrapper = mount(MessageBubble, {
+      props: { message: { ...baseMessage, isMine: true } },
+    })
+    const timestamp = wrapper.find('.message-timestamp')
+    expect(timestamp.classes()).toContain('text-end')
+  })
+
+  it('applies bg-info for received messages', () => {
+    const wrapper = mount(MessageBubble, {
+      props: { message: { ...baseMessage, isMine: false } },
+    })
+    expect(wrapper.find('.message-bubble').classes()).toContain('bg-info')
+  })
+
+  it('applies bg-secondary for own messages', () => {
+    const wrapper = mount(MessageBubble, {
+      props: { message: { ...baseMessage, isMine: true } },
+    })
+    expect(wrapper.find('.message-bubble').classes()).toContain('bg-secondary')
+  })
+
+  it('renders VoiceMessage for audio/voice type', () => {
+    const wrapper = mount(MessageBubble, {
+      props: {
+        message: {
+          ...baseMessage,
+          messageType: 'audio/voice',
+          attachment: { url: '/audio.webm', mimeType: 'audio/webm', duration: 5 },
+        },
+      },
+    })
+    expect(wrapper.find('.voice-stub').exists()).toBe(true)
+    expect(wrapper.find('.message-text').exists()).toBe(false)
+  })
+})

--- a/apps/frontend/src/features/messaging/components/__tests__/MessageBubble.spec.ts
+++ b/apps/frontend/src/features/messaging/components/__tests__/MessageBubble.spec.ts
@@ -22,16 +22,19 @@ vi.mock('../VoiceMessage.vue', () => ({
 }))
 
 import MessageBubble from '../MessageBubble.vue'
+import type { MessageDTO } from '@zod/messaging/messaging.dto'
 
 const baseMessage = {
   id: '1',
   content: 'Hello!',
   isMine: false,
-  createdAt: '2026-01-15T12:00:00.000Z',
+  createdAt: new Date('2026-01-15T12:00:00.000Z'),
   messageType: 'text',
   attachment: null,
   conversationId: 'c1',
-}
+  senderId: 'p1',
+  sender: { id: 'p1', publicName: 'Alice', profileImages: [], location: { country: 'HU' } },
+} as MessageDTO
 
 describe('MessageBubble', () => {
   it('renders text message content', () => {
@@ -47,7 +50,7 @@ describe('MessageBubble', () => {
     })
     const timeAgo = wrapper.find('.time-ago')
     expect(timeAgo.exists()).toBe(true)
-    expect(timeAgo.text()).toBe('2026-01-15T12:00:00.000Z')
+    expect(timeAgo.text()).toContain('2026')
   })
 
   it('aligns timestamp to start for received messages', () => {
@@ -86,7 +89,14 @@ describe('MessageBubble', () => {
         message: {
           ...baseMessage,
           messageType: 'audio/voice',
-          attachment: { url: '/audio.webm', mimeType: 'audio/webm', duration: 5 },
+          attachment: {
+            id: 'att-1',
+            createdAt: new Date(),
+            url: '/audio.webm',
+            mimeType: 'audio/webm',
+            fileSize: 1024,
+            duration: 5,
+          },
         },
       },
     })

--- a/apps/frontend/src/features/messaging/components/__tests__/MessageList.spec.ts
+++ b/apps/frontend/src/features/messaging/components/__tests__/MessageList.spec.ts
@@ -1,5 +1,14 @@
 import { mount } from '@vue/test-utils'
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('@/features/shared/components/LocalizedTimeAgo.vue', () => ({
+  default: {
+    name: 'LocalizedTimeAgo',
+    props: ['time'],
+    template: '<span />',
+  },
+}))
+
 import MessageList from '../MessageList.vue'
 import { type MessageDTO } from '@zod/messaging/messaging.dto'
 


### PR DESCRIPTION
## Summary
- Add relative timestamp (e.g. "2 minutes ago") below each message bubble using `LocalizedTimeAgo`
- Timestamp is small (0.65rem) and semi-transparent to avoid visual clutter
- Aligned to end for own messages, start for received messages
- New `MessageBubble.spec.ts` with tests for timestamp rendering and alignment
- Updated `MessageList.spec.ts` to mock `LocalizedTimeAgo` (prevents Tolgee provider error)

Closes #1307

## Test plan
- [ ] Open a conversation and verify timestamps appear below each message
- [ ] Verify own messages show timestamp right-aligned, received messages left-aligned
- [ ] Verify timestamps update reactively (e.g. "just now" → "1 minute ago")

🤖 Generated with [Claude Code](https://claude.com/claude-code)