### PR TITLE
feat(admin): expose User.originDomain and User.language in users table + detail modal

### DIFF
--- a/.changeset/copper-otters-trail.md
+++ b/.changeset/copper-otters-trail.md
@@ -1,0 +1,6 @@
+---
+'@opencupid/backend': patch
+'@opencupid/admin': patch
+---
+
+Expose `User.originDomain` and `User.language` in the admin UI — a new `Origin` column in the users table (last data column, before action buttons) and two new rows (`Language`, `Origin`) in the user detail modal. Backend `/admin/users` list endpoint now returns both fields; `/admin/users/:id` adds `originDomain` (already had `language`).

--- a/apps/admin/src/pages/UsersPage.vue
+++ b/apps/admin/src/pages/UsersPage.vue
@@ -14,6 +14,8 @@ interface AdminUser {
   roles: string[]
   createdAt: string
   lastLoginAt: string | null
+  language: string
+  originDomain: string
   profile: { id: string; publicName: string } | null
 }
 
@@ -290,6 +292,7 @@ onUnmounted(() => {
             >
               Last Login{{ sortIndicator('lastLoginAt') }}
             </th>
+            <th>Origin</th>
             <th></th>
           </tr>
         </thead>
@@ -324,6 +327,7 @@ onUnmounted(() => {
             </td>
             <td>{{ new Date(user.createdAt).toLocaleDateString() }}</td>
             <td>{{ user.lastLoginAt ? new Date(user.lastLoginAt).toLocaleDateString() : '-' }}</td>
+            <td>{{ user.originDomain || '-' }}</td>
             <td class="text-nowrap">
               <button
                 v-if="user.profile"
@@ -343,7 +347,7 @@ onUnmounted(() => {
           </tr>
           <tr v-if="users.length === 0">
             <td
-              colspan="9"
+              colspan="10"
               class="text-center text-muted"
             >
               No users found
@@ -439,6 +443,10 @@ onUnmounted(() => {
                     : 'Never'
                 }}
               </dd>
+              <dt class="col-sm-4">Language</dt>
+              <dd class="col-sm-8">{{ selectedUser.language || '-' }}</dd>
+              <dt class="col-sm-4">Origin</dt>
+              <dd class="col-sm-8">{{ selectedUser.originDomain || '-' }}</dd>
               <dt class="col-sm-4">Profile</dt>
               <dd class="col-sm-8">
                 {{ selectedUser.profile?.publicName || 'No profile' }}

--- a/apps/backend/src/api/routes/admin.route.ts
+++ b/apps/backend/src/api/routes/admin.route.ts
@@ -184,6 +184,8 @@ const adminRoutes: FastifyPluginAsync = async (fastify) => {
             roles: true,
             createdAt: true,
             lastLoginAt: true,
+            language: true,
+            originDomain: true,
             newsletterOptIn: true,
             isRegistrationConfirmed: true,
             profile: { select: { id: true, publicName: true } },
@@ -228,6 +230,7 @@ const adminRoutes: FastifyPluginAsync = async (fastify) => {
           updatedAt: true,
           lastLoginAt: true,
           language: true,
+          originDomain: true,
           newsletterOptIn: true,
           isPushNotificationEnabled: true,
           profile: {


### PR DESCRIPTION
## Summary

- **Backend**: \`/admin/users\` list endpoint now returns \`originDomain\` and \`language\`; \`/admin/users/:id\` adds \`originDomain\` (it already had \`language\`).
- **Admin UI**: new \`Origin\` column in the users table as the last data column (immediately before the action buttons). User detail modal gets two new rows: \`Language\` and \`Origin\`.

## Test plan

- [x] Backend + admin typecheck clean.
- [ ] UAT on staging/prod: open Users page → scan Origin column → open a user → confirm Language + Origin shown correctly.
- [ ] Search unaffected.
- [ ] Empty-state row colspan updated from 9 → 10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)