### PR TITLE
Add responsive mobile sidebar with offcanvas navigation

### DIFF
--- a/.changeset/funny-lemons-deny.md
+++ b/.changeset/funny-lemons-deny.md
@@ -1,0 +1,5 @@
+---
+"@opencupid/admin": patch
+---
+
+Add responsive mobile sidebar with offcanvas navigation

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "bootstrap": "5.3.8",
+    "bootstrap-vue-next": "0.43.7",
     "chart.js": "^4.5.1",
     "vue": "3.5.28",
     "vue-chartjs": "^5.3.3",

--- a/apps/admin/src/App.vue
+++ b/apps/admin/src/App.vue
@@ -1,16 +1,90 @@
 <script setup lang="ts">
-import { computed } from 'vue'
+import { ref, computed, watch } from 'vue'
+import { useRoute } from 'vue-router'
+import { BOffcanvas } from 'bootstrap-vue-next'
 
 const version = computed(() => __APP_VERSION__)
+const route = useRoute()
+
+const STORAGE_KEY = 'admin-sidebar-open'
+
+const sidebarOpen = ref(localStorage.getItem(STORAGE_KEY) === 'true')
+
+watch(sidebarOpen, (val) => {
+  localStorage.setItem(STORAGE_KEY, String(val))
+})
+
+watch(
+  () => route.path,
+  () => {
+    if (window.innerWidth < 992) {
+      sidebarOpen.value = false
+    }
+  }
+)
 </script>
 
 <template>
-  <div class="d-flex">
-    <nav
-      class="sidebar d-flex flex-column p-3"
-      style="width: 220px; flex-shrink: 0"
+  <header class="d-lg-none topbar d-flex align-items-center px-3">
+    <button
+      class="sidebar-toggle me-3"
+      type="button"
+      aria-label="Toggle navigation"
+      @click="sidebarOpen = !sidebarOpen"
     >
-      <h5 class="text-white mb-4">Admin</h5>
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="24"
+        height="24"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      >
+        <line
+          x1="3"
+          y1="6"
+          x2="21"
+          y2="6"
+        />
+        <line
+          x1="3"
+          y1="12"
+          x2="21"
+          y2="12"
+        />
+        <line
+          x1="3"
+          y1="18"
+          x2="21"
+          y2="18"
+        />
+      </svg>
+    </button>
+    <span class="fw-semibold">Admin</span>
+  </header>
+
+  <div class="d-flex">
+    <BOffcanvas
+      v-model="sidebarOpen"
+      placement="start"
+      responsive="lg"
+      :teleport-disabled="true"
+      no-header
+      class="sidebar"
+      body-class="d-flex flex-column"
+    >
+      <div class="d-flex align-items-center justify-content-between mb-4">
+        <h5 class="text-white mb-0">Admin</h5>
+        <button
+          class="btn-close btn-close-white d-lg-none"
+          type="button"
+          aria-label="Close"
+          @click="sidebarOpen = false"
+        />
+      </div>
       <ul class="nav flex-column">
         <li class="nav-item">
           <router-link
@@ -51,9 +125,10 @@ const version = computed(() => __APP_VERSION__)
         </li>
       </ul>
       <div class="mt-auto text-white-50 small">v{{ version }}</div>
-    </nav>
+    </BOffcanvas>
+
     <main
-      class="flex-grow-1 p-4 pb-5 bg-light"
+      class="flex-grow-1 p-3 p-lg-4 pb-5 bg-light"
       style="min-height: 100vh; min-width: 0"
     >
       <router-view />

--- a/apps/admin/src/main.ts
+++ b/apps/admin/src/main.ts
@@ -1,10 +1,13 @@
 import { createApp } from 'vue'
 import 'bootstrap/dist/css/bootstrap.min.css'
+import 'bootstrap-vue-next/dist/bootstrap-vue-next.css'
 import 'bootstrap'
+import { createBootstrap } from 'bootstrap-vue-next'
 import App from './App.vue'
 import { router } from './router'
 import './style.css'
 
 const app = createApp(App)
 app.use(router)
+app.use(createBootstrap())
 app.mount('#app')

--- a/apps/admin/src/pages/DashboardPage.vue
+++ b/apps/admin/src/pages/DashboardPage.vue
@@ -153,54 +153,48 @@ onMounted(async () => {
 
     <div
       v-if="stats"
-      class="row g-3"
+      class="kpi-grid"
     >
-      <div class="col-sm-6 col-lg-4">
-        <div class="card kpi-card">
-          <div class="card-body">
-            <div class="text-muted small">Total Users</div>
-            <div class="kpi-value">{{ stats.totalUsers }}</div>
-          </div>
+      <div class="card kpi-card">
+        <div class="card-body">
+          <h6 class="card-title">Total Users</h6>
+          <h6 class="card-subtitle mb-2 text-body-secondary">&nbsp;</h6>
+          <div class="kpi-value">{{ stats.totalUsers }}</div>
         </div>
       </div>
-      <div class="col-sm-6 col-lg-4">
-        <div class="card kpi-card">
-          <div class="card-body">
-            <div class="text-muted small">Total Profiles</div>
-            <div class="kpi-value">{{ stats.totalProfiles }}</div>
-          </div>
+      <div class="card kpi-card">
+        <div class="card-body">
+          <h6 class="card-title">Total Profiles</h6>
+          <h6 class="card-subtitle mb-2 text-body-secondary">&nbsp;</h6>
+          <div class="kpi-value">{{ stats.totalProfiles }}</div>
         </div>
       </div>
-      <div class="col-sm-6 col-lg-4">
-        <div class="card kpi-card">
-          <div class="card-body">
-            <div class="text-muted small">Active Profiles</div>
-            <div class="kpi-value">{{ stats.activeProfiles }}</div>
-          </div>
+      <div class="card kpi-card">
+        <div class="card-body">
+          <h6 class="card-title">Active Profiles</h6>
+          <h6 class="card-subtitle mb-2 text-body-secondary">&nbsp;</h6>
+          <div class="kpi-value">{{ stats.activeProfiles }}</div>
         </div>
       </div>
-      <div class="col-sm-6 col-lg-4">
-        <div class="card kpi-card">
-          <div class="card-body">
-            <div class="text-muted small">Signups (Last 7 Days)</div>
-            <div class="kpi-value">{{ stats.recentSignups }}</div>
-          </div>
+      <div class="card kpi-card">
+        <div class="card-body">
+          <h6 class="card-title">Signups</h6>
+          <h6 class="card-subtitle mb-2 text-body-secondary">Last 7 Days</h6>
+          <div class="kpi-value">{{ stats.recentSignups }}</div>
         </div>
       </div>
-      <div class="col-sm-6 col-lg-4">
-        <div class="card kpi-card">
-          <div class="card-body">
-            <div class="text-muted small">Blocked Users</div>
-            <div class="kpi-value">{{ stats.blockedUsers }}</div>
-          </div>
+      <div class="card kpi-card">
+        <div class="card-body">
+          <h6 class="card-title">Blocked Users</h6>
+          <h6 class="card-subtitle mb-2 text-body-secondary">&nbsp;</h6>
+          <div class="kpi-value">{{ stats.blockedUsers }}</div>
         </div>
       </div>
-      <div class="col-sm-6 col-lg-4">
-        <div class="card kpi-card">
-          <div class="card-body">
-            <div class="text-muted small">Reported Profiles</div>
-            <div class="kpi-value">{{ stats.reportedProfiles }}</div>
-          </div>
+      <div class="card kpi-card">
+        <div class="card-body">
+          <h6 class="card-title">Reported Profiles</h6>
+          <h6 class="card-subtitle mb-2 text-body-secondary">&nbsp;</h6>
+          <div class="kpi-value">{{ stats.reportedProfiles }}</div>
         </div>
       </div>
     </div>
@@ -305,3 +299,18 @@ onMounted(async () => {
     </div>
   </div>
 </template>
+
+<style scoped>
+.kpi-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  grid-auto-rows: 1fr;
+  gap: 1rem;
+}
+
+@media (min-width: 992px) {
+  .kpi-grid {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+</style>

--- a/apps/admin/src/pages/ProfilesPage.vue
+++ b/apps/admin/src/pages/ProfilesPage.vue
@@ -221,7 +221,7 @@ onUnmounted(() => {
       {{ error }}
     </div>
 
-    <div class="mb-3 d-flex gap-2">
+    <div class="mb-3 d-flex flex-wrap gap-2">
       <input
         v-model="search"
         type="text"

--- a/apps/admin/src/pages/TagsPage.vue
+++ b/apps/admin/src/pages/TagsPage.vue
@@ -418,7 +418,7 @@ onUnmounted(() => {
       {{ error }}
     </div>
 
-    <div class="mb-3 d-flex gap-2">
+    <div class="mb-3 d-flex flex-wrap gap-2">
       <input
         v-model="search"
         type="text"

--- a/apps/admin/src/style.css
+++ b/apps/admin/src/style.css
@@ -1,7 +1,43 @@
 /* Admin-specific styles */
-.sidebar {
-  min-height: 100vh;
+
+/* Mobile top bar */
+.topbar {
+  height: 56px;
   background-color: #212529;
+  color: #fff;
+}
+
+.sidebar-toggle {
+  background: none;
+  border: none;
+  color: #fff;
+  padding: 0;
+  cursor: pointer;
+}
+
+/* Sidebar (BOffcanvas) */
+.sidebar {
+  background-color: #212529;
+}
+
+.sidebar.offcanvas-lg {
+  --bs-offcanvas-width: 260px;
+}
+
+/* Desktop: override Bootstrap responsive offcanvas resets to keep sidebar look */
+@media (min-width: 992px) {
+  .sidebar.offcanvas-lg {
+    width: 220px;
+    flex-shrink: 0;
+    background-color: #212529 !important;
+    min-height: 100vh;
+  }
+
+  .sidebar.offcanvas-lg .offcanvas-body {
+    flex-grow: 1 !important;
+    flex-direction: column;
+    padding: 1rem !important;
+  }
 }
 
 .sidebar .nav-link {
@@ -40,4 +76,12 @@
   background: #fff;
   border-radius: 0.5rem;
   box-shadow: 0 0.125rem 0.25rem rgba(0, 0, 0, 0.075);
+}
+
+/* Responsive tables: horizontal scroll on small screens */
+@media (max-width: 991.98px) {
+  .table-container {
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -73,6 +73,9 @@ importers:
       bootstrap:
         specifier: 5.3.8
         version: 5.3.8(@popperjs/core@2.11.8)
+      bootstrap-vue-next:
+        specifier: 0.43.7
+        version: 0.43.7(@vueuse/core@14.2.1(vue@3.5.28(typescript@5.9.3)))(vue-router@5.0.3(@vue/compiler-sfc@3.5.28)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.28(typescript@5.9.3)))(vue@3.5.28(typescript@5.9.3)))(vue@3.5.28(typescript@5.9.3))
       chart.js:
         specifier: ^4.5.1
         version: 4.5.1


### PR DESCRIPTION
## Summary
Refactored the admin sidebar to use Bootstrap Vue Next's `BOffcanvas` component, enabling a responsive mobile-friendly navigation drawer that collapses on smaller screens while maintaining the desktop sidebar layout on larger viewports.

## Key Changes
- **Sidebar Navigation**: Converted fixed sidebar to `BOffcanvas` component with responsive behavior (collapses on mobile, fixed on desktop at 992px breakpoint)
- **Mobile Top Bar**: Added a new header with hamburger menu toggle button visible only on screens smaller than 992px
- **State Management**: Implemented sidebar open/close state with localStorage persistence to remember user preference across sessions
- **Route-based Auto-close**: Sidebar automatically closes when navigating to a new route on mobile devices
- **Styling Updates**: 
  - Added mobile topbar styling (56px height, dark background)
  - Configured offcanvas width (260px on mobile, 220px on desktop)
  - Added responsive table container styles for horizontal scrolling on small screens
  - Updated main content padding to be responsive (smaller on mobile, larger on desktop)
- **Dependencies**: Added `bootstrap-vue-next` (v0.43.7) and integrated it into the Vue app
- **Layout Fixes**: Added `flex-wrap` to filter controls in ProfilesPage and TagsPage for better mobile responsiveness

## Implementation Details
- Sidebar state is persisted in localStorage using the key `admin-sidebar-open`
- The offcanvas component uses `responsive="lg"` to automatically convert to a drawer on mobile
- Desktop view (≥992px) maintains the original sidebar appearance with proper styling overrides
- Close button added to sidebar header for mobile users to dismiss the drawer
- All navigation links automatically close the sidebar on mobile when clicked

https://claude.ai/code/session_011Ki9wCBuYTy74H2aAbz8sf