### PR TITLE
fix(backend): stamp __o on /refresh to backfill active sessions

### DIFF
--- a/.changeset/silver-tigers-roam.md
+++ b/.changeset/silver-tigers-roam.md
@@ -1,0 +1,5 @@
+---
+'@opencupid/backend': patch
+---
+
+Stamp `__o` cookie in the `/refresh` handler so users with pre-existing active sessions get their home-brand marker backfilled without having to log out and back in (#1340).

--- a/apps/backend/src/api/routes/auth.route.ts
+++ b/apps/backend/src/api/routes/auth.route.ts
@@ -230,6 +230,7 @@ const authRoutes: FastifyPluginAsync = async (fastify) => {
 
       setSessionCookie(reply, newJwt)
       setRefreshCookie(reply, newRefreshToken)
+      setOriginCookie(reply, user.originDomain)
 
       const response: RefreshTokenResponse = { success: true, token: newJwt }
       reply.code(200).send(response)


### PR DESCRIPTION
## Summary

Users whose session was created before v0.53.0 shipped (i.e., everyone with an active session at the moment cross-brand logic went live) don't have the \`__o\` home-brand cookie set on the host serving them. The stamping code only runs in \`/send-magic-link\` and \`/verify-token\` — both require an explicit auth action. An active user's SPA silently refreshes its JWT via \`/refresh\`, which didn't stamp \`__o\`, so they never get the marker and the frontend inline redirect never fires.

\`/refresh\` already fetches the full User row to verify tokenVersion, so stamping \`__o\` there is one line and zero extra DB cost.

## Why this is safe

Audited prod: all 359 users have \`originDomain=komaterkep.hu\`, no empty/null values and no stale brand strings. Every active session will be backfilled to the correct target.

## Side-effects considered

- **Wrong \`originDomain\` in DB would redirect users wrongly.** Prod audit shows none.
- **Mid-session redirect interrupts user state.** When \`/refresh\` fires (JWT near expiry or 401-recovery), the response stamps \`__o\`; the next full page load triggers the inline-script bounce to the home brand via sidecar. Any in-memory SPA state (form drafts, unsaved input) is blown away. Acceptable for a migration; the session itself is preserved through the bridge.
- **Revoked sessions.** If \`tokenVersion\` was bumped, \`/refresh\` short-circuits before \`setOriginCookie\` — revoked sessions don't get a stamp.
- **XHR-triggered refresh.** Every background \`/refresh\` now carries an 80-byte \`Set-Cookie\`. Negligible.

## Test plan

- [x] Typecheck clean.
- [ ] UAT on prod: an existing user with an active session on gaians.net (currently no \`__o\` on gaians) navigates around until JWT refreshes, observes \`__o=komaterkep.hu\` set on the gaians cookie jar, and is redirected to komaterkep.hu on the next full page load.
- [ ] Users already on their home brand (\`__o=<self>\` equals hostname) see no behavioral change — inline script no-op remains correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)