### PR TITLE
feat(frontend): move OG tags + brand labels to landing /pages/

### DIFF
--- a/.changeset/strange-rabbits-smell.md
+++ b/.changeset/strange-rabbits-smell.md
@@ -1,0 +1,5 @@
+---
+"@opencupid/frontend": patch
+---
+
+feat(frontend): move OG tags + brand labels to landing /pages/

--- a/apps/frontend/docker-entrypoint.sh
+++ b/apps/frontend/docker-entrypoint.sh
@@ -1,14 +1,18 @@
 #!/bin/sh
 set -eu
 
-# 1. Substitute OG placeholders in index.html
+# 1. Substitute placeholders in index.html
 envsubst < /var/www/index.html > /var/www/index.html.tmp
 mv /var/www/index.html.tmp /var/www/index.html
 
-# 2. Generate config.js from committed template
+# 2. Substitute placeholders in site.webmanifest
+envsubst < /var/www/assets/site.webmanifest > /var/www/assets/site.webmanifest.tmp
+mv /var/www/assets/site.webmanifest.tmp /var/www/assets/site.webmanifest
+
+# 3. Generate config.js from committed template
 envsubst < /var/www/config.template.js > /var/www/config.js
 
-# 3. Generate security headers from template
+# 4. Generate security headers from template
 if [ -n "${CSP_REPORT_URI:-}" ]; then
   export CSP_REPORT_DIRECTIVE="; report-uri ${CSP_REPORT_URI}"
 else

--- a/apps/frontend/index.html
+++ b/apps/frontend/index.html
@@ -6,27 +6,7 @@
       name="viewport"
       content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, interactive-widget=resizes-visual"
     />
-    <meta
-      property="og:title"
-      content="${OG_TITLE}"
-    />
     <title>${SITE_NAME}</title>
-    <meta
-      property="og:description"
-      content="${OG_DESCRIPTION}"
-    />
-    <meta
-      property="og:image"
-      content="${OG_IMAGE}"
-    />
-    <meta
-      property="og:url"
-      content="${OG_URL}"
-    />
-    <meta
-      property="og:type"
-      content="${OG_TYPE}"
-    />
 
     <link
       rel="icon"
@@ -50,7 +30,7 @@
     />
     <meta
       name="apple-mobile-web-app-title"
-      content="Gaians.net"
+      content="${SITE_NAME}"
     />
     <link
       rel="manifest"
@@ -58,7 +38,7 @@
     />
     <meta
       name="theme-color"
-      content="#008000"
+      content="#325d88"
     />
   </head>
 

--- a/apps/frontend/public/assets/site.webmanifest
+++ b/apps/frontend/public/assets/site.webmanifest
@@ -1,6 +1,6 @@
 {
-  "name": "Gaians.net",
-  "short_name": "Gaians",
+  "name": "${SITE_NAME}",
+  "short_name": "${SITE_SHORT_NAME}",
   "start_url": "/home",
   "scope": "/",
   "launch_handler": {
@@ -32,7 +32,7 @@
       "purpose": "maskable"
     }
   ],
-  "theme_color": "#008000",
+  "theme_color": "#325d88",
   "background_color": "#f8f5f0",
   "display": "standalone"
 }


### PR DESCRIPTION
## Summary

Companion PR to opencupid/landingpages#4. Crawlers don't send cookies, so they always hit the landing container at `gaians.net/` — the SPA's OG meta tags are effectively dead code because link-preview requests never reach them. OG ownership moves to the landing repo; this PR removes the SPA copies and fixes two latent brand-correctness bugs surfaced while editing the same file.

### Changes

- **Remove 5 `og:*` meta tags** from `index.html` (were substituted from `OG_TITLE`/`OG_DESCRIPTION`/`OG_IMAGE`/`OG_URL`/`OG_TYPE` env vars — those env vars become unused after this ships and are removed in the conf-prod PR)
- **Template `<meta apple-mobile-web-app-title>`** from hardcoded `"Gaians.net"` to `${SITE_NAME}` — fixes Hungarian iOS users seeing "Gaians.net" as their home-screen label instead of "Komatérkép"
- **Template manifest `name`/`short_name`** to `${SITE_NAME}`/`${SITE_SHORT_NAME}` (new env var) — same bug class, affects Android install dialog + PWA name in browser chrome
- **Update `theme-color`** from stale `#008000` (pre-Sandstone green) to `#325d88` (current Sandstone primary) in both `<meta>` and manifest
- **Extend `docker-entrypoint.sh`** with a second `envsubst` pass for `site.webmanifest` (parallel to existing `index.html` substitution)

### What stays

- All icon `<link>` paths under `/assets/*` — files remain in this repo, each container carries its own copy (duplication policy for self-containment; DRY-up is a follow-up)
- Splash `<img src=/assets/logo.png>`
- The `__o` cookie cross-brand bounce script
- Manifest `start_url: /home` (vestigial-broken reference — fix in a separate PR)
- `sw.js` fallback `icon: '/assets/favicon-96x96.png'` (app container still serves this path)

### Companion PRs

- **opencupid/landingpages#3** — Bootstrap + SCSS toolchain, external asset pipeline (base)
- **opencupid/landingpages#4** — `/pages/` namespace (OG tags, icons, manifest, bounce script — the landing side of this migration)
- **conf-prod** (next) — swap `OG_*` env vars for `SITE_SHORT_NAME`, add `PathPrefix(/pages)` Traefik rule

### Deployment ordering

This PR depends on `SITE_SHORT_NAME` being present in the container env. Ship the conf-prod PR (which adds the env var) at the same time or just before this merges; otherwise `${SITE_SHORT_NAME}` renders literally in the manifest for the gap period — cosmetic glitch, not a functional break.

## Test plan

- [x] `docker build` succeeds
- [ ] Boot locally with `SITE_NAME=Gaians.net`, `SITE_SHORT_NAME=Gaians`: `curl /index.html` contains no `og:*` tags, `apple-mobile-web-app-title="Gaians.net"`, `theme-color="#325d88"`
- [ ] Same but `SITE_NAME=Komatérkép`, `SITE_SHORT_NAME=Komatérkép`: `curl /assets/site.webmanifest` returns `"name": "Komatérkép"`, `"short_name": "Komatérkép"`
- [ ] `curl /assets/favicon-96x96.png` returns 200 (sw.js fallback still works)
- [ ] PWA install dialog on Android shows correct brand name for komaterkep.hu deploy
- [ ] iOS "Add to Home Screen" label reads correct brand

🤖 Generated with [Claude Code](https://claude.com/claude-code)