### PR TITLE
Ensure cluster cache eviction on success path for profile routes

### DIFF
--- a/.changeset/silver-cache-evict.md
+++ b/.changeset/silver-cache-evict.md
@@ -2,4 +2,4 @@
 '@opencupid/backend': patch
 ---
 
-Move clusterService.evict() into finally block in PATCH /scopes (#1329)
+Evict cluster cache after updateSession succeeds in PATCH /scopes (#1329)

--- a/.changeset/silver-cache-evict.md
+++ b/.changeset/silver-cache-evict.md
@@ -1,0 +1,5 @@
+---
+'@opencupid/backend': patch
+---
+
+Move clusterService.evict() into finally block in PATCH /scopes (#1329)

--- a/apps/backend/src/__tests__/routes/profile.route.spec.ts
+++ b/apps/backend/src/__tests__/routes/profile.route.spec.ts
@@ -229,7 +229,7 @@ describe('GET /:id', () => {
 })
 
 describe('POST /:id/block', () => {
-  it('blocks a profile successfully', async () => {
+  it('blocks a profile successfully and evicts cluster cache', async () => {
     const handler = fastify.routes['POST /:id/block']
     mockProfileService.blockProfile.mockResolvedValue({})
 
@@ -237,6 +237,7 @@ describe('POST /:id/block', () => {
     await handler(req, reply as any)
     expect(reply.statusCode).toBe(204)
     expect(mockProfileService.blockProfile).toHaveBeenCalledWith('p1', 'cm000000000000000000000p2')
+    expect(mockClusterService.evict).toHaveBeenCalledWith('p1')
   })
 
   it('returns 400 when trying to block yourself', async () => {
@@ -253,13 +254,14 @@ describe('POST /:id/block', () => {
 })
 
 describe('POST /:id/unblock', () => {
-  it('unblocks a profile', async () => {
+  it('unblocks a profile and evicts cluster cache', async () => {
     const handler = fastify.routes['POST /:id/unblock']
     mockProfileService.unblockProfile.mockResolvedValue({})
 
     const req = makeReq({ params: { id: 'cm000000000000000000000p2' } })
     await handler(req, reply as any)
     expect(reply.statusCode).toBe(204)
+    expect(mockClusterService.evict).toHaveBeenCalledWith('p1')
   })
 })
 
@@ -278,7 +280,7 @@ describe('GET /blocked', () => {
 })
 
 describe('PATCH /me', () => {
-  it('updates profile and returns 200', async () => {
+  it('updates profile and returns 200, evicts cluster cache', async () => {
     const handler = fastify.routes['PATCH /me']
     const updatedDb = {
       id: 'p1',
@@ -293,6 +295,7 @@ describe('PATCH /me', () => {
     await handler(req, reply as any)
     expect(reply.statusCode).toBe(200)
     expect(reply.payload.success).toBe(true)
+    expect(mockClusterService.evict).toHaveBeenCalledWith('p1')
   })
 })
 

--- a/apps/backend/src/__tests__/routes/profile.route.spec.ts
+++ b/apps/backend/src/__tests__/routes/profile.route.spec.ts
@@ -7,9 +7,13 @@ let reply: MockReply
 let mockProfileService: any
 let mockProfileMatchService: any
 let mockMessageService: any
+let mockClusterService: any
 
 vi.mock('../../services/profile.service', () => ({
   ProfileService: { getInstance: () => mockProfileService },
+}))
+vi.mock('../../services/cluster.service', () => ({
+  ClusterService: { getInstance: () => mockClusterService },
 }))
 vi.mock('../../services/profileMatch.service', () => ({
   ProfileMatchService: { getInstance: () => mockProfileMatchService },
@@ -94,6 +98,9 @@ beforeEach(async () => {
   }
   mockMessageService = {
     sendWelcomeMessage: vi.fn(),
+  }
+  mockClusterService = {
+    evict: vi.fn(),
   }
   await profileRoutes(fastify as any, {})
 })
@@ -354,6 +361,7 @@ describe('PATCH /scopes', () => {
         isActive: true,
       },
     })
+    expect(mockClusterService.evict).toHaveBeenCalledWith('p1')
   })
 
   it('returns 404 when profile not found', async () => {
@@ -363,6 +371,24 @@ describe('PATCH /scopes', () => {
     const req = makeReq({ body: { isDatingActive: true } })
     await handler(req, reply as any)
     expect(reply.statusCode).toBe(404)
+  })
+
+  it('evicts cluster cache even when updateSession throws', async () => {
+    const handler = fastify.routes['PATCH /scopes']
+    const updatedDb = {
+      id: 'p1',
+      isDatingActive: true,
+      isSocialActive: true,
+      isActive: true,
+    }
+    mockProfileService.updateScopes.mockResolvedValue(updatedDb)
+    const req = makeReq({ body: { isDatingActive: true } })
+    req.updateSession = vi.fn().mockRejectedValue(new Error('session failure'))
+
+    await handler(req, reply as any)
+
+    expect(mockClusterService.evict).toHaveBeenCalledWith('p1')
+    expect(reply.statusCode).toBe(500)
   })
 })
 

--- a/apps/backend/src/__tests__/routes/profile.route.spec.ts
+++ b/apps/backend/src/__tests__/routes/profile.route.spec.ts
@@ -376,7 +376,7 @@ describe('PATCH /scopes', () => {
     expect(reply.statusCode).toBe(404)
   })
 
-  it('evicts cluster cache even when updateSession throws', async () => {
+  it('does not evict when updateSession throws', async () => {
     const handler = fastify.routes['PATCH /scopes']
     const updatedDb = {
       id: 'p1',
@@ -390,7 +390,7 @@ describe('PATCH /scopes', () => {
 
     await handler(req, reply as any)
 
-    expect(mockClusterService.evict).toHaveBeenCalledWith('p1')
+    expect(mockClusterService.evict).not.toHaveBeenCalled()
     expect(reply.statusCode).toBe(500)
   })
 })

--- a/apps/backend/src/api/routes/profile.route.ts
+++ b/apps/backend/src/api/routes/profile.route.ts
@@ -359,8 +359,12 @@ const profileRoutes: FastifyPluginAsync = async (fastify) => {
         return profile
       })
 
-      const response: UpdateProfileResponse = { success: true, profile: updated }
-      return reply.code(200).send(response)
+      try {
+        const response: UpdateProfileResponse = { success: true, profile: updated }
+        return reply.code(200).send(response)
+      } finally {
+        clusterService.evict(updated.id)
+      }
     } catch (err) {
       fastify.log.error(err)
       // profileService.updateProfile() returned null, which means the profile was not found
@@ -442,8 +446,11 @@ const profileRoutes: FastifyPluginAsync = async (fastify) => {
         return reply.code(400).send({ error: 'Cannot block yourself.' })
       }
       await profileService.blockProfile(profileId, id)
-      clusterService.evict(profileId)
-      return reply.code(204).send()
+      try {
+        return reply.code(204).send()
+      } finally {
+        clusterService.evict(profileId)
+      }
     } catch (error) {
       fastify.log.error(error)
       return sendError(reply, 500, 'Failed to block profile')
@@ -461,7 +468,11 @@ const profileRoutes: FastifyPluginAsync = async (fastify) => {
     try {
       const { id } = IdLookupParamsSchema.parse(req.params)
       await profileService.unblockProfile(profileId, id)
-      return reply.code(204).send()
+      try {
+        return reply.code(204).send()
+      } finally {
+        clusterService.evict(profileId)
+      }
     } catch (error) {
       fastify.log.error(error)
       return sendError(reply, 500, 'Failed to unblock profile')

--- a/apps/backend/src/api/routes/profile.route.ts
+++ b/apps/backend/src/api/routes/profile.route.ts
@@ -359,12 +359,9 @@ const profileRoutes: FastifyPluginAsync = async (fastify) => {
         return profile
       })
 
-      try {
-        const response: UpdateProfileResponse = { success: true, profile: updated }
-        return reply.code(200).send(response)
-      } finally {
-        clusterService.evict(updated.id)
-      }
+      clusterService.evict(updated.id)
+      const response: UpdateProfileResponse = { success: true, profile: updated }
+      return reply.code(200).send(response)
     } catch (err) {
       fastify.log.error(err)
       // profileService.updateProfile() returned null, which means the profile was not found
@@ -401,27 +398,24 @@ const profileRoutes: FastifyPluginAsync = async (fastify) => {
       try {
         const updated = await profileService.updateScopes(req.user.userId, data)
         if (!updated) return sendError(reply, 404, 'Profile not found')
-        try {
-          // Update session with new profile scope data
-          await req.updateSession({
-            hasActiveProfile: updated.isActive,
-            profile: {
-              id: updated.id,
-              isDatingActive: updated.isDatingActive,
-              isSocialActive: updated.isSocialActive,
-              isActive: updated.isActive,
-            },
-          })
-
-          const response: UpdateProfileScopeResponse = {
-            success: true,
+        // Update session with new profile scope data
+        await req.updateSession({
+          hasActiveProfile: updated.isActive,
+          profile: {
+            id: updated.id,
             isDatingActive: updated.isDatingActive,
+            isSocialActive: updated.isSocialActive,
             isActive: updated.isActive,
-          }
-          return reply.code(200).send(response)
-        } finally {
-          clusterService.evict(updated.id)
+          },
+        })
+        clusterService.evict(updated.id)
+
+        const response: UpdateProfileScopeResponse = {
+          success: true,
+          isDatingActive: updated.isDatingActive,
+          isActive: updated.isActive,
         }
+        return reply.code(200).send(response)
       } catch (error: any) {
         if (error.name === 'DatingEligibilityError') {
           return sendError(reply, 403, error.message)
@@ -446,11 +440,8 @@ const profileRoutes: FastifyPluginAsync = async (fastify) => {
         return reply.code(400).send({ error: 'Cannot block yourself.' })
       }
       await profileService.blockProfile(profileId, id)
-      try {
-        return reply.code(204).send()
-      } finally {
-        clusterService.evict(profileId)
-      }
+      clusterService.evict(profileId)
+      return reply.code(204).send()
     } catch (error) {
       fastify.log.error(error)
       return sendError(reply, 500, 'Failed to block profile')
@@ -468,11 +459,8 @@ const profileRoutes: FastifyPluginAsync = async (fastify) => {
     try {
       const { id } = IdLookupParamsSchema.parse(req.params)
       await profileService.unblockProfile(profileId, id)
-      try {
-        return reply.code(204).send()
-      } finally {
-        clusterService.evict(profileId)
-      }
+      clusterService.evict(profileId)
+      return reply.code(204).send()
     } catch (error) {
       fastify.log.error(error)
       return sendError(reply, 500, 'Failed to unblock profile')

--- a/apps/backend/src/api/routes/profile.route.ts
+++ b/apps/backend/src/api/routes/profile.route.ts
@@ -397,24 +397,27 @@ const profileRoutes: FastifyPluginAsync = async (fastify) => {
       try {
         const updated = await profileService.updateScopes(req.user.userId, data)
         if (!updated) return sendError(reply, 404, 'Profile not found')
-        clusterService.evict(updated.id)
-        // Update session with new profile scope data
-        await req.updateSession({
-          hasActiveProfile: updated.isActive,
-          profile: {
-            id: updated.id,
-            isDatingActive: updated.isDatingActive,
-            isSocialActive: updated.isSocialActive,
-            isActive: updated.isActive,
-          },
-        })
+        try {
+          // Update session with new profile scope data
+          await req.updateSession({
+            hasActiveProfile: updated.isActive,
+            profile: {
+              id: updated.id,
+              isDatingActive: updated.isDatingActive,
+              isSocialActive: updated.isSocialActive,
+              isActive: updated.isActive,
+            },
+          })
 
-        const response: UpdateProfileScopeResponse = {
-          success: true,
-          isDatingActive: updated.isDatingActive,
-          isActive: updated.isActive,
+          const response: UpdateProfileScopeResponse = {
+            success: true,
+            isDatingActive: updated.isDatingActive,
+            isActive: updated.isActive,
+          }
+          return reply.code(200).send(response)
+        } finally {
+          clusterService.evict(updated.id)
         }
-        return reply.code(200).send(response)
       } catch (error: any) {
         if (error.name === 'DatingEligibilityError') {
           return sendError(reply, 403, error.message)


### PR DESCRIPTION
## Summary

- `clusterService.evict()` moved to the success branch in all four affected profile route handlers — eviction only fires after the DB write **and** all subsequent steps succeed
- Added `clusterService.evict()` to `POST /:id/unblock` and `PATCH /me`, which were previously missing it entirely
- Added `ClusterService` mock to `profile.route.spec.ts` and updated/added tests to assert eviction on the happy path and absence of eviction on failure

## Changes

| Route | Before | After |
|---|---|---|
| `PATCH /me` | no eviction | evict after transaction + response |
| `PATCH /scopes` | evict before `updateSession` (happy path only) | evict after `updateSession` succeeds |
| `POST /:id/block` | evict before response | evict after response (same position, now explicit) |
| `POST /:id/unblock` | no eviction | evict after response |

Closes #1329

https://claude.ai/code/session_01A9WkUKJZuY1w1SdQJWSKRL