### PR TITLE
fix: break cross-brand login redirect loop

### DIFF
--- a/.changeset/amber-moths-trace.md
+++ b/.changeset/amber-moths-trace.md
@@ -1,0 +1,6 @@
+---
+'@opencupid/backend': patch
+'@opencupid/frontend': patch
+---
+
+Break cross-brand login redirect loop by making __o cookie stamping authoritative on both /send-magic-link and /verify-token, and removing the direct-redirect bypass for /auth and /magic-link in the frontend inline redirect script.

--- a/apps/backend/src/api/routes/auth.route.ts
+++ b/apps/backend/src/api/routes/auth.route.ts
@@ -323,7 +323,9 @@ const authRoutes: FastifyPluginAsync = async (fastify) => {
       // existing users to new brand domains expires.
       setOriginCookie(reply, user.originDomain)
       const linkBase =
-        user.originDomain && user.originDomain !== appConfig.DOMAIN
+        user.originDomain &&
+        user.originDomain !== appConfig.DOMAIN &&
+        appConfig.NODE_ENV !== 'development'
           ? `https://${user.originDomain}`
           : appConfig.FRONTEND_URL
 

--- a/apps/backend/src/api/routes/auth.route.ts
+++ b/apps/backend/src/api/routes/auth.route.ts
@@ -59,6 +59,20 @@ function clearRefreshCookie(reply: FastifyReply) {
   reply.clearCookie(REFRESH_COOKIE, SESSION_COOKIE_OPTS)
 }
 
+// Stamps the __o cookie authoritatively on any host where login activity
+// occurs. Rewriting on every send and consume (not only cross-brand ones)
+// prevents ping-pong loops caused by stale __o values left on both brands
+// pointing at each other.
+function setOriginCookie(reply: FastifyReply, originDomain: string | null | undefined) {
+  if (!originDomain) return
+  if (appConfig.NODE_ENV === 'development') return
+  reply.setCookie(ORIGIN_COOKIE, originDomain, {
+    ...SESSION_COOKIE_OPTS,
+    secure: true,
+    maxAge: ORIGIN_MAX_AGE,
+  })
+}
+
 const WS_TICKET_TTL = 30 // seconds
 
 const authRoutes: FastifyPluginAsync = async (fastify) => {
@@ -123,6 +137,7 @@ const authRoutes: FastifyPluginAsync = async (fastify) => {
 
         setSessionCookie(reply, jwt)
         setRefreshCookie(reply, refreshToken)
+        setOriginCookie(reply, user.originDomain)
 
         const response: VerifyTokenResponse = { success: true, token: jwt }
         reply.code(200).send(response)
@@ -300,24 +315,17 @@ const authRoutes: FastifyPluginAsync = async (fastify) => {
         isPushNotificationEnabled: user.isPushNotificationEnabled,
       }
 
-      // Cross-brand login: when an existing user registered on a different
-      // brand tries to log in here, mark the response with __o so the frontend
-      // / sidecar can route them home, and stamp the magic-link URL with their
-      // origin domain so the link itself lands on the right brand.
-
-      // TODO this code can be retired once the migration window for moving existing
-      // users to new brand domains expires
-      let linkBase = appConfig.FRONTEND_URL
-      if (user.email && appConfig.NODE_ENV !== 'development') {
-        if (user.originDomain && user.originDomain !== appConfig.DOMAIN) {
-          reply.setCookie(ORIGIN_COOKIE, user.originDomain, {
-            ...SESSION_COOKIE_OPTS,
-            secure: true,
-            maxAge: ORIGIN_MAX_AGE,
-          })
-          linkBase = `https://${user.originDomain}`
-        }
-      }
+      // Stamp __o authoritatively so the frontend inline redirect and the
+      // sidecar route the user to their home brand. The magic-link URL in the
+      // email is stamped with the origin domain so the link itself lands on
+      // the right brand.
+      // TODO this code can be retired once the migration window for moving
+      // existing users to new brand domains expires.
+      setOriginCookie(reply, user.originDomain)
+      const linkBase =
+        user.originDomain && user.originDomain !== appConfig.DOMAIN
+          ? `https://${user.originDomain}`
+          : appConfig.FRONTEND_URL
 
       if (user.email)
         await notifierService.notifyUser(user.id, 'login_link', {

--- a/apps/frontend/index.html
+++ b/apps/frontend/index.html
@@ -100,13 +100,13 @@
         var target = decodeURIComponent(m[1])
         if (target === window.location.hostname) return
         var p = window.location.pathname
-        if (p === '/_migrate') return
+        // Never bounce the sidecar path (would recurse) or /magic-link (the URL
+        // is already authoritatively stamped by the backend with the user's
+        // originDomain, and verify-token must run on the landing host so it can
+        // overwrite stale __o cookies).
+        if (p === '/_migrate' || p === '/magic-link') return
         var rest = window.location.search + window.location.hash
-        var dest =
-          p === '/auth' || p === '/magic-link'
-            ? 'https://' + target + p + rest
-            : '/_migrate?to=' + encodeURIComponent(p + rest)
-        window.location.replace(dest)
+        window.location.replace('/_migrate?to=' + encodeURIComponent(p + rest))
       })()
     </script>
     <script


### PR DESCRIPTION
## Summary

- Backend: new \`setOriginCookie\` helper; stamp \`__o\` on every \`/send-magic-link\` and successful \`/verify-token\` (not only on cross-brand mismatch). \`verify-token\` now writes an authoritative \`__o\` on the landing host.
- Frontend: inline redirect script in \`index.html\` drops the direct \`location.replace\` bypass for \`/auth\` and \`/magic-link\`. \`/magic-link\` is skipped entirely — the email URL is already authoritative, and \`verify-token\` must run on the landing host to overwrite stale \`__o\`. \`/auth\` now routes through the sidecar.

Together these break the ping-pong loop that could occur when \`__o\` cookies on both brand hosts pointed at each other. Any login-related endpoint now rewrites \`__o\` to the correct value, and the landing host can no longer be skipped past by a client-side redirect.

## Test plan

- [x] UAT on staging: fresh cross-brand login (origin=A, submit on B) → email link → lands and stays on origin host, session established, \`__o\` correct on landing host.
- [x] UAT on staging: loop reproduction (both brands with mismatched \`__o\`) no longer loops after magic-link consume.
- [ ] Residual loop risk on \`/auth\` with both-sides-stale \`__o\` (no endpoint fires during a pure \`/auth\` bounce) — acceptable edge case; self-heals on first successful login. Follow-up if it bites.
- [ ] \`__o\` cookie allow-list hardening (defense against XSS writing a malicious \`__o\`) — separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)