### PR TITLE
fix(offcanvas): disable auto-focus on persistent panels

### DIFF
--- a/.changeset/coral-focus-fix.md
+++ b/.changeset/coral-focus-fix.md
@@ -1,0 +1,5 @@
+---
+'@opencupid/frontend': patch
+---
+
+Fix transient focus-outline artifact on BOffcanvas panels (NearbyFeatures, DetailPanelOrchestrator). BootstrapVueNext auto-focused the panel root on open, painting a 2px focus-visible outline above the panel edge until the first state change moved focus away. Passing `:focus="false"` opts out of the auto-focus for these persistent/secondary panels where the ring isn't needed.

--- a/apps/frontend/src/features/app/components/DetailPanelOrchestrator.vue
+++ b/apps/frontend/src/features/app/components/DetailPanelOrchestrator.vue
@@ -17,6 +17,7 @@ const { isOpen, currentComponent, currentProps, close, notifyHidden } = useDetai
     v-model="isOpen"
     placement="start"
     no-header
+    :focus="false"
     class="detail-panel shadow-lg"
     body-class="p-0 overflow-hidden"
     @hidden="notifyHidden"

--- a/apps/frontend/src/features/browse/components/NearbyFeatures.vue
+++ b/apps/frontend/src/features/browse/components/NearbyFeatures.vue
@@ -40,6 +40,7 @@ const isVisible = computed(() => props.posts.length > 0)
     :show="isVisible"
     no-backdrop
     no-trap
+    :focus="false"
     placement="bottom"
     body-class="p-0 d-flex overflow-hidden"
     header-class="py-1"


### PR DESCRIPTION
## Summary
Disable BootstrapVueNext's auto-focus on `BOffcanvas` for the two panels that aren't user-triggered modals:
- **NearbyFeatures** on the browse map
- **DetailPanelOrchestrator** (desktop start-side drawer)

## Root cause
On hard reload, BootstrapVueNext programmatically focuses the offcanvas root (`tabindex="-1"`) for a11y announcement. The browser paints a 2px `:focus-visible` outline, which — because outlines sit outside the element's border-box — appears as a thin line hovering just above the panel's top edge. The outline disappears on the first state change (toggle expand, click anywhere) because focus moves away.

This is the correct a11y pattern for *modal* offcanvases a user just opened. It's wrong here: these panels appear as ambient UI, not in response to a user action.

## Fix
Pass `:focus="false"` to both `BOffcanvas` instances. Verified via live DOM inspection:

```
Before: outline: rgb(142, 140, 132) solid 2px   activeElement: panel root
After:  outline: 0px                            activeElement: BODY
```

## Test plan
- [x] Hard-reload browse page: no outline above NearbyFeatures
- [x] Hard-reload browse + open a profile: no outline above desktop detail drawer
- [x] Toggle expand/collapse on NearbyFeatures: no regression
- [x] Keyboard-interactive children (search bar, cards, buttons) still receive their own focus rings
- [x] Type-check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)