### PR TITLE
Hide title and hint when email magic-link token error occurs

### DIFF
--- a/.changeset/silver-token-hide.md
+++ b/.changeset/silver-token-hide.md
@@ -1,0 +1,5 @@
+---
+'@opencupid/frontend': patch
+---
+
+Hide title and hint when email magic-link token error is shown (#1337)

--- a/apps/frontend/src/features/auth/__tests__/MagicLink.spec.ts
+++ b/apps/frontend/src/features/auth/__tests__/MagicLink.spec.ts
@@ -153,7 +153,7 @@ describe('MagicLink', () => {
       expect(wrapper.text()).toContain('auth.token_check_email')
     })
 
-    it('shows error alongside check-email message on failed magic link', async () => {
+    it('shows only error and back button on failed magic link, hiding title and hint', async () => {
       route.query = { token: '123456' }
       const authStore = useAuthStore()
       authStore.loginUser = emailLoginUser
@@ -169,8 +169,10 @@ describe('MagicLink', () => {
       await flushPromises()
 
       expect(wrapper.find('[data-testid="token-form"]').exists()).toBe(false)
-      expect(wrapper.text()).toContain('auth.token_check_email')
+      expect(wrapper.text()).not.toContain('auth.token_check_email')
+      expect(wrapper.text()).not.toContain('auth.token_check_messages')
       expect(wrapper.text()).toContain('auth.token_expired')
+      expect(wrapper.text()).toContain('uicomponents.back_button_title')
     })
   })
 })

--- a/apps/frontend/src/features/auth/views/MagicLink.vue
+++ b/apps/frontend/src/features/auth/views/MagicLink.vue
@@ -120,18 +120,17 @@ function handleBackButton() {
       />
       <DevAutoLogin v-else-if="DevAutoLogin" />
       <template v-else>
-        <div class="fs-4 mb-3 w-100">
-          <ViewTitle
-            :icon="authStore.isPhoneAuth ? IconMessage : IconMail"
-            title=""
-            class="text-primary"
-          />
-          <div class="text-center">
-            {{ $t('auth.token_check_messages') }}
-          </div>
-        </div>
-
         <template v-if="authStore.isPhoneAuth">
+          <div class="fs-4 mb-3 w-100">
+            <ViewTitle
+              :icon="IconMessage"
+              title=""
+              class="text-primary"
+            />
+            <div class="text-center">
+              {{ $t('auth.token_check_messages') }}
+            </div>
+          </div>
           <div class="mb-3 form-text">
             {{ $t('auth.token_sent_phone') }}
           </div>
@@ -147,7 +146,19 @@ function handleBackButton() {
           v-else
           class="text-center"
         >
-          <p class="text-muted fs-6">{{ $t('auth.token_check_email') }}</p>
+          <template v-if="!error">
+            <div class="fs-4 mb-3 w-100">
+              <ViewTitle
+                :icon="IconMail"
+                title=""
+                class="text-primary"
+              />
+              <div class="text-center">
+                {{ $t('auth.token_check_messages') }}
+              </div>
+            </div>
+            <p class="text-muted fs-6">{{ $t('auth.token_check_email') }}</p>
+          </template>
           <div
             v-if="error"
             class="mt-2"


### PR DESCRIPTION
## Summary
This PR improves the UX of the magic link authentication flow by hiding the title and hint message when an email token validation error occurs, showing only the error message and back button instead.

## Key Changes
- Moved the shared title and hint UI (`ViewTitle` and `token_check_messages`) from the common template into the phone auth branch, since it's only needed for phone authentication
- Added conditional rendering for the email auth section to hide the title, hint, and token check message when an error is present
- Updated the test expectations to verify that the title and hint are hidden when an error is displayed, while the error message and back button remain visible

## Implementation Details
- The title and hint are now only rendered in the phone auth flow
- For email auth, these elements are wrapped in a `v-if="!error"` condition, ensuring they're hidden when token validation fails
- The error message and back button continue to display regardless of the error state, providing clear feedback to the user

https://claude.ai/code/session_01WpdjWZanA3cqumrTQ8Qaru