### PR TITLE
fix: add certResolver to admin mTLS routers

### DIFF
--- a/.changeset/warm-doors-knock.md
+++ b/.changeset/warm-doors-knock.md
@@ -1,0 +1,5 @@
+---
+'@opencupid/ingress': patch
+---
+
+Fix self-signed certificate on admin domain by adding explicit certResolver to mTLS routers

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -63,6 +63,7 @@ services:
       traefik.http.routers.admin-backend.rule: "Host(`${ADMIN_DOMAIN}`) && (PathPrefix(`/api`) || PathPrefix(`/bull-board`))"
       traefik.http.routers.admin-backend.entrypoints: websecure
       traefik.http.routers.admin-backend.tls.options: admin-mtls@file
+      traefik.http.routers.admin-backend.tls.certResolver: letsencrypt
       traefik.http.routers.admin-backend.middlewares: admin-header@file
 
   frontend:
@@ -99,6 +100,7 @@ services:
       traefik.http.routers.admin.priority: "1"
       traefik.http.routers.admin.entrypoints: websecure
       traefik.http.routers.admin.tls.options: admin-mtls@file
+      traefik.http.routers.admin.tls.certResolver: letsencrypt
       traefik.http.services.admin.loadbalancer.server.port: "3002"
 
   media:


### PR DESCRIPTION
## Summary
- `admin.gaians.net` was showing a self-signed certificate error because Traefik never requested a Let's Encrypt cert for the admin domain
- Root cause: when a router specifies `tls.options` (for mTLS), Traefik v3 does not inherit the entrypoint-level `certResolver` — it must be set explicitly on the router
- Adds `tls.certResolver: letsencrypt` to both `admin` and `admin-backend` routers

## Test plan
- [ ] Merge and deploy to production (`docker compose up -d --no-deps ingress`)
- [ ] Wait ~30s for Traefik to request the ACME cert
- [ ] Verify `https://admin.gaians.net` serves a valid Let's Encrypt certificate
- [ ] Verify mTLS still works (client cert required to access admin)

🤖 Generated with [Claude Code](https://claude.com/claude-code)