### PR TITLE
fix(frontend): adjust ShareDialog shadow and disable autofocus

### DIFF
--- a/.changeset/gorgeous-paws-shop.md
+++ b/.changeset/gorgeous-paws-shop.md
@@ -1,0 +1,5 @@
+---
+"@opencupid/frontend": patch
+---
+
+fix(frontend): adjust ShareDialog shadow and disable autofocus

--- a/apps/frontend/src/features/app/components/ShareDialog.vue
+++ b/apps/frontend/src/features/app/components/ShareDialog.vue
@@ -58,12 +58,12 @@ const handleWebShare = async () => {
   <BOffcanvas
     v-model="showModal"
     placement="bottom"
-    class="share-offcanvas col-12 col-md-6 offset-md-3 col-lg-4 offset-lg-4"
+    class="share-offcanvas col-12 col-md-6 offset-md-3 col-lg-4 offset-lg-4 shadow-lg"
     :class="{ 'share-offcanvas--expanded': expanded }"
     body-class="py-0 px-3 bg-light"
     header-class="bg-light"
     no-backdrop
-    shadow
+    :focus="false"
   >
     <div
       class="mx-2 mb-3 text-center"


### PR DESCRIPTION
## Summary
- Replace BOffcanvas `shadow` prop with `shadow-lg` utility class on the offcanvas element
- Disable autofocus (`:focus="false"`) so opening the share dialog doesn't steal focus

## Test plan
- [ ] Open share dialog on a profile/post and verify drop shadow renders correctly
- [ ] Confirm focus stays on the triggering element when the dialog opens
- [ ] Verify no regressions on mobile and desktop breakpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)