### PR TITLE
fix(profile): evict cluster cache on dating-mode toggle

### DIFF
--- a/.changeset/swift-caches-refresh.md
+++ b/.changeset/swift-caches-refresh.md
@@ -1,0 +1,5 @@
+---
+'@opencupid/backend': patch
+---
+
+Evict cluster cache when dating scope is toggled so the map reflects the new active state.

--- a/apps/backend/src/api/routes/profile.route.ts
+++ b/apps/backend/src/api/routes/profile.route.ts
@@ -397,6 +397,7 @@ const profileRoutes: FastifyPluginAsync = async (fastify) => {
       try {
         const updated = await profileService.updateScopes(req.user.userId, data)
         if (!updated) return sendError(reply, 404, 'Profile not found')
+        clusterService.evict(updated.id)
         // Update session with new profile scope data
         await req.updateSession({
           hasActiveProfile: updated.isActive,


### PR DESCRIPTION
## Summary
- Call `clusterService.evict(updated.id)` after a successful `PATCH /scopes`
- Prevents stale map clusters after the user toggles dating mode on/off
- Mirrors the existing eviction pattern used after `profileService.blockProfile`

## Test plan
- [ ] Toggle dating mode and verify the map re-queries and reflects the new active state
- [ ] Confirm backend test suite stays green (`pnpm --filter backend test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)