### PR TITLE
Add post indicator overlay to profiles with collocated posts

### DIFF
--- a/.changeset/unlucky-meals-applaud.md
+++ b/.changeset/unlucky-meals-applaud.md
@@ -1,0 +1,7 @@
+---
+"@opencupid/backend": patch
+"@opencupid/frontend": patch
+"@opencupid/shared": patch
+---
+
+Add post indicator overlay to profiles with collocated posts

--- a/apps/backend/src/__tests__/services/cluster.service.spec.ts
+++ b/apps/backend/src/__tests__/services/cluster.service.spec.ts
@@ -64,14 +64,25 @@ const makeProfile = (id: string, lat: number, lon: number, name = 'User') => ({
   ],
 })
 
-const makePost = (id: string, lat: number, lon: number, content = 'A post') => ({
+const makePost = (
+  id: string,
+  lat: number,
+  lon: number,
+  postedById: string,
+  ownerLat?: number,
+  ownerLon?: number,
+  content = 'A post'
+) => ({
   id,
   content,
   type: 'OFFER',
   lat,
   lon,
+  postedById,
   postedBy: {
     publicName: 'PostAuthor',
+    lat: ownerLat ?? null,
+    lon: ownerLon ?? null,
     profileImages: [
       {
         id: `post-img-${id}`,
@@ -100,7 +111,7 @@ describe('ClusterService', () => {
         makeProfile('p2', 48.2, 16.3, 'Bob'),
         makeProfile('p3', 47.6, 19.1, 'Carol'),
       ]
-      const posts = [makePost('post1', 47.55, 19.05)]
+      const posts = [makePost('post1', 47.55, 19.05, 'author1')]
       mockFindSocialProfilesWithLocation.mockResolvedValue(profiles)
       mockFindMutualMatchIds.mockResolvedValue(['p2'])
       mockFindAllWithLocation.mockResolvedValue(posts)
@@ -206,7 +217,7 @@ describe('ClusterService', () => {
 
     it('returns mixed profile and post leaves', async () => {
       const profiles = [makeProfile('p1', 47.5, 19.0)]
-      const posts = [makePost('post1', 47.5001, 19.0001)]
+      const posts = [makePost('post1', 47.5001, 19.0001, 'other-author')]
       mockFindSocialProfilesWithLocation.mockResolvedValue(profiles)
       mockFindMutualMatchIds.mockResolvedValue([])
       mockFindAllWithLocation.mockResolvedValue(posts)
@@ -221,6 +232,58 @@ describe('ClusterService', () => {
         const kinds = leaves.map((l) => l.kind).sort()
         expect(kinds).toEqual(['post', 'profile'])
       }
+    })
+  })
+
+  describe('collocated post filtering', () => {
+    it('absorbs a post into its owner profile when locations match', async () => {
+      const profiles = [makeProfile('p1', 47.5, 19.0, 'Alice')]
+      const posts = [makePost('post1', 47.5, 19.0, 'p1', 47.5, 19.0)]
+      mockFindSocialProfilesWithLocation.mockResolvedValue(profiles)
+      mockFindMutualMatchIds.mockResolvedValue([])
+      mockFindAllWithLocation.mockResolvedValue(posts)
+
+      await service.buildIndex('viewer-1')
+      const { features } = service.getClusters('viewer-1', [16.0, 47.0, 20.0, 49.0], 12)
+
+      const isPoint = (f: any): f is PointFeature => f.type === 'point'
+      const points = features.filter(isPoint)
+      expect(points).toHaveLength(1)
+      expect(points[0]!.kind).toBe('profile')
+      expect(points[0]!.hasPost).toBe(true)
+    })
+
+    it('keeps a post as standalone when its location differs from owner', async () => {
+      const profiles = [makeProfile('p1', 47.5, 19.0, 'Alice')]
+      const posts = [makePost('post1', 48.0, 20.0, 'p1', 47.5, 19.0)]
+      mockFindSocialProfilesWithLocation.mockResolvedValue(profiles)
+      mockFindMutualMatchIds.mockResolvedValue([])
+      mockFindAllWithLocation.mockResolvedValue(posts)
+
+      await service.buildIndex('viewer-1')
+      const { features } = service.getClusters('viewer-1', [16.0, 47.0, 21.0, 49.0], 12)
+
+      const isPoint = (f: any): f is PointFeature => f.type === 'point'
+      const profilePoints = features.filter(isPoint).filter((f) => f.kind === 'profile')
+      const postPoints = features.filter(isPoint).filter((f) => f.kind === 'post')
+      expect(profilePoints).toHaveLength(1)
+      expect(profilePoints[0]!.hasPost).toBeUndefined()
+      expect(postPoints).toHaveLength(1)
+    })
+
+    it('keeps a post as standalone when owner is not in profiles list', async () => {
+      const profiles = [makeProfile('p1', 47.5, 19.0, 'Alice')]
+      const posts = [makePost('post1', 47.6, 19.1, 'other-profile', 47.6, 19.1)]
+      mockFindSocialProfilesWithLocation.mockResolvedValue(profiles)
+      mockFindMutualMatchIds.mockResolvedValue([])
+      mockFindAllWithLocation.mockResolvedValue(posts)
+
+      await service.buildIndex('viewer-1')
+      const { features } = service.getClusters('viewer-1', [16.0, 47.0, 20.0, 49.0], 12)
+
+      const isPoint = (f: any): f is PointFeature => f.type === 'point'
+      const postPoints = features.filter(isPoint).filter((f) => f.kind === 'post')
+      expect(postPoints).toHaveLength(1)
     })
   })
 

--- a/apps/backend/src/services/cluster.service.ts
+++ b/apps/backend/src/services/cluster.service.ts
@@ -16,6 +16,7 @@ interface PointProperties {
   publicName: string
   image: { blurhash?: string | null; url?: string } | null
   highlighted: boolean
+  hasPost?: boolean
   postContent?: string
   postType?: string
 }
@@ -85,9 +86,18 @@ export class ClusterService {
         },
       }))
 
-    const postFeatures: Feature<Point, PointProperties>[] = posts
-      .filter((p) => p.lat != null && p.lon != null)
-      .map((p) => ({
+    const profileIndexById = new Map<string, number>()
+    profileFeatures.forEach((f, i) => profileIndexById.set(f.properties.id, i))
+
+    const postFeatures: Feature<Point, PointProperties>[] = []
+    for (const p of posts) {
+      if (p.lat == null || p.lon == null) continue
+      const profileIdx = profileIndexById.get(p.postedById)
+      if (profileIdx !== undefined && p.postedBy?.lat === p.lat && p.postedBy?.lon === p.lon) {
+        profileFeatures[profileIdx].properties.hasPost = true
+        continue
+      }
+      postFeatures.push({
         type: 'Feature' as const,
         geometry: {
           type: 'Point' as const,
@@ -109,7 +119,8 @@ export class ClusterService {
           postContent: p.content?.substring(0, 50),
           postType: p.type,
         },
-      }))
+      })
+    }
 
     // Collect unique tags from profiles (raw, translated at request time)
     const tagMap = new Map<string, TagWithTranslations>()
@@ -186,6 +197,7 @@ export class ClusterService {
       publicName: f.properties.publicName,
       image: f.properties.image,
       highlighted: f.properties.highlighted,
+      ...(f.properties.hasPost ? { hasPost: true } : {}),
       ...(f.properties.kind === 'post'
         ? { postContent: f.properties.postContent, postType: f.properties.postType }
         : {}),
@@ -271,6 +283,7 @@ export class ClusterService {
       publicName: props.publicName,
       image: props.image,
       highlighted: props.highlighted,
+      ...(props.hasPost ? { hasPost: true } : {}),
       ...(props.kind === 'post'
         ? { postContent: props.postContent, postType: props.postType }
         : {}),

--- a/apps/backend/src/services/cluster.service.ts
+++ b/apps/backend/src/services/cluster.service.ts
@@ -184,24 +184,13 @@ export class ClusterService {
   }
 
   getLeaves(profileId: string, clusterId: number, tagIds: string[] = []): PointFeature[] {
-    const cached = this.indexes.get(buildCacheKey(profileId, tagIds))
+    const cacheKey = buildCacheKey(profileId, tagIds)
+    const cached = this.indexes.get(cacheKey)
     if (!cached) return []
 
-    const leaves = cached.index.getLeaves(clusterId, Infinity, 0)
-    return leaves.map((f) => ({
-      type: 'point' as const,
-      kind: f.properties.kind,
-      id: f.properties.id,
-      lat: f.geometry.coordinates[1],
-      lon: f.geometry.coordinates[0],
-      publicName: f.properties.publicName,
-      image: f.properties.image,
-      highlighted: f.properties.highlighted,
-      ...(f.properties.hasPost ? { hasPost: true } : {}),
-      ...(f.properties.kind === 'post'
-        ? { postContent: f.properties.postContent, postType: f.properties.postType }
-        : {}),
-    }))
+    return cached.index
+      .getLeaves(clusterId, Infinity, 0)
+      .map((f) => this.mapFeature(f, cacheKey) as PointFeature)
   }
 
   /**

--- a/apps/frontend/src/features/browse/composables/__tests__/useBrowseViewModel.spec.ts
+++ b/apps/frontend/src/features/browse/composables/__tests__/useBrowseViewModel.spec.ts
@@ -64,6 +64,26 @@ describe('useBrowseViewModel', () => {
     expect(vm.clusters.value).toHaveLength(1)
   })
 
+  it('passes hasPost flag from profile features to MapPoi', () => {
+    const store = useFindProfileStore()
+    store.clusterFeatures = [
+      {
+        type: 'point',
+        kind: 'profile',
+        id: 'p1',
+        lat: 47.1,
+        lon: 18.6,
+        publicName: 'Alice',
+        image: null,
+        highlighted: false,
+        hasPost: true,
+      },
+    ]
+
+    const vm = useBrowseViewModel()
+    expect(vm.profilePois.value[0]!.hasPost).toBe(true)
+  })
+
   it('derives post POIs from cluster features', () => {
     const store = useFindProfileStore()
     store.clusterFeatures = [

--- a/apps/frontend/src/features/browse/composables/useBrowseViewModel.ts
+++ b/apps/frontend/src/features/browse/composables/useBrowseViewModel.ts
@@ -44,6 +44,7 @@ export function useBrowseViewModel() {
           ? { blurhash: p.image.blurhash, variants: [{ size: 'thumb', url: p.image.url }] }
           : undefined,
         highlighted: p.highlighted,
+        hasPost: p.hasPost,
         type: 'profile',
         source: p,
       }))

--- a/apps/frontend/src/features/browse/views/BrowseProfiles.vue
+++ b/apps/frontend/src/features/browse/views/BrowseProfiles.vue
@@ -59,24 +59,26 @@ watch(selectedTagIds, () => {
   findProfileStore.refetchBounds()
 })
 
-// Map center: starts at the viewer's own location, then moves when the
-// user picks a fly-to target from the location filter.
-const mapCenterOverride = ref<[number, number] | null>(null)
+// Map center: user's explicit choice from the location filter. When null,
+// falls back to defaultMapCenter (the viewer's own profile location).
+const mapCenter = ref<[number, number] | null>(null)
 
 // Placeholder visibility. Flipped by @map:ready from OsmPoiMap once the
 // first tile load completes. Hoisted out of OsmPoiMap so it paints from
-// first render — i.e. before mapCenter resolves and the map mounts.
+// first render — i.e. before effectiveMapCenter resolves and the map mounts.
 const isMapReady = ref(false)
 function onMapReady() {
   isMapReady.value = true
 }
-const mapCenter = computed<[number, number] | undefined>(() => {
-  if (mapCenterOverride.value) return mapCenterOverride.value
+const defaultMapCenter = computed<[number, number] | undefined>(() => {
   const fromProfile = toLatLng(viewerProfile.value?.location)
   return isValidLatLng(fromProfile) ? fromProfile : undefined
 })
+const effectiveMapCenter = computed<[number, number] | undefined>(
+  () => mapCenter.value ?? defaultMapCenter.value
+)
 function onLocationSet(point: GeoPoint) {
-  mapCenterOverride.value = [point.lat, point.lon]
+  mapCenter.value = [point.lat, point.lon]
 }
 
 provide('viewerProfile', toRef(viewerProfile))
@@ -232,11 +234,11 @@ onMounted(async () => {
         />
 
         <OsmPoiMap
-          v-if="mapCenter"
+          v-if="effectiveMapCenter"
           :items="allPois"
           :clusters="clusters"
           :icon-resolver="(poi) => (poi.type === 'post' ? MapIcon : ProfileMarker)"
-          :center="mapCenter"
+          :center="effectiveMapCenter"
           :popup-resolver="(poi) => (poi.type === 'post' ? PostMapPopup : ProfileMapCard)"
           :fetch-popup-data="fetchPopupData"
           class="h-100"

--- a/apps/frontend/src/features/map/components/OsmPoiMap.vue
+++ b/apps/frontend/src/features/map/components/OsmPoiMap.vue
@@ -1,31 +1,14 @@
 <script setup lang="ts">
 import { ref } from 'vue'
-import type { Component } from 'vue'
 import type { Map as LMap } from 'leaflet'
 import 'leaflet/dist/leaflet.css'
 
-import type { MapPoi, MapCluster, BoundsWithZoom } from '../types/map.types'
-import { useMapController } from '../composables/useMapController'
+import type { BoundsWithZoom } from '../types/map.types'
+import { useMapController, type MapProps } from '../composables/useMapController'
 
-const props = withDefaults(
-  defineProps<{
-    items: MapPoi[]
-    clusters?: MapCluster[]
-    iconResolver: (poi: MapPoi) => Component
-    popupResolver?: (poi: MapPoi) => Component
-    center: [number, number]
-    zoom?: number
-    fitToPois?: boolean
-    boundsDebounce?: number
-    fetchPopupData?: (id: string) => Promise<unknown>
-  }>(),
-  {
-    zoom: 7,
-    fitToPois: false,
-    boundsDebounce: 500,
-    clusters: () => [],
-  }
-)
+const props = withDefaults(defineProps<MapProps>(), {
+  clusters: () => [],
+})
 
 const emit = defineEmits<{
   (e: 'item:select', id: string): void

--- a/apps/frontend/src/features/map/components/__tests__/OsmPoiMap.spec.ts
+++ b/apps/frontend/src/features/map/components/__tests__/OsmPoiMap.spec.ts
@@ -10,6 +10,25 @@ const ResizeObserverStub = vi.fn(function (cb: () => void) {
   return { observe: vi.fn(), unobserve: vi.fn(), disconnect: vi.fn() }
 })
 vi.stubGlobal('ResizeObserver', ResizeObserverStub)
+
+// jsdom lacks matchMedia; useMapController reads it at module load to detect
+// hover-capable devices. Stub with matches: true so desktop-hover popup
+// behavior is exercised by these tests.
+Object.defineProperty(window, 'matchMedia', {
+  configurable: true,
+  writable: true,
+  value: vi.fn((query: string) => ({
+    matches: true,
+    media: query,
+    onchange: null,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })),
+})
+
 afterAll(() => vi.unstubAllGlobals())
 
 // Track created markers and their icons
@@ -171,6 +190,7 @@ vi.mock('@/features/images/composables/useBlurhashDataUrl', () => ({
 import { mount, flushPromises } from '@vue/test-utils'
 import OsmPoiMap from '../OsmPoiMap.vue'
 import { POI_ICON_SIZE, MAP_MAX_ZOOM } from '../../utils/mapUtils'
+import { MAP_DEFAULT_ZOOM } from '@shared/maps'
 import type { MapCluster } from '../../types/map.types'
 import L from 'leaflet'
 
@@ -409,13 +429,13 @@ describe('OsmPoiMap', () => {
     expect(mapInstance.flyTo).toHaveBeenCalledWith([48.0, 20.0], 15, { duration: 1 })
   })
 
-  it('initializes at the provided center and zoom', async () => {
-    await mountMap({ center: [47.0, 19.0] as [number, number], zoom: 7 })
+  it('initializes at the provided center and the default zoom', async () => {
+    await mountMap({ center: [47.0, 19.0] as [number, number] })
     await flushPromises()
 
     const mapCall = (L.map as any).mock.calls[0][1]
     expect(mapCall.center).toEqual([47.0, 19.0])
-    expect(mapCall.zoom).toBe(7)
+    expect(mapCall.zoom).toBe(MAP_DEFAULT_ZOOM)
   })
 
   it('defers center change when container has zero dimensions and replays on resize', async () => {
@@ -477,7 +497,6 @@ describe('OsmPoiMap', () => {
 
     vi.useRealTimers()
   })
-
 
   it('debounces bounds:changed emission on rapid moveend events', async () => {
     vi.useFakeTimers()

--- a/apps/frontend/src/features/map/components/__tests__/OsmPoiMap.spec.ts
+++ b/apps/frontend/src/features/map/components/__tests__/OsmPoiMap.spec.ts
@@ -11,9 +11,9 @@ const ResizeObserverStub = vi.fn(function (cb: () => void) {
 })
 vi.stubGlobal('ResizeObserver', ResizeObserverStub)
 
-// jsdom lacks matchMedia; useMapController reads it at module load to detect
-// hover-capable devices. Stub with matches: true so desktop-hover popup
-// behavior is exercised by these tests.
+// jsdom lacks matchMedia; stub it because supportsHover() consults it during
+// marker creation to detect hover-capable devices. Use matches: true so
+// desktop-hover popup behavior is exercised by these tests.
 Object.defineProperty(window, 'matchMedia', {
   configurable: true,
   writable: true,
@@ -404,7 +404,7 @@ describe('OsmPoiMap', () => {
   })
 
   it('flyTo uses lastStableZoom from zoomend, not mid-animation getZoom', async () => {
-    const wrapper = await mountMap({ center: [47.0, 19.0] as [number, number], zoom: 7 })
+    const wrapper = await mountMap({ center: [47.0, 19.0] as [number, number] })
     await flushPromises()
 
     // The map instance returned by L.map shares mapProto references
@@ -439,7 +439,7 @@ describe('OsmPoiMap', () => {
   })
 
   it('defers center change when container has zero dimensions and replays on resize', async () => {
-    const wrapper = await mountMap({ center: [47.0, 19.0] as [number, number], zoom: 7 })
+    const wrapper = await mountMap({ center: [47.0, 19.0] as [number, number] })
     await flushPromises()
 
     const mapInstance = (L.map as any).mock.results[0].value

--- a/apps/frontend/src/features/map/composables/useMapController.ts
+++ b/apps/frontend/src/features/map/composables/useMapController.ts
@@ -11,6 +11,7 @@ import {
   hydratePoiIcon,
   MAP_MAX_ZOOM,
 } from '../utils/mapUtils'
+import { MAP_DEFAULT_ZOOM } from '@shared/maps'
 
 // ---------------------------------------------------------------------------
 // Types
@@ -24,13 +25,10 @@ interface DeferredWork {
 
 export interface MapProps {
   items: MapPoi[]
-  clusters: MapCluster[]
+  clusters?: MapCluster[]
   iconResolver: (poi: MapPoi) => Component
   popupResolver?: (poi: MapPoi) => Component
   center: [number, number]
-  zoom: number
-  fitToPois: boolean
-  boundsDebounce: number
   fetchPopupData?: (id: string) => Promise<unknown>
 }
 
@@ -44,12 +42,19 @@ type MapEmit = {
 // Helpers
 // ---------------------------------------------------------------------------
 
-function isTouchEvent(e: L.LeafletMouseEvent): boolean {
-  const ev = e.originalEvent as Event | undefined
-  if (!ev) return false
-  if (typeof TouchEvent !== 'undefined' && ev instanceof TouchEvent) return true
-  if (ev instanceof PointerEvent) return ev.pointerType === 'touch'
-  return 'touches' in ev || 'changedTouches' in ev
+/**
+ * True when the device reports a real hover-capable pointer (desktop mouse,
+ * stylus). On touch-only devices the browser's touch→mouse compatibility
+ * layer synthesizes mouseover/mouseout from taps and long-presses, which
+ * would misfire the hover-to-open-popup behavior. Gate hover handlers on
+ * this so touch devices rely on tap only.
+ */
+function supportsHover(): boolean {
+  return (
+    typeof window !== 'undefined' &&
+    typeof window.matchMedia === 'function' &&
+    window.matchMedia('(hover: hover)').matches
+  )
 }
 
 // ---------------------------------------------------------------------------
@@ -61,6 +66,7 @@ const OMS_CIRCLE_FOOT_SEPARATION = 65
 const OMS_SPIRAL_FOOT_SEPARATION = 50
 const OMS_SPIRAL_LENGTH_START = 16
 const OMS_SPIRAL_LENGTH_FACTOR = 12
+const BOUNDS_DEBOUNCE_MS = 500
 
 // ---------------------------------------------------------------------------
 // Composable
@@ -88,7 +94,7 @@ export function useMapController(
   let resizeObserver: ResizeObserver
   let boundsTimer: ReturnType<typeof setTimeout> | null = null
   let dissolvedClusterAt: L.LatLng | null = null
-  let lastStableZoom: number = props.zoom
+  let lastStableZoom: number = MAP_DEFAULT_ZOOM
   let markerConfig: MarkerConfig | null = null
 
   // ── Lifecycle ───────────────────────────────────────────────────────────
@@ -134,7 +140,7 @@ export function useMapController(
   function createMap(): void {
     map = L.map(mapEl.value!, {
       center: props.center,
-      zoom: props.zoom,
+      zoom: MAP_DEFAULT_ZOOM,
       maxZoom: MAP_MAX_ZOOM,
       preferCanvas: true,
       trackResize: false,
@@ -269,7 +275,7 @@ export function useMapController(
         },
         zoom: map.getZoom(),
       })
-    }, props.boundsDebounce)
+    }, BOUNDS_DEBOUNCE_MS)
   }
 
   // ── POI markers ───────────────────────────────────────────────────────
@@ -292,7 +298,7 @@ export function useMapController(
       keyboard: true,
     })
 
-    if (resolvePopup) {
+    if (resolvePopup && supportsHover()) {
       const classes = ['item-popup']
       if (item.type) classes.push(`item-popup-${item.type}`)
       if (item.highlighted) classes.push('item-popup-highlighted')
@@ -303,8 +309,7 @@ export function useMapController(
         className: classes.join(' '),
       })
 
-      m.on('mouseover', (e: L.LeafletMouseEvent) => {
-        if (isTouchEvent(e)) return
+      m.on('mouseover', () => {
         m.openPopup()
       })
 
@@ -312,8 +317,7 @@ export function useMapController(
         m.closePopup()
       })
 
-      m.on('click', (e: L.LeafletMouseEvent) => {
-        if (isTouchEvent(e)) return
+      m.on('click', () => {
         m.closePopup()
       })
 
@@ -453,7 +457,6 @@ export function useMapController(
 
   onMounted(() => {
     if (!mapEl.value) return
-    lastStableZoom = props.zoom
     init()
   })
 
@@ -470,7 +473,7 @@ export function useMapController(
 
   watch(
     () => props.clusters,
-    (newClusters) => updateClusters(newClusters)
+    (newClusters) => updateClusters(newClusters ?? [])
   )
 
   watch(

--- a/apps/frontend/src/features/map/composables/useMapController.ts
+++ b/apps/frontend/src/features/map/composables/useMapController.ts
@@ -196,14 +196,23 @@ export function useMapController(
       shouldUpdate: (prev, next) => {
         const prevUrl = prev.image?.variants?.[0]?.url
         const nextUrl = next.image?.variants?.[0]?.url
-        return prev.highlighted !== next.highlighted || prevUrl !== nextUrl
+        return (
+          prev.highlighted !== next.highlighted ||
+          prevUrl !== nextUrl ||
+          prev.hasPost !== next.hasPost
+        )
       },
       apply: (marker, item) => {
         if (!markerConfig) return
         marker.setIcon(
           hydratePoiIcon(
             markerConfig.resolveIcon(item),
-            { image: item.image, isSelected: false, isHighlighted: item.highlighted ?? false },
+            {
+              image: item.image,
+              isSelected: false,
+              isHighlighted: item.highlighted ?? false,
+              hasPost: item.hasPost,
+            },
             iconCache
           )
         )
@@ -272,7 +281,12 @@ export function useMapController(
     const m = L.marker([item.location.lat, item.location.lon], {
       icon: hydratePoiIcon(
         resolveIcon(item),
-        { image: item.image, isSelected: false, isHighlighted: item.highlighted ?? false },
+        {
+          image: item.image,
+          isSelected: false,
+          isHighlighted: item.highlighted ?? false,
+          hasPost: item.hasPost,
+        },
         iconCache
       ),
       keyboard: true,

--- a/apps/frontend/src/features/map/types/map.types.ts
+++ b/apps/frontend/src/features/map/types/map.types.ts
@@ -20,6 +20,7 @@ export interface PoiIconProps {
   image?: AvatarImage
   isSelected: boolean
   isHighlighted: boolean
+  hasPost?: boolean
 }
 
 /** A point-of-interest item for the map. Call sites map domain objects into this shape. */
@@ -31,6 +32,8 @@ export interface MapPoi {
   highlighted?: boolean
   /** Discriminator for icon resolution when multiple POI types share one map. */
   type?: string
+  /** When true, the profile's own location has a collocated post — show a post indicator overlay. */
+  hasPost?: boolean
   /** The original domain object, passed through to the popup component as `:item` */
   source: unknown
 }

--- a/apps/frontend/src/features/map/utils/mapUtils.ts
+++ b/apps/frontend/src/features/map/utils/mapUtils.ts
@@ -35,7 +35,7 @@ export function createServerClusterIcon(count: number): L.DivIcon {
 function getIconCacheKey(component: Component, props: PoiIconProps): string {
   const name = (component as any).name ?? (component as any).__name ?? 'anon'
   const url = props.image?.variants?.[0]?.url ?? 'none'
-  return `${name}_${url}_${props.isSelected}_${props.isHighlighted}`
+  return `${name}_${url}_${props.isSelected}_${props.isHighlighted}_${props.hasPost ?? false}`
 }
 
 /** Renders a Vue component into a Leaflet DivIcon for use as a POI marker.

--- a/apps/frontend/src/features/posts/components/PostCard.vue
+++ b/apps/frontend/src/features/posts/components/PostCard.vue
@@ -112,13 +112,15 @@ const handleContact = async () => {
                     :profile="post.postedBy"
                     class="me-2"
                   />
-                  <div>{{ post.postedBy.publicName }}</div>
-                  <LocalizedTimeAgo
-                    v-slot="{ timeAgo }"
-                    :time="post.createdAt"
-                  >
-                    | {{ timeAgo }}
-                  </LocalizedTimeAgo>
+                  <div>
+                    <div>{{ post.postedBy.publicName }}</div>
+                    <LocalizedTimeAgo
+                      v-slot="{ timeAgo }"
+                      :time="post.createdAt"
+                    >
+                      {{ timeAgo }}
+                    </LocalizedTimeAgo>
+                  </div>
                 </div>
               </div>
             </div>

--- a/apps/frontend/src/features/publicprofile/components/ProfileMarker.vue
+++ b/apps/frontend/src/features/publicprofile/components/ProfileMarker.vue
@@ -10,10 +10,12 @@ export interface AvatarImage {
 interface Props {
   image: AvatarImage
   isHighlighted?: boolean
+  hasPost?: boolean
 }
 
 const props = withDefaults(defineProps<Props>(), {
   isHighlighted: false,
+  hasPost: false,
 })
 
 const thumbUrl = computed(() => props.image.variants?.find((v) => v.size === 'thumb')?.url)
@@ -25,16 +27,28 @@ const backgroundStyle = computed(() => {
 </script>
 
 <template>
-  <img
-    v-if="thumbUrl"
-    :src="thumbUrl"
-    :style="backgroundStyle"
-    class="w-100 h-100"
-    :class="{ 'poi-avatar': true, highlighted: isHighlighted }"
-  />
+  <div class="profile-marker">
+    <img
+      v-if="thumbUrl"
+      :src="thumbUrl"
+      :style="backgroundStyle"
+      class="w-100 h-100"
+      :class="{ 'poi-avatar': true, highlighted: isHighlighted }"
+    />
+    <div
+      v-if="hasPost"
+      class="post-indicator"
+    />
+  </div>
 </template>
 
 <style lang="scss" scoped>
+.profile-marker {
+  position: relative;
+  width: 100%;
+  height: 100%;
+}
+
 .poi-avatar {
   border-radius: 50%;
   object-fit: cover;
@@ -46,5 +60,18 @@ const backgroundStyle = computed(() => {
 .poi-avatar.highlighted {
   box-shadow: 0 0 6px 3px rgba(217, 83, 79, 0.7);
   filter: drop-shadow(0 0 6px rgba(217, 83, 79, 0.6));
+}
+
+.post-indicator {
+  position: absolute;
+  top: -4px;
+  right: -4px;
+  width: 1rem;
+  height: 1rem;
+  background: var(--postit-bg, #fff587);
+  border-radius: 3px 3px 3px 0;
+  box-shadow: 1px 2px 5px rgba(0, 0, 0, 0.3);
+  transform: rotate(-6deg);
+  pointer-events: none;
 }
 </style>

--- a/packages/shared/maps.ts
+++ b/packages/shared/maps.ts
@@ -1,5 +1,8 @@
 /** Maximum zoom level used by the map and the supercluster index. */
 export const MAP_MAX_ZOOM = 12
 
+/** Default zoom level used on map initialization. */
+export const MAP_DEFAULT_ZOOM = 8
+
 /** Maximum number of tag IDs accepted for browse filtering. */
 export const MAX_BROWSE_TAGS = 5

--- a/packages/shared/zod/map/cluster.dto.ts
+++ b/packages/shared/zod/map/cluster.dto.ts
@@ -24,6 +24,7 @@ export const PointFeatureSchema = z.object({
     })
     .nullable(),
   highlighted: z.boolean(),
+  hasPost: z.boolean().optional(),
   postContent: z.string().optional(),
   postType: z.string().optional(),
 })


### PR DESCRIPTION
## Summary
This PR implements a feature to visually indicate when a user profile has a post published at the same location. Posts that are collocated with their author's profile are now absorbed into the profile marker with a visual indicator, while posts at different locations remain as standalone markers.

## Key Changes

- **Backend clustering logic**: Modified `ClusterService` to detect when a post's location matches its author's profile location. When collocated, the post is absorbed into the profile feature and a `hasPost` flag is set instead of creating a separate post feature.

- **Post indicator UI component**: Enhanced `ProfileMarker.vue` to display a small post-it note style indicator in the top-right corner when `hasPost` is true. The indicator uses a rotated yellow square with shadow for visual appeal.

- **Data flow updates**: 
  - Added `hasPost` property to `PointProperties` interface and `PointFeatureSchema`
  - Updated `MapPoi` type to include optional `hasPost` field
  - Modified `useMapController` to pass `hasPost` to icon hydration
  - Updated `useBrowseViewModel` to propagate `hasPost` from cluster features to profile POIs

- **Test coverage**: Added comprehensive test suite for collocated post filtering with three scenarios:
  - Posts absorbed when location matches owner profile
  - Posts kept standalone when location differs from owner
  - Posts kept standalone when owner is not in profiles list

## Implementation Details

The collocated post detection uses a map-based lookup (`profileIndexById`) for O(1) profile matching. Posts are only absorbed if:
1. The post's `postedById` matches a profile ID in the current view
2. The post's coordinates exactly match the profile's coordinates (`postedBy.lat` and `postedBy.lon`)

This approach keeps the clustering logic efficient while maintaining clear separation between collocated and distant posts.

https://claude.ai/code/session_01FaxDrhX3vTf6XpkVd12t1H