### PR TITLE
infra: add redis+postgres healthchecks, gate backend/worker on them

### DIFF
--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -5,6 +5,12 @@ services:
     restart: always
     volumes:
       - redis-data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 3s
+      retries: 5
+      start_period: 20s
 
   db:
     image: postgres:15
@@ -13,6 +19,12 @@ services:
       - .env
     volumes:
       - ${POSTGRES_DATADIR}:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER -d $$POSTGRES_DB"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
 
   ingress:
     image: ${DOCKER_IMAGE_PREFIX:-ghcr.io/opencupid/opencupid}-ingress:${INGRESS_VERSION:-latest}
@@ -39,8 +51,10 @@ services:
       context: .
       dockerfile: apps/backend/Dockerfile
     depends_on:
-      - db
-      - redis
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
     env_file:
       - .env
     volumes:
@@ -75,8 +89,10 @@ services:
     restart: always
     command: ["node", "dist/worker.js"]
     depends_on:
-      - db
-      - redis
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
     env_file:
       - .env
     volumes:


### PR DESCRIPTION
## Summary
- Add idiomatic healthchecks to `redis` (redis-cli ping) and `db` (pg_isready) in production compose.
- Convert `backend` and `worker` `depends_on` to long-form with `condition: service_healthy` for both dependencies, so they no longer start before Redis/Postgres accept connections.
- Mitigates the startup-race class of errors seen in #1347 (ECONNREFUSED / ENOTFOUND on Redis) by ensuring dependents wait for a real readiness signal, not just container start.

## Test plan
- [ ] `docker compose -f docker-compose.production.yml config --quiet` parses cleanly
- [ ] On prod host: `docker compose -f docker-compose.production.yml up -d` starts redis+db, waits for healthy, then starts backend+worker
- [ ] `docker compose ps` shows `(healthy)` for redis and db
- [ ] Kill+restart redis mid-run: backend reconnects without flooding Sentry (behavior unchanged from before — healthchecks only affect initial startup ordering)

🤖 Generated with [Claude Code](https://claude.com/claude-code)