### PR TITLE
fix: batch of integration-testing fixes — DOMAIN default + Traefik route persistence

### DIFF
--- a/.changeset/integration-testing-fixes.md
+++ b/.changeset/integration-testing-fixes.md
@@ -1,0 +1,5 @@
+---
+'@opencupid/frontend': patch
+---
+
+Unblock frontend Docker build: give `DOMAIN` in the shared appConfig schema a `'localhost'` default so build-time parsing (where runtime env isn't exposed) no longer fails. Runtime `DOMAIN` is still injected by `envsubst` at container start from `.env`, and the backend continues to enforce a non-empty `DOMAIN` via its own schema. Updates the corresponding unit test and removes the now-redundant `DOMAIN: "ci.local"` workaround from the CI workflow.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,9 +13,6 @@ jobs:
       TURBO_NO_UPDATE_NOTIFIER: 1
       PRISMA_DISABLE_WARNINGS: "true"
       CI: "true"
-      # Required by the shared appConfigSchema; the frontend build's
-      # runtimeConfigPlugin validates process.env against the schema.
-      DOMAIN: "ci.local"
 
     steps:
       - uses: actions/checkout@v6

--- a/apps/frontend/src/lib/__tests__/appConfig.spec.ts
+++ b/apps/frontend/src/lib/__tests__/appConfig.spec.ts
@@ -23,8 +23,8 @@ describe('appConfig schema', () => {
     })
   })
 
-  it('rejects config without required DOMAIN', () => {
-    expect(() => appConfigSchema.parse({})).toThrow(/DOMAIN/)
+  it('applies placeholder default when DOMAIN is absent', () => {
+    expect(appConfigSchema.parse({})).toMatchObject({ DOMAIN: 'localhost' })
   })
 
   it('overrides defaults with provided values', () => {

--- a/apps/ingress/traefik.yml
+++ b/apps/ingress/traefik.yml
@@ -32,6 +32,11 @@ providers:
   docker:
     exposedByDefault: false
     watch: true
+    # Keep routers/services registered for containers that have exited so a
+    # request matching their rule returns 502 instead of falling through to
+    # a less-specific router (e.g. the SPA's Host-only catch-all). Requires
+    # `traefik.docker.allownonrunning=true` on each opted-in container.
+    allowEmptyServices: true
   file:
     directory: /etc/traefik/dynamic/
     watch: true

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -47,6 +47,7 @@ services:
       - '${MEDIA_UPLOAD_DIR}:${MEDIA_UPLOAD_DIR}'
     labels:
       traefik.enable: "true"
+      traefik.docker.allownonrunning: "true"
 
       # --- Public domain: API ---
       traefik.http.routers.api.rule: "Host(`${DOMAIN}`) && PathPrefix(`/api`)"
@@ -84,6 +85,7 @@ services:
       replicas: 1
     labels:
       traefik.enable: "true"
+      traefik.docker.allownonrunning: "true"
 
       # --- Admin domain: Bull Board (mTLS) ---
       traefik.http.routers.admin-bull-board.rule: "Host(`${ADMIN_DOMAIN}`) && PathPrefix(`/bull-board`)"
@@ -105,6 +107,7 @@ services:
       - backend
     labels:
       traefik.enable: "true"
+      traefik.docker.allownonrunning: "true"
       traefik.http.routers.frontend.rule: "Host(`${DOMAIN}`)"
       traefik.http.routers.frontend.priority: "1"
       traefik.http.routers.frontend.entrypoints: websecure
@@ -123,6 +126,7 @@ services:
       - backend
     labels:
       traefik.enable: "true"
+      traefik.docker.allownonrunning: "true"
       traefik.http.routers.admin.rule: "Host(`${ADMIN_DOMAIN}`)"
       traefik.http.routers.admin.priority: "1"
       traefik.http.routers.admin.entrypoints: websecure
@@ -137,6 +141,7 @@ services:
       - '${MEDIA_UPLOAD_DIR}:/usr/share/nginx/html:ro'
     labels:
       traefik.enable: "true"
+      traefik.docker.allownonrunning: "true"
       traefik.http.routers.media.rule: "Host(`${DOMAIN}`) && PathPrefix(`/user-content`)"
       traefik.http.routers.media.entrypoints: websecure
       traefik.http.routers.media.middlewares: media-jwt,media-strip,media-cache

--- a/packages/shared/zod/config/appConfig.schema.ts
+++ b/packages/shared/zod/config/appConfig.schema.ts
@@ -6,7 +6,7 @@ export const appConfigSchema = z.object({
   WS_BASE_URL: z.string().default('/ws'),
   MEDIA_URL_BASE: z.string().default('/user-content'),
   NODE_ENV: z.string().default('development'),
-  DOMAIN: z.string().min(1),
+  DOMAIN: z.string().min(1).default('localhost'),
   VAPID_PUBLIC_KEY: z.string().default(''),
   SENTRY_DSN: z.string().default(''),
   SITE_NAME: z.string().default('OpenCupid'),


### PR DESCRIPTION
## Summary

Two independent but related fixes surfaced during staging integration testing of PRs #1324/#1325/#1326/#1327:

- **Unblock frontend Docker build**: give `DOMAIN` in the shared `appConfig` schema a `'localhost'` default. PR #1325 made it required-non-empty, but the frontend's `runtimeConfigPlugin` parses the schema at Vite build time — and `env_file:` in compose only applies at runtime, so the builder container has no `DOMAIN` and Zod rejects. Updates the corresponding unit test and removes the now-redundant `DOMAIN: "ci.local"` workaround from the CI workflow. Backend schema (`apps/backend/src/lib/appconfig.ts`) is independent and continues to enforce non-empty `DOMAIN` at server boot.

- **Stop silent API outages from being masked by the SPA catch-all**: when a labeled container crashed, Traefik's docker provider removed its routers and requests to the intended rule fell through to the frontend's Host-only router — nginx served `index.html` with HTTP 200 for `/api/*`, making monitoring think everything was fine. Enable `providers.docker.allowEmptyServices: true` + per-container `traefik.docker.allownonrunning=true` on every public-facing service (`backend`, `worker`, `frontend`, `admin`, `media`). With both set, Traefik keeps the router/service registered even when the container exits; matching requests return 5xx from a zero-endpoint service, surfacing the failure loudly.

## Test plan

- [ ] `pnpm --filter frontend exec vitest run src/lib/__tests__/appConfig.spec.ts` — all 5 cases pass (new `applies placeholder default when DOMAIN is absent` test included)
- [ ] CI green without the `DOMAIN: "ci.local"` env var
- [ ] `docker compose build frontend` succeeds without `DOMAIN` set in the build environment
- [ ] On staging: stop a labeled API container → `curl` its host/api path returns 5xx with empty/JSON body (not HTML 200)
- [ ] Start the container back → routing resumes as JSON 200 within seconds

🤖 Generated with [Claude Code](https://claude.com/claude-code)