### PR TITLE
chore: add host-side backup scripts

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,35 @@
+# Operations scripts
+
+Host-side utility scripts for the production deployment on `gaians.net`.
+
+## Inventory
+
+| Script | Purpose |
+|---|---|
+| [backup-srv.sh](backup-srv.sh) | Daily restic backup of `/srv` to Hetzner Storage Box, from a recursive ZFS snapshot. Weekly pg_dumpall on Sundays. |
+| [notify-sentry.sh](notify-sentry.sh) | POSTs a single error event to Sentry when a systemd unit fails. Used via `OnFailure=` on backup-related units. |
+
+## Deployment
+
+Scripts are **not** included in any Docker image; they run on the host. Deploy by pulling this repo on the host and symlinking into `/usr/local/bin`:
+
+```
+# On gaians.net, as root:
+cd /opt/opencupid-scripts && git pull --ff-only
+install -m 750 -o root -g root /opt/opencupid-scripts/scripts/backup-srv.sh /usr/local/bin/
+install -m 750 -o root -g root /opt/opencupid-scripts/scripts/notify-sentry.sh /usr/local/bin/
+```
+
+(Adjust `/opt/opencupid-scripts` to wherever you clone the repo on the host.)
+
+## Systemd units (expected alongside)
+
+`/etc/systemd/system/restic-backup.service` and `.timer` invoke `backup-srv.sh`. The service's `OnFailure=restic-backup-notify.service` chain calls `notify-sentry.sh restic-backup.service`.
+
+## Host prerequisites
+
+- ZFS pool `tank` with dataset `tank/srv` containing child datasets.
+- `restic` binary at `/usr/local/bin/restic`.
+- `/root/.config/restic/password` (mode 600) — repository key.
+- `/root/.ssh/config` alias `storagebox` → `u446506-sub2@u446506-sub2.your-storagebox.de:23` with `IdentityFile=/root/.ssh/storagebox`.
+- Docker exec access to `opencupid-db-1` (for pg_dumpall).

--- a/scripts/backup-srv.sh
+++ b/scripts/backup-srv.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+# Daily backup of /srv to Hetzner Storage Box via restic.
+# Runs from a recursive ZFS snapshot for consistency across child datasets.
+#
+# Requires on the host:
+#   /root/.config/restic/password           (mode 600)
+#   /root/.ssh/storagebox + config alias    (u446506-sub2 via port 23)
+#   docker exec access to opencupid-db-1    (weekly pg_dumpall)
+
+set -euo pipefail
+
+TS="$(date -u +%Y%m%d-%H%M%S)"
+SNAP="tank/srv@backup-${TS}"
+SNAPDIR="/srv/.zfs/snapshot/backup-${TS}"
+
+export RESTIC_REPOSITORY="sftp:storagebox:restic"
+export RESTIC_PASSWORD_FILE="/root/.config/restic/password"
+export RESTIC_CACHE_DIR="/var/cache/restic"
+
+log() { printf "[%s] %s\n" "$(date -u +%FT%TZ)" "$*"; }
+
+cleanup() {
+  log "Destroying snapshot ${SNAP}"
+  zfs destroy -r "${SNAP}" 2>/dev/null || log "WARN: snapshot destroy failed"
+}
+trap cleanup EXIT
+
+log "Creating recursive ZFS snapshot ${SNAP}"
+zfs snapshot -r "${SNAP}"
+
+# Weekly (Sunday) pg_dumpall — written to live fs so next day's snapshot
+# picks it up. Kept 5 weeks locally for fast rollback without Hetzner.
+if [ "$(date +%u)" = "7" ]; then
+  log "Weekly pg_dumpall"
+  mkdir -p /srv/opencupid/db-dumps
+  chmod 700 /srv/opencupid/db-dumps
+  DUMP="/srv/opencupid/db-dumps/pgdumpall-$(date +%Y%m%d).sql.gz"
+  docker exec -i opencupid-db-1 pg_dumpall -U appuser | gzip > "${DUMP}"
+  find /srv/opencupid/db-dumps -name 'pgdumpall-*.sql.gz' -mtime +35 -delete
+fi
+
+log "Running restic backup from ${SNAPDIR}"
+restic backup "${SNAPDIR}" \
+  --host gaians \
+  --tag daily \
+  --exclude='**/.zfs' \
+  --exclude='**/lost+found'
+
+log "Applying retention policy"
+restic forget --prune \
+  --keep-daily 7 \
+  --keep-weekly 4 \
+  --keep-monthly 6 \
+  --keep-yearly 2 \
+  --tag daily
+
+log "Done"

--- a/scripts/notify-sentry.sh
+++ b/scripts/notify-sentry.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# Post a single error event to Sentry when a systemd unit fails.
+# Invoked by a companion unit via:
+#   OnFailure=systemd-notify-sentry@<service>.service
+# or directly:
+#   ExecStart=/usr/local/bin/notify-sentry.sh <unit-name>
+
+set -euo pipefail
+
+UNIT="${1:-unknown.service}"
+DSN="${SENTRY_DSN:-https://31c384058e2e404eb38413f6918f2d8a@log.gaians.net/1}"
+
+KEY=$(echo "$DSN" | sed -nE 's#^https://([^@]+)@.*#\1#p')
+HOST=$(echo "$DSN" | sed -nE 's#^https://[^@]+@([^/]+)/.*#\1#p')
+PROJECT=$(echo "$DSN" | sed -nE 's#^https://[^@]+@[^/]+/(.*)#\1#p')
+
+EVENT_ID=$(head -c 16 /dev/urandom | xxd -p)
+TS_ISO=$(date -u +"%Y-%m-%dT%H:%M:%S.000Z")
+TS_UNIX=$(date +%s)
+
+LOGS=$(journalctl -u "$UNIT" --since '1 hour ago' --no-pager --output=short -n 30 2>/dev/null \
+       | tr '"' "'" | head -c 3000)
+
+PAYLOAD=$(cat <<EOF
+{
+  "event_id": "$EVENT_ID",
+  "timestamp": "$TS_ISO",
+  "level": "error",
+  "server_name": "gaians",
+  "logger": "systemd/$UNIT",
+  "platform": "other",
+  "tags": {"component": "backup", "unit": "$UNIT"},
+  "message": {"formatted": "systemd unit $UNIT failed"},
+  "extra": {"journal_tail": "$LOGS"}
+}
+EOF
+)
+
+curl -sS --max-time 10 \
+  -H "Content-Type: application/json" \
+  -H "X-Sentry-Auth: Sentry sentry_version=7,sentry_client=systemd-notify/1.0,sentry_key=$KEY,sentry_timestamp=$TS_UNIX" \
+  -d "$PAYLOAD" \
+  "https://$HOST/api/$PROJECT/store/" >/dev/null || true
+
+logger -t notify-sentry "sent event $EVENT_ID for failed unit $UNIT"


### PR DESCRIPTION
## Summary

Host-side operations scripts for the production deployment, committed to the repo so they're version-tracked and deployable via `git pull` on the box.

- `scripts/backup-srv.sh` — daily restic backup of `/srv` to Hetzner Storage Box from a recursive ZFS snapshot. Weekly Sunday `pg_dumpall`. Retention 7d/4w/6m/2y.
- `scripts/notify-sentry.sh` — post a failure event to Sentry via curl. Intended for `OnFailure=` in systemd units.

See `scripts/README.md` for deployment and host prerequisites.

## Test plan

- [x] `bash -n` syntax-check both scripts.
- [ ] Install on `gaians.net`, do a dry-run: `sudo RESTIC_REPOSITORY=sftp:storagebox:restic restic backup --dry-run /srv/.zfs/snapshot/<test>/...`
- [ ] Run a full one-shot backup, verify snapshots in `restic snapshots`, stats in `restic stats`, integrity via `restic check`.
- [ ] Test a trivial restore (pick one file) to `/tmp/restore-test/`.
- [ ] Trip `notify-sentry.sh` manually, confirm event arrives in Sentry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)