### PR TITLE
fix: evict cluster cache after post create/update/delete (#1309)

### DIFF
--- a/.changeset/bright-posts-clear.md
+++ b/.changeset/bright-posts-clear.md
@@ -1,0 +1,5 @@
+---
+'@opencupid/backend': patch
+---
+
+Evict cluster cache when posts are created, updated, or deleted (#1309)

--- a/apps/backend/src/__tests__/services/cluster.service.spec.ts
+++ b/apps/backend/src/__tests__/services/cluster.service.spec.ts
@@ -235,5 +235,19 @@ describe('ClusterService', () => {
       service.evict('viewer-1')
       expect(service.getClusters('viewer-1', [-180, -90, 180, 90], 5).features).toEqual([])
     })
+
+    it('evictAll clears all cached indexes', async () => {
+      mockFindSocialProfilesWithLocation.mockResolvedValue([makeProfile('p1', 47.5, 19.0)])
+      mockFindMutualMatchIds.mockResolvedValue([])
+
+      await service.buildIndex('viewer-1')
+      await service.buildIndex('viewer-2')
+      expect(service.hasIndex('viewer-1')).toBe(true)
+      expect(service.hasIndex('viewer-2')).toBe(true)
+
+      service.evictAll()
+      expect(service.hasIndex('viewer-1')).toBe(false)
+      expect(service.hasIndex('viewer-2')).toBe(false)
+    })
   })
 })

--- a/apps/backend/src/api/routes/post.route.ts
+++ b/apps/backend/src/api/routes/post.route.ts
@@ -12,6 +12,7 @@ import {
 } from '@zod/post/post.dto'
 import { rateLimitConfig, sendError } from '../helpers'
 import { PostService } from '@/services/post.service'
+import { ClusterService } from '@/services/cluster.service'
 import type {
   PostsResponse,
   CreatePostResponse,
@@ -22,6 +23,7 @@ import { mapDbPostToOwner, mapDbPostToPublic, mapDbPostToDetail } from '../mappe
 
 const postRoutes: FastifyPluginAsync = async (fastify) => {
   const postService = PostService.getInstance()
+  const clusterService = ClusterService.getInstance()
 
   /**
    * POST /
@@ -46,6 +48,7 @@ const postRoutes: FastifyPluginAsync = async (fastify) => {
 
       try {
         const created = await postService.create(profileId, data)
+        clusterService.evictAll()
         const post = mapDbPostToOwner(created)
         // TODO filter non-public fields
         const response: CreatePostResponse = { success: true, post }
@@ -114,6 +117,7 @@ const postRoutes: FastifyPluginAsync = async (fastify) => {
           return sendError(reply, 404, 'Post not found or access denied')
         }
 
+        clusterService.evictAll()
         const post = mapDbPostToOwner(raw)
         const response: UpdatePostResponse = { success: true, post }
         return reply.code(200).send(response)
@@ -150,6 +154,7 @@ const postRoutes: FastifyPluginAsync = async (fastify) => {
           return sendError(reply, 404, 'Post not found or access denied')
         }
 
+        clusterService.evictAll()
         const response: DeletePostResponse = { success: true }
         return reply.code(200).send(response)
       } catch (err: any) {

--- a/apps/backend/src/services/cluster.service.ts
+++ b/apps/backend/src/services/cluster.service.ts
@@ -205,6 +205,14 @@ export class ClusterService {
     }
   }
 
+  /**
+   * Evicts the entire cluster cache. Called when data visible to all viewers
+   * changes (e.g. a new post is created).
+   */
+  evictAll(): void {
+    this.indexes.clear()
+  }
+
   hasIndex(profileId: string, tagIds: string[] = []): boolean {
     return this.indexes.has(buildCacheKey(profileId, tagIds))
   }


### PR DESCRIPTION
## Summary
- Add `evictAll()` method to `ClusterService` that clears the entire index cache
- Call `evictAll()` in the post create, update, and delete route handlers so new/changed/removed posts are immediately visible on the map
- New unit test for `evictAll()` verifying it clears all viewer indexes

Closes #1309

## Test plan
- [ ] New unit test for `evictAll()` passes
- [ ] Create a post and verify it appears on the map without waiting for cache expiry
- [ ] Delete a post and verify it disappears from the map immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)