### PR TITLE
feat(frontend): tag Sentry events with frontend_origin

### DIFF
--- a/.changeset/amber-sentry-tags.md
+++ b/.changeset/amber-sentry-tags.md
@@ -1,0 +1,5 @@
+---
+'@opencupid/frontend': patch
+---
+
+Tag frontend Sentry events with `frontend_origin` set to `__APP_CONFIG__.DOMAIN`, so dashboards/alerts are brand-attributable without URL parsing.

--- a/apps/frontend/src/app.ts
+++ b/apps/frontend/src/app.ts
@@ -56,6 +56,7 @@ async function initSentry(app: ReturnType<typeof createApp>) {
       replaysSessionSampleRate: 0.1,
       replaysOnErrorSampleRate: 1.0,
     })
+    Sentry.setTag('frontend_origin', __APP_CONFIG__.DOMAIN)
   } catch (err) {
     console.warn('Failed to load Sentry:', err)
   }


### PR DESCRIPTION
## Summary

- Promote `DOMAIN` to required in shared `AppConfig` schema (`z.string().min(1)`)
- Runtime config: `DOMAIN: '${DOMAIN}'` in [apps/frontend/config.template.js](apps/frontend/config.template.js) (Docker) and [apps/frontend/vite.common.ts](apps/frontend/vite.common.ts) (dev)
- `Sentry.setTag('frontend_origin', __APP_CONFIG__.DOMAIN)` right after `Sentry.init(...)` in [apps/frontend/src/app.ts](apps/frontend/src/app.ts)

## Why

Sentry events coming from different brand domains (e.g. `sm89hoqc.staging.opencupid.org` vs `test.komaterkep.hu`) are otherwise indistinguishable except by URL parsing. A first-class tag lets dashboards and alerts filter brand without string-munging.

Making `DOMAIN` mandatory fails fast if env is misconfigured; in exchange, the Sentry call site is a single line with no empty guard.

## Test plan

- [x] `pnpm --filter frontend type-check`
- [x] `pnpm --filter admin type-check`
- [x] `pnpm --filter backend type-check`
- [x] `pnpm --filter backend test` — 500 passing
- [x] `pnpm --filter backend lint`
- [x] `pnpm --filter frontend lint`
- [ ] Dev smoke: `pnpm dev` with `DOMAIN=localhost` in `.env`, verify `window.__APP_CONFIG__.DOMAIN === 'localhost'`
- [ ] Staging: trigger a client-side error on each brand's domain; Sentry event has `frontend_origin` matching the origin

## Note on overlap with PR #1325

PR #1325 (`feat/brand-payload`) also adds `DOMAIN` to the shared `AppConfig` schema with the same `z.string().min(1)` shape. When both land on main, git merges the identical additions cleanly — no conflict either way round.

🤖 Generated with [Claude Code](https://claude.com/claude-code)