### PR TITLE
fix(imageprocessor): detect faces in full-body portraits for autocrop

### DIFF
--- a/.changeset/iron-pines-gaze.md
+++ b/.changeset/iron-pines-gaze.md
@@ -1,0 +1,5 @@
+---
+'@opencupid/backend': patch
+---
+
+Fix face-aware autocrop missing faces on full-body portraits: swap BlazeFace (selfie-tuned short-range, 128×128 input) for MediaPipe FaceDetector full-range (192×192, trained on wider scenes), raise smartcrop boost weight so small faces outscore saturated/high-detail regions, and stop sharp's attention strategy from re-cropping over smartcrop's output.

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -47,7 +47,7 @@
     "@maxmind/geoip2-node": "6.3.4",
     "@prisma/client": "6.15.0",
     "@sentry/node": "10.39.0",
-    "@tensorflow-models/blazeface": "0.1.0",
+    "@tensorflow-models/face-detection": "1.0.3",
     "@tensorflow/tfjs": "4.22.0",
     "@tensorflow/tfjs-backend-cpu": "4.22.0",
     "@vue/server-renderer": "3.5.28",

--- a/apps/backend/src/__tests__/services/imageprocessor.integration.spec.ts
+++ b/apps/backend/src/__tests__/services/imageprocessor.integration.spec.ts
@@ -4,8 +4,9 @@ import path from 'path'
 
 const mockEstimateFaces = vi.fn(async () => [] as any[])
 
-vi.mock('@tensorflow-models/blazeface', () => ({
-  load: vi.fn(async () => ({
+vi.mock('@tensorflow-models/face-detection', () => ({
+  SupportedModels: { MediaPipeFaceDetector: 'MediaPipeFaceDetector' },
+  createDetector: vi.fn(async () => ({
     estimateFaces: mockEstimateFaces,
   })),
 }))

--- a/apps/backend/src/__tests__/services/imageprocessor.spec.ts
+++ b/apps/backend/src/__tests__/services/imageprocessor.spec.ts
@@ -10,8 +10,9 @@ const { mockEstimateFaces, mockSmartcrop } = vi.hoisted(() => ({
   })),
 }))
 
-vi.mock('@tensorflow-models/blazeface', () => ({
-  load: vi.fn(async () => ({
+vi.mock('@tensorflow-models/face-detection', () => ({
+  SupportedModels: { MediaPipeFaceDetector: 'MediaPipeFaceDetector' },
+  createDetector: vi.fn(async () => ({
     estimateFaces: mockEstimateFaces,
   })),
 }))
@@ -108,7 +109,10 @@ describe('ImageProcessor', () => {
 
   it('getSmartCrop passes face boosts to smartcrop', async () => {
     mockEstimateFaces.mockResolvedValueOnce([
-      { topLeft: [500, 600], bottomRight: [800, 1000], probability: [0.95] },
+      {
+        box: { xMin: 500, yMin: 600, xMax: 800, yMax: 1000, width: 300, height: 400 },
+        keypoints: [],
+      },
     ])
 
     const processor = new ImageProcessor(buffer)
@@ -116,20 +120,22 @@ describe('ImageProcessor', () => {
 
     const rect = await processor.getSmartCrop(600, 600)
 
-    // Verify smartcrop was called with the face as a boost
+    // Verify smartcrop was called with the face as a boost using a heavy
+    // weight — small faces in large frames need this to outscore high-detail
+    // non-face regions (clothing, saturated backgrounds).
     expect(mockSmartcrop).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({
         width: 600,
         height: 600,
         boost: [
-          expect.objectContaining({
-            x: expect.any(Number),
-            y: expect.any(Number),
-            width: expect.any(Number),
-            height: expect.any(Number),
-            weight: 1.0,
-          }),
+          {
+            x: 500,
+            y: 600,
+            width: 300,
+            height: 400,
+            weight: 10,
+          },
         ],
       })
     )

--- a/apps/backend/src/services/imageprocessor.ts
+++ b/apps/backend/src/services/imageprocessor.ts
@@ -6,10 +6,15 @@ import * as tf from '@tensorflow/tfjs'
 // Suppress "install tfjs-node for speed" console warning — we intentionally use the CPU backend
 tf.env().set('IS_NODE', false)
 import '@tensorflow/tfjs-backend-cpu'
-import * as blazeface from '@tensorflow-models/blazeface'
+import * as faceDetection from '@tensorflow-models/face-detection'
 
 type FaceBox = { x: number; y: number; width: number; height: number }
 type Rect = { left: number; top: number; width: number; height: number }
+
+// Smartcrop boost weight for detected faces. Values ≥ 1 strongly bias crops
+// toward faces; small faces in large frames need a high weight to outscore
+// high-detail regions like clothing texture or saturated backgrounds.
+const FACE_BOOST_WEIGHT = 10
 
 function toIntRect(r: Rect, iw: number, ih: number): sharp.Region {
   const left = Math.floor(r.left)
@@ -30,22 +35,28 @@ export class ImageProcessor {
   private sharpInstance: sharp.Sharp
   private metadata?: sharp.Metadata
   private faces: FaceBox[] = []
-  private static detector: blazeface.BlazeFaceModel | null = null
+  private static detector: faceDetection.FaceDetector | null = null
 
   constructor(buffer: Buffer) {
     this.buffer = buffer
     this.sharpInstance = sharp(buffer, { failOn: 'error' })
     if (!ImageProcessor.detector) {
-      throw new Error('BlazeFace detector not initialized. Call ImageProcessor.initialize() first.')
+      throw new Error('Face detector not initialized. Call ImageProcessor.initialize() first.')
     }
   }
 
   static async initialize() {
     try {
       await tf.ready()
-      this.detector = await blazeface.load()
+      // MediaPipe FaceDetector full-range model: 192×192 input, trained on
+      // wider scenes (up to ~5m). Unlike BlazeFace's selfie-tuned short-range
+      // variant, it reliably detects smaller faces in full-body portraits.
+      this.detector = await faceDetection.createDetector(
+        faceDetection.SupportedModels.MediaPipeFaceDetector,
+        { runtime: 'tfjs', modelType: 'full' }
+      )
     } catch (err) {
-      console.error('Failed to load BlazeFace model:', err)
+      console.error('Failed to load face detector:', err)
     }
   }
 
@@ -67,12 +78,13 @@ export class ImageProcessor {
 
     const tensor = tf.tensor3d(new Uint8Array(data), [info.height, info.width, 3])
     try {
-      const preds = await this.detector.estimateFaces(tensor, false)
-      return preds.map((p) => {
-        const [x1, y1] = p.topLeft as [number, number]
-        const [x2, y2] = p.bottomRight as [number, number]
-        return { x: x1, y: y1, width: x2 - x1, height: y2 - y1 }
-      })
+      const preds = await this.detector.estimateFaces(tensor, { flipHorizontal: false })
+      return preds.map((p) => ({
+        x: p.box.xMin,
+        y: p.box.yMin,
+        width: p.box.width,
+        height: p.box.height,
+      }))
     } finally {
       tensor.dispose()
     }
@@ -90,7 +102,7 @@ export class ImageProcessor {
       y: f.y,
       width: f.width,
       height: f.height,
-      weight: 1.0,
+      weight: FACE_BOOST_WEIGHT,
     }))
 
     const result = await smartcrop.crop(this.buffer, {
@@ -120,10 +132,14 @@ export class ImageProcessor {
         ? toIntRect(r, iw, ih)
         : { left: 0, top: 0, width: Math.max(1, iw), height: Math.max(1, ih) }
 
+    // The extracted rect is already at the target aspect ratio, so resize
+    // is a pure scale. Use a fixed centre position instead of attention to
+    // avoid sharp's content-aware crop silently overriding our smartcrop
+    // choice when toIntRect rounding shifts the aspect by a pixel.
     await this.sharpInstance
       .clone()
       .extract(rect)
-      .resize(width, height, { fit: 'cover', position: sharp.strategy.attention })
+      .resize(width, height, { fit: 'cover', position: 'centre' })
       .webp({ quality: 85 })
       .toFile(outputPath)
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -152,9 +152,9 @@ importers:
       '@sentry/node':
         specifier: 10.39.0
         version: 10.39.0
-      '@tensorflow-models/blazeface':
-        specifier: 0.1.0
-        version: 0.1.0(@tensorflow/tfjs-converter@4.22.0(@tensorflow/tfjs-core@4.22.0))(@tensorflow/tfjs-core@4.22.0)
+      '@tensorflow-models/face-detection':
+        specifier: 1.0.3
+        version: 1.0.3(@mediapipe/face_detection@0.4.1646425229)(@tensorflow/tfjs-backend-webgl@4.22.0(@tensorflow/tfjs-core@4.22.0))(@tensorflow/tfjs-converter@4.22.0(@tensorflow/tfjs-core@4.22.0))(@tensorflow/tfjs-core@4.22.0)
       '@tensorflow/tfjs':
         specifier: 4.22.0
         version: 4.22.0(seedrandom@3.0.5)
@@ -1811,6 +1811,9 @@ packages:
   '@maxmind/geoip2-node@6.3.4':
     resolution: {integrity: sha512-BTRFHCX7Uie4wVSPXsWQfg0EVl4eGZgLCts0BTKAP+Eiyt1zmF2UPyuUZkaj0R59XSDYO+84o1THAtaenUoQYg==}
 
+  '@mediapipe/face_detection@0.4.1646425229':
+    resolution: {integrity: sha512-aeCN+fRAojv9ch3NXorP6r5tcGVLR3/gC1HmtqB0WEZBRXrdP6/3W/sGR0dHr1iT6ueiK95G9PVjbzFosf/hrg==}
+
   '@modelcontextprotocol/sdk@1.22.0':
     resolution: {integrity: sha512-VUpl106XVTCpDmTBil2ehgJZjhyLY2QZikzF8NvTXtLRF1CvO5iEE2UNZdVIUer35vFOwMKYeUGbjJtvPWan3g==}
     engines: {node: '>=18'}
@@ -2677,11 +2680,13 @@ packages:
   '@stomp/stompjs@7.3.0':
     resolution: {integrity: sha512-nKMLoFfJhrQAqkvvKd1vLq/cVBGCMwPRCD0LqW7UT1fecRx9C3GoKEIR2CYwVuErGeZu8w0kFkl2rlhPlqHVgQ==}
 
-  '@tensorflow-models/blazeface@0.1.0':
-    resolution: {integrity: sha512-Qc5Wii8/OE5beC7XfehkhF9SEFLaPbVKnxxalV0T9JXsUynXqvLommc9Eko7b8zXKy4SJ1BtVlcX2cmCzQrn9A==}
+  '@tensorflow-models/face-detection@1.0.3':
+    resolution: {integrity: sha512-4Ld/vFF8MrdFdrMWhlLKZD4hMW0PNY9OkYeqoCPNZ+LwFyenxAqVaNaWrR8JKp37vw9Nuzp4ILbkal5zPUnA0g==}
     peerDependencies:
-      '@tensorflow/tfjs-converter': ^4.10.0
-      '@tensorflow/tfjs-core': ^4.10.0
+      '@mediapipe/face_detection': ~0.4.0
+      '@tensorflow/tfjs-backend-webgl': ^4.21.0
+      '@tensorflow/tfjs-converter': ^4.21.0
+      '@tensorflow/tfjs-core': ^4.21.0
 
   '@tensorflow/tfjs-backend-cpu@4.22.0':
     resolution: {integrity: sha512-1u0FmuLGuRAi8D2c3cocHTASGXOmHc/4OvoVDENJayjYkS119fcTcQf4iHrtLthWyDIPy3JiPhRrZQC9EwnhLw==}
@@ -7387,6 +7392,9 @@ packages:
   tsconfig@7.0.0:
     resolution: {integrity: sha512-vZXmzPrL+EmC4T/4rVlT2jNVMWCi/O4DIiSj3UHg1OE5kCKbk4mfrXc6dZksLgRM/TZlKnousKH9bbTazUWRRw==}
 
+  tslib@2.4.0:
+    resolution: {integrity: sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==}
+
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
@@ -9272,6 +9280,8 @@ snapshots:
     dependencies:
       maxmind: 5.0.5
 
+  '@mediapipe/face_detection@0.4.1646425229': {}
+
   '@modelcontextprotocol/sdk@1.22.0':
     dependencies:
       ajv: 8.18.0
@@ -10165,10 +10175,14 @@ snapshots:
 
   '@stomp/stompjs@7.3.0': {}
 
-  '@tensorflow-models/blazeface@0.1.0(@tensorflow/tfjs-converter@4.22.0(@tensorflow/tfjs-core@4.22.0))(@tensorflow/tfjs-core@4.22.0)':
+  '@tensorflow-models/face-detection@1.0.3(@mediapipe/face_detection@0.4.1646425229)(@tensorflow/tfjs-backend-webgl@4.22.0(@tensorflow/tfjs-core@4.22.0))(@tensorflow/tfjs-converter@4.22.0(@tensorflow/tfjs-core@4.22.0))(@tensorflow/tfjs-core@4.22.0)':
     dependencies:
+      '@mediapipe/face_detection': 0.4.1646425229
+      '@tensorflow/tfjs-backend-webgl': 4.22.0(@tensorflow/tfjs-core@4.22.0)
       '@tensorflow/tfjs-converter': 4.22.0(@tensorflow/tfjs-core@4.22.0)
       '@tensorflow/tfjs-core': 4.22.0
+      rimraf: 3.0.2
+      tslib: 2.4.0
 
   '@tensorflow/tfjs-backend-cpu@4.22.0(@tensorflow/tfjs-core@4.22.0)':
     dependencies:
@@ -15411,6 +15425,8 @@ snapshots:
       '@types/strip-json-comments': 0.0.30
       strip-bom: 3.0.0
       strip-json-comments: 2.0.1
+
+  tslib@2.4.0: {}
 
   tslib@2.8.1: {}
 


### PR DESCRIPTION
BlazeFace's default short-range model (128×128 input, selfie-tuned)
silently failed to detect faces in full-body portraits like the vineyard
shot reported. With no face boost, smartcrop's content scoring reliably
picked the legs+grass region instead of the face.

- Swap @tensorflow-models/blazeface → @tensorflow-models/face-detection
  with MediaPipe FaceDetector full-range model (192×192 input, trained
  on wider scenes up to ~5m).
- Raise smartcrop face-boost weight from 1.0 → 10 so small faces in
  large frames outscore high-detail clothing or saturated backgrounds.
- Stop passing sharp.strategy.attention to the post-extract resize —
  the rect is already at target aspect, so attention could silently
  override smartcrop's choice when toIntRect rounding nudges the aspect
  by a pixel. Use centre instead.