### PR TITLE
refactor(map): tighten MapPoi.id to string

### DIFF
--- a/.changeset/amber-types-narrow.md
+++ b/.changeset/amber-types-narrow.md
@@ -1,0 +1,5 @@
+---
+'@opencupid/frontend': patch
+---
+
+Tighten MapPoi.id and related map-layer types from `string | number` to `string`, removing redundant coercions.

--- a/apps/frontend/src/features/browse/composables/useBrowseViewModel.ts
+++ b/apps/frontend/src/features/browse/composables/useBrowseViewModel.ts
@@ -89,10 +89,10 @@ export function useBrowseViewModel() {
     await findProfileStore.fetchBounds(bounds, zoom)
   }
 
-  const fetchPopupData = (id: string | number) => {
+  const fetchPopupData = (id: string) => {
     const poi = allPois.value.find((p) => p.id === id)
     if (poi?.type === 'post') return Promise.resolve(null)
-    return findProfileStore.fetchProfileForPopup(String(id))
+    return findProfileStore.fetchProfileForPopup(id)
   }
 
   return {

--- a/apps/frontend/src/features/browse/views/BrowseProfiles.vue
+++ b/apps/frontend/src/features/browse/views/BrowseProfiles.vue
@@ -98,7 +98,7 @@ watch(
       onSelectionClear()
       return
     }
-    const found = allPois.value.find((p) => String(p.id) === d.id)
+    const found = allPois.value.find((p) => p.id === d.id)
     activePoi.value = found ?? null
   },
   { immediate: true }
@@ -147,13 +147,13 @@ function openInboxDrawer() {
 }
 
 function handlePostSelect(post: PostSummary) {
-  router.push({ name: 'PublicPost', params: { postId: String(post.id) } })
+  router.push({ name: 'PublicPost', params: { postId: post.id } })
 }
 function handleProfileSelect(profile: ProfileSummary) {
-  router.push({ name: 'PublicProfile', params: { profileId: String(profile.id) } })
+  router.push({ name: 'PublicProfile', params: { profileId: profile.id } })
 }
 
-function handleMarkerSelect(id: string | number) {
+function handleMarkerSelect(id: string ) {
   const poi = allPois.value.find((p) => p.id === id)
   if (!poi) return
   if (poi.type === 'post') {

--- a/apps/frontend/src/features/map/components/OsmPoiMap.vue
+++ b/apps/frontend/src/features/map/components/OsmPoiMap.vue
@@ -28,7 +28,7 @@ const props = withDefaults(
 )
 
 const emit = defineEmits<{
-  (e: 'item:select', id: string ): void
+  (e: 'item:select', id: string): void
   (e: 'map:ready', map: LMap): void
   (e: 'bounds:changed', payload: BoundsWithZoom): void
 }>()
@@ -147,8 +147,12 @@ defineExpose({ flyToMarker })
 }
 
 @keyframes popup-fade-in {
-  from { opacity: 0; }
-  to { opacity: 1; }
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
 }
 
 :deep(.leaflet-popup-content-wrapper) {

--- a/apps/frontend/src/features/map/components/OsmPoiMap.vue
+++ b/apps/frontend/src/features/map/components/OsmPoiMap.vue
@@ -17,7 +17,7 @@ const props = withDefaults(
     zoom?: number
     fitToPois?: boolean
     boundsDebounce?: number
-    fetchPopupData?: (id: string | number) => Promise<unknown>
+    fetchPopupData?: (id: string) => Promise<unknown>
   }>(),
   {
     zoom: 7,
@@ -28,7 +28,7 @@ const props = withDefaults(
 )
 
 const emit = defineEmits<{
-  (e: 'item:select', id: string | number): void
+  (e: 'item:select', id: string ): void
   (e: 'map:ready', map: LMap): void
   (e: 'bounds:changed', payload: BoundsWithZoom): void
 }>()

--- a/apps/frontend/src/features/map/composables/useMapController.ts
+++ b/apps/frontend/src/features/map/composables/useMapController.ts
@@ -5,7 +5,12 @@ import type { Component, Ref } from 'vue'
 
 import { DiffableLayer } from './DiffableLayer'
 import type { MapPoi, MapCluster, BoundsWithZoom, MarkerConfig } from '../types/map.types'
-import { isValidLatLng, createServerClusterIcon, hydratePoiIcon, MAP_MAX_ZOOM } from '../utils/mapUtils'
+import {
+  isValidLatLng,
+  createServerClusterIcon,
+  hydratePoiIcon,
+  MAP_MAX_ZOOM,
+} from '../utils/mapUtils'
 
 // ---------------------------------------------------------------------------
 // Types
@@ -26,12 +31,12 @@ export interface MapProps {
   zoom: number
   fitToPois: boolean
   boundsDebounce: number
-  fetchPopupData?: (id: string | number) => Promise<unknown>
+  fetchPopupData?: (id: string) => Promise<unknown>
 }
 
 type MapEmit = {
   (e: 'bounds:changed', payload: BoundsWithZoom): void
-  (e: 'item:select', id: string | number): void
+  (e: 'item:select', id: string): void
   (e: 'map:ready', map: LMap): void
 }
 

--- a/apps/frontend/src/features/map/types/map.types.ts
+++ b/apps/frontend/src/features/map/types/map.types.ts
@@ -24,7 +24,7 @@ export interface PoiIconProps {
 
 /** A point-of-interest item for the map. Call sites map domain objects into this shape. */
 export interface MapPoi {
-  id: string | number
+  id: string
   title: string
   location: PoiLocation
   image?: AvatarImage
@@ -53,5 +53,5 @@ export interface BoundsWithZoom {
 export interface MarkerConfig {
   resolveIcon: (poi: MapPoi) => Component
   resolvePopup?: (poi: MapPoi) => Component
-  fetchPopupData?: (id: string | number) => Promise<unknown>
+  fetchPopupData?: (id: string) => Promise<unknown>
 }


### PR DESCRIPTION
## Summary
- Narrow `MapPoi.id`, `MarkerConfig.fetchPopupData`, and `OsmPoiMap`'s `item:select` event from `string | number` to `string`
- Remove dead `String(...)` coercions in `useBrowseViewModel` and `BrowseProfiles`
- Pure type-system change — zero runtime behavior difference

The id is always a CUID string from the backend (see `PointFeature.id = z.string()` in the shared cluster DTO). The `string | number` union was legacy breathing room with no real-world number values.

Extracted from #1315 so the NearbyFeatures feature work can be reviewed independently of this refactor.

## Test plan
- [x] `pnpm type-check` passes
- [x] `pnpm lint` passes
- [x] `pnpm --filter frontend test` — 565/565 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)