### PR TITLE
fix(frontend): tighten posts UI and offcanvas widths

### DIFF
--- a/.changeset/shaggy-bears-accept.md
+++ b/.changeset/shaggy-bears-accept.md
@@ -1,0 +1,6 @@
+---
+"@opencupid/frontend": patch
+"@opencupid/shared": patch
+---
+
+fix(frontend): tighten posts UI and offcanvas widths

--- a/apps/frontend/src/css/layout.scss
+++ b/apps/frontend/src/css/layout.scss
@@ -80,10 +80,8 @@ nav.navbar + main {
 }
 
 .offcanvas.owner-drawer {
-  @include media-breakpoint-down(md) {
-    width: 100vw;
-  }
-
+  width: 100vw;
+  
   @include media-breakpoint-up(md) {
     width: 75vw;
   }
@@ -94,9 +92,7 @@ nav.navbar + main {
 }
 
 .offcanvas.detail-panel {
-  @include media-breakpoint-down(sm) {
-    width: 100vw;
-  }
+  width: 100vw;
 
   @include media-breakpoint-up(md) {
     width: 75vw;

--- a/apps/frontend/src/features/browse/components/NearbyFeatures.vue
+++ b/apps/frontend/src/features/browse/components/NearbyFeatures.vue
@@ -71,7 +71,7 @@ const isVisible = computed(() => props.posts.length > 0)
       <div
         v-for="post in posts"
         :key="post.id"
-        class="user-select-none col-12 col-sm-6 col-md-4 col-lg-2"
+        class="user-select-none col-12 col-sm-6 col-md-4 col-lg-3"
         @click="handleClick(post)"
       >
         <PostIt

--- a/apps/frontend/src/features/posts/components/EditPostDialog.vue
+++ b/apps/frontend/src/features/posts/components/EditPostDialog.vue
@@ -20,6 +20,9 @@ import PostIt from '@/features/shared/ui/PostIt.vue'
 import PostTypeBadge from './PostTypeBadge.vue'
 import LocationSelector from '@/features/shared/profileform/LocationSelector.vue'
 
+import IconHide from '@/assets/icons/interface/hide.svg'
+import IconShow from '@/assets/icons/interface/unhide.svg'
+
 interface Emits {
   (e: 'cancel'): void
   (e: 'saved', post: OwnerPost): void
@@ -138,14 +141,27 @@ const handleSubmit = async () => {
         </BFormGroup>
 
         <!-- isVisible flag checkbox -->
-        <BFormGroup v-if="isEdit">
-          <BFormCheckbox
-            type="checkbox"
-            v-model="form.isVisible"
-            :label="$t('posts.labels.visibility')"
+        <BFormGroup
+          v-if="isEdit"
+          class="d-flex align-items-center"
+        >
+          <BButton
+            variant="link-secondary"
+            size="sm"
+            v-model:pressed="form.isVisible"
+            :title="form.isVisible ? $t('posts.actions.hide') : $t('posts.actions.show')"
+            :aria-label="form.isVisible ? $t('posts.actions.hide') : $t('posts.actions.show')"
           >
-            {{ $t('posts.labels.visibility') }}
-          </BFormCheckbox>
+            <IconShow
+              v-if="form.isVisible"
+              class="svg-icon"
+            />
+            <IconHide
+              v-else
+              class="svg-icon"
+            />
+          </BButton>
+          {{ $t('posts.labels.visibility') }}
         </BFormGroup>
       </div>
 

--- a/apps/frontend/src/features/posts/components/MyPostList.vue
+++ b/apps/frontend/src/features/posts/components/MyPostList.vue
@@ -64,9 +64,9 @@ function handlePostHide(post: any) {
 
 <template>
   <div class="post-list h-100 w-100 d-flex flex-column">
-    <BContainer v-if="!isInitialized && posts.length === 0">
+    <div v-if="!isInitialized && posts.length === 0" class="p-2 p-md-3">
       <PostPlaceholdersGrid />
-    </BContainer>
+    </div>
 
     <div
       v-else-if="posts.length === 0"

--- a/apps/frontend/src/features/posts/components/OwnerToolbar.vue
+++ b/apps/frontend/src/features/posts/components/OwnerToolbar.vue
@@ -42,11 +42,11 @@ defineEmits<{
       :title="isVisible ? $t('posts.actions.hide') : $t('posts.actions.show')"
       :aria-label="isVisible ? $t('posts.actions.hide') : $t('posts.actions.show')"
     >
-      <IconHide
+      <IconShow
         v-if="isVisible"
         class="svg-icon"
       />
-      <IconShow
+      <IconHide
         v-else
         class="svg-icon"
       />

--- a/apps/frontend/src/features/posts/components/PostPlaceholdersGrid.vue
+++ b/apps/frontend/src/features/posts/components/PostPlaceholdersGrid.vue
@@ -16,7 +16,6 @@ withDefaults(
 <template>
   <BRow
     cols="1"
-    cols-sm="2"
     cols-lg="3"
     class="g-2 gx-4 gy-4"
   >

--- a/packages/shared/i18n/hu.json
+++ b/packages/shared/i18n/hu.json
@@ -349,7 +349,7 @@
       "location": "Helyszín",
       "type": "Típus",
       "updated": "Utoljára frissítve",
-      "visibility": "Látható mások számára"
+      "visibility": "Látható?"
     },
     "location": {
       "enable": "Helymeghatározás engedélyezése",
@@ -461,7 +461,7 @@
       "kids_preference_label": "Gyerekei?",
       "more_options": "További lehetőségek...",
       "my_dating_profile": "Párkereső profilom",
-      "my_preferences": "Preferenciáim",
+      "my_preferences": "Kit keresek?",
       "my_profile": "Adataim",
       "name_first_name_only": "Csak a keresztnevedet",
       "name_invalid": "Adj meg legalább 3 betűt",


### PR DESCRIPTION
## Summary
- Swap the post visibility checkbox for an icon-based show/hide toggle button in `EditPostDialog`
- Simplify `.offcanvas.owner-drawer` / `.offcanvas.detail-panel` width rules (default 100vw, 75vw on md+)
- Adjust Nearby grid to `col-lg-3`, drop `cols-sm="2"` from placeholders, and use a plain container in `MyPostList`
- Refine Hungarian labels (`posts.labels.visibility`, `profile.labels.my_preferences`)

## Test plan
- [ ] Edit an existing post — toggle visibility via the new icon button, confirm pressed state and saved value
- [ ] Verify owner-drawer and detail-panel widths across xs/sm/md/lg breakpoints
- [ ] Check Nearby posts grid layout at lg (4 columns)
- [ ] Confirm placeholders render while posts load on `/posts`
- [ ] Visual check of Hungarian strings in post edit form and profile nav

🤖 Generated with [Claude Code](https://claude.com/claude-code)