### PR TITLE
Silent cookie migration to domain-scoped session cookies

### DIFF
--- a/.changeset/silent-cookies-migrate.md
+++ b/.changeset/silent-cookies-migrate.md
@@ -1,0 +1,7 @@
+---
+'@opencupid/backend': patch
+'@opencupid/frontend': patch
+'@opencupid/shared': patch
+---
+
+Silent cookie migration to domain-scoped __session/__refresh cookies ahead of SPA subdomain split. Every authenticated response now sets the new domain-scoped cookie shape (driven by `appConfig.DOMAIN`) and emits a delete for the legacy host-only variant, so active users are migrated in-place without being logged out (#1351)

--- a/apps/backend/src/__tests__/routes/auth.route.spec.ts
+++ b/apps/backend/src/__tests__/routes/auth.route.spec.ts
@@ -131,15 +131,66 @@ describe('GET /verify-token', () => {
     expect(reply.cookies[0].opts).toMatchObject({
       path: '/',
       httpOnly: false,
-      sameSite: 'strict',
+      sameSite: 'lax',
     })
+    // Dev mode: no Domain attribute (browsers reject Domain on localhost).
+    expect(reply.cookies[0].opts.domain).toBeUndefined()
     expect(reply.cookies[1].name).toBe('__refresh')
     expect(reply.cookies[1].value).toBe('mock-refresh-token')
     expect(reply.cookies[1].opts).toMatchObject({
       path: '/',
       httpOnly: true,
-      sameSite: 'strict',
+      sameSite: 'lax',
     })
+    // Dev mode: the new-shape cookie is already host-only, so emitting a
+    // legacy host-only clearCookie would target the same (name, Domain, Path)
+    // slot as the just-set cookie and wipe it. The migration helper must
+    // skip the legacy clear in this case.
+    const clearedNames = reply.clearedCookies.map((c: any) => c.name)
+    expect(clearedNames).not.toContain('__session')
+    expect(clearedNames).not.toContain('__refresh')
+  })
+
+  it('sets Domain=.<DOMAIN> on session + refresh cookies in production', async () => {
+    const origNodeEnv = appConfig.NODE_ENV
+    appConfig.NODE_ENV = 'production'
+    try {
+      const handler = fastify.routes['GET /verify-token']
+      const user = { id: 'u1', email: 't@e.com', tokenVersion: 0, roles: [], language: 'en' }
+      mockUserService.validateLoginToken.mockResolvedValue({
+        success: true,
+        user,
+        isNewUser: false,
+      })
+      mockGetExistingUserSession.mockResolvedValue({
+        profileId: 'p1',
+        sessionData: {
+          userId: 'u1',
+          profileId: 'p1',
+          tokenVersion: 0,
+          lang: 'en',
+          roles: [],
+          hasActiveProfile: false,
+          profile: { id: 'p1', isDatingActive: false, isSocialActive: false, isActive: false },
+        },
+      })
+      fastify.jwt = { sign: vi.fn().mockReturnValue('jwt-token') }
+      await handler({ query: { token: 'abc123' } } as any, reply as any)
+
+      const session = reply.cookies.find((c: any) => c.name === '__session')!
+      const refresh = reply.cookies.find((c: any) => c.name === '__refresh')!
+      // Domain is the apex with a leading dot so the cookie is sent on any
+      // subdomain (apex + app. + api. etc.).
+      expect(session.opts.domain).toBe('.fallback.example')
+      expect(refresh.opts.domain).toBe('.fallback.example')
+      // The legacy-shape delete must NOT carry the Domain attribute — it
+      // targets the pre-migration host-only slot, which the browser keys
+      // separately from the domain-scoped slot.
+      const clearedSession = reply.clearedCookies.find((c: any) => c.name === '__session')!
+      expect(clearedSession.opts).toEqual({ path: '/' })
+    } finally {
+      appConfig.NODE_ENV = origNodeEnv
+    }
   })
 
   it('returns 200 and token for new user and initializes profile', async () => {
@@ -341,7 +392,7 @@ describe('POST /send-magic-link', () => {
       expect(originCookie!.value).toBe('other.example')
       expect(originCookie!.opts).toMatchObject({
         path: '/',
-        sameSite: 'strict',
+        sameSite: 'lax',
         maxAge: 60 * 60 * 24 * 365 * 10,
       })
       expect(notifier.notifyUser).toHaveBeenCalledWith('user5', 'login_link', {
@@ -608,13 +659,16 @@ describe('POST /logout', () => {
     expect(deleteSession).toHaveBeenCalled()
     expect(mockRefreshTokenService.delete).toHaveBeenCalledWith('tok-abc', 'user1')
     expect(mockRefreshTokenService.deleteAllForUser).not.toHaveBeenCalled()
-    expect(reply.clearedCookies[0]).toMatchObject({
+    // Logout clears both shapes for each cookie so a mid-migration user
+    // fully logs out regardless of which variant their browser still holds.
+    const cleared = reply.clearedCookies.map((c: any) => ({ name: c.name, opts: c.opts }))
+    expect(cleared).toContainEqual({
       name: '__session',
-      opts: { path: '/' },
+      opts: expect.objectContaining({ path: '/' }),
     })
-    expect(reply.clearedCookies[1]).toMatchObject({
+    expect(cleared).toContainEqual({
       name: '__refresh',
-      opts: { path: '/' },
+      opts: expect.objectContaining({ path: '/' }),
     })
   })
 })

--- a/apps/backend/src/api/helpers.ts
+++ b/apps/backend/src/api/helpers.ts
@@ -26,6 +26,13 @@ export function sendForbiddenError(
   return sendError(reply, 403, message)
 }
 
+export function sendServiceUnavailableError(
+  reply: FastifyPluginAsync['prototype']['reply'],
+  message: string = 'Service temporarily unavailable'
+) {
+  return sendError(reply, 503, message)
+}
+
 export function getUserRoles(req: FastifyRequest): UserRole[] {
   return req.session?.roles || []
 }

--- a/apps/backend/src/api/routes/auth.route.ts
+++ b/apps/backend/src/api/routes/auth.route.ts
@@ -1,6 +1,6 @@
 import cuid from 'cuid'
 import { randomUUID } from 'crypto'
-import { FastifyPluginAsync, FastifyReply } from 'fastify'
+import { FastifyPluginAsync } from 'fastify'
 import { notifierService } from '@/services/notifier.service'
 import { UserService } from '@/services/user.service'
 import { RefreshTokenService } from '@/services/refresh-token.service'
@@ -24,54 +24,14 @@ import type {
 } from '@zod/apiResponse.dto'
 import { UserIdentifier, JwtPayload } from '@zod/user/user.dto'
 import {
-  SESSION_COOKIE,
-  SESSION_COOKIE_OPTS,
-  SESSION_MAX_AGE,
-  REFRESH_COOKIE,
-  REFRESH_MAX_AGE,
-  ORIGIN_COOKIE,
-  ORIGIN_MAX_AGE,
-} from '@shared/session'
-
-function setSessionCookie(reply: FastifyReply, jwt: string) {
-  reply.setCookie(SESSION_COOKIE, jwt, {
-    ...SESSION_COOKIE_OPTS,
-    httpOnly: false,
-    secure: appConfig.NODE_ENV !== 'development',
-    maxAge: SESSION_MAX_AGE,
-  })
-}
-
-function setRefreshCookie(reply: FastifyReply, token: string) {
-  reply.setCookie(REFRESH_COOKIE, token, {
-    ...SESSION_COOKIE_OPTS,
-    httpOnly: true,
-    secure: appConfig.NODE_ENV !== 'development',
-    maxAge: REFRESH_MAX_AGE,
-  })
-}
-
-function clearSessionCookie(reply: FastifyReply) {
-  reply.clearCookie(SESSION_COOKIE, SESSION_COOKIE_OPTS)
-}
-
-function clearRefreshCookie(reply: FastifyReply) {
-  reply.clearCookie(REFRESH_COOKIE, SESSION_COOKIE_OPTS)
-}
-
-// Stamps the __o cookie authoritatively on any host where login activity
-// occurs. Rewriting on every send and consume (not only cross-brand ones)
-// prevents ping-pong loops caused by stale __o values left on both brands
-// pointing at each other.
-function setOriginCookie(reply: FastifyReply, originDomain: string | null | undefined) {
-  if (!originDomain) return
-  if (appConfig.NODE_ENV === 'development') return
-  reply.setCookie(ORIGIN_COOKIE, originDomain, {
-    ...SESSION_COOKIE_OPTS,
-    secure: true,
-    maxAge: ORIGIN_MAX_AGE,
-  })
-}
+  setSessionCookie,
+  setRefreshCookie,
+  clearSessionCookie,
+  clearRefreshCookie,
+  setOriginCookie,
+  getSessionCookie,
+  getRefreshCookie,
+} from '@/lib/session'
 
 const WS_TICKET_TTL = 30 // seconds
 
@@ -161,12 +121,12 @@ const authRoutes: FastifyPluginAsync = async (fastify) => {
       },
     },
     async (req, reply) => {
-      const refreshToken = req.cookies[REFRESH_COOKIE]
+      const refreshToken = getRefreshCookie(req)
       if (!refreshToken) {
         return sendUnauthorizedError(reply, 'Missing refresh token')
       }
 
-      const expiredJwt = req.cookies[SESSION_COOKIE]
+      const expiredJwt = getSessionCookie(req)
       if (!expiredJwt) {
         return sendUnauthorizedError(reply, 'Missing session cookie')
       }
@@ -361,7 +321,7 @@ const authRoutes: FastifyPluginAsync = async (fastify) => {
         // tokenVersion, which would invalidate all other active sessions
         // (other devices/browsers) since we have no "logout all" feature.
         await req.deleteSession()
-        const refreshToken = req.cookies[REFRESH_COOKIE]
+        const refreshToken = getRefreshCookie(req)
         if (refreshToken) {
           await refreshTokenService.delete(refreshToken, req.user.userId)
         }

--- a/apps/backend/src/lib/session-legacy.ts
+++ b/apps/backend/src/lib/session-legacy.ts
@@ -6,6 +6,12 @@
  * — delete both files together once the migration window has elapsed; every
  * import will fail loudly, pointing at call sites that still emit legacy
  * behavior.
+ *
+ * TODO(2026-07-22): Retire this file + the frontend sibling. The date is
+ * anchored to ~90 days after Phase 1 deploy (refresh-token TTL), by which
+ * point every active user is on the domain-scoped shape and any dormant
+ * host-only refresh token has expired. Bump this date forward if the PR
+ * #1353 merge slips materially past 2026-04-22.
  */
 import { FastifyReply } from 'fastify'
 import { canScopeToDomain } from '@shared/session'

--- a/apps/backend/src/lib/session-legacy.ts
+++ b/apps/backend/src/lib/session-legacy.ts
@@ -1,0 +1,30 @@
+/**
+ * Backend adapter for the Phase 1 silent cookie migration (issue #1351).
+ *
+ * Closes over `appConfig` so route handlers can emit the legacy host-only
+ * clear with a single call. Pairs with `apps/frontend/src/lib/session-legacy.ts`
+ * — delete both files together once the migration window has elapsed; every
+ * import will fail loudly, pointing at call sites that still emit legacy
+ * behavior.
+ */
+import { FastifyReply } from 'fastify'
+import { canScopeToDomain } from '@shared/session'
+import { appConfig } from '@/lib/appconfig'
+
+/**
+ * Options that identify the pre-migration host-only cookie slot. Browsers key
+ * cookies by (name, Domain, Path); matching Path is sufficient for deletion.
+ *
+ * Duplicated (verbatim) in the frontend adapter rather than shared so that
+ * deleting this file removes every trace of the migration — no orphaned
+ * shared helper gets left behind by accident.
+ */
+const LEGACY_HOST_ONLY_COOKIE_OPTS = { path: '/' }
+
+export function clearLegacyCookie(reply: FastifyReply, name: string): void {
+  // No-op when the new shape is itself host-only (dev / unusable DOMAIN) so
+  // the clear never collides with the just-set cookie's (name, Domain, Path)
+  // slot.
+  if (!canScopeToDomain(appConfig.NODE_ENV, appConfig.DOMAIN)) return
+  reply.clearCookie(name, LEGACY_HOST_ONLY_COOKIE_OPTS)
+}

--- a/apps/backend/src/lib/session.ts
+++ b/apps/backend/src/lib/session.ts
@@ -1,0 +1,81 @@
+/**
+ * Backend-side cookie helpers for the session / refresh / origin cookies.
+ * Centralizes every Fastify `setCookie`/`clearCookie` call that touches these
+ * names so the cookie shape is decided in exactly one place per operation.
+ *
+ * Platform-agnostic primitives (cookie names, max-ages, `resolveSessionCookie`,
+ * `canScopeToDomain`) live in `@shared/session`; migration-only helpers live
+ * alongside in `./session-legacy` and get deleted post-sunset.
+ */
+import { FastifyReply, FastifyRequest } from 'fastify'
+import '@fastify/cookie'
+import {
+  SESSION_COOKIE,
+  SESSION_COOKIE_OPTS,
+  SESSION_MAX_AGE,
+  REFRESH_COOKIE,
+  REFRESH_MAX_AGE,
+  ORIGIN_COOKIE,
+  ORIGIN_MAX_AGE,
+  resolveSessionCookie,
+} from '@shared/session'
+import { clearLegacyCookie } from './session-legacy'
+import { appConfig } from '@/lib/appconfig'
+
+function currentSessionCookieOpts() {
+  return resolveSessionCookie(appConfig.NODE_ENV, appConfig.DOMAIN)
+}
+
+export function getSessionCookie(req: FastifyRequest): string | undefined {
+  return req.cookies[SESSION_COOKIE]
+}
+
+export function getRefreshCookie(req: FastifyRequest): string | undefined {
+  return req.cookies[REFRESH_COOKIE]
+}
+
+export function setSessionCookie(reply: FastifyReply, jwt: string) {
+  reply.setCookie(SESSION_COOKIE, jwt, {
+    ...currentSessionCookieOpts(),
+    httpOnly: false,
+    secure: appConfig.NODE_ENV !== 'development',
+    maxAge: SESSION_MAX_AGE,
+  })
+  clearLegacyCookie(reply, SESSION_COOKIE)
+}
+
+export function setRefreshCookie(reply: FastifyReply, token: string) {
+  reply.setCookie(REFRESH_COOKIE, token, {
+    ...currentSessionCookieOpts(),
+    httpOnly: true,
+    secure: appConfig.NODE_ENV !== 'development',
+    maxAge: REFRESH_MAX_AGE,
+  })
+  clearLegacyCookie(reply, REFRESH_COOKIE)
+}
+
+export function clearSessionCookie(reply: FastifyReply) {
+  reply.clearCookie(SESSION_COOKIE, currentSessionCookieOpts())
+  clearLegacyCookie(reply, SESSION_COOKIE)
+}
+
+export function clearRefreshCookie(reply: FastifyReply) {
+  reply.clearCookie(REFRESH_COOKIE, currentSessionCookieOpts())
+  clearLegacyCookie(reply, REFRESH_COOKIE)
+}
+
+/**
+ * Stamps the __o cookie authoritatively on any host where login activity
+ * occurs. Rewriting on every send and consume (not only cross-brand ones)
+ * prevents ping-pong loops caused by stale __o values left on both brands
+ * pointing at each other.
+ */
+export function setOriginCookie(reply: FastifyReply, originDomain: string | null | undefined) {
+  if (!originDomain) return
+  if (appConfig.NODE_ENV === 'development') return
+  reply.setCookie(ORIGIN_COOKIE, originDomain, {
+    ...SESSION_COOKIE_OPTS,
+    secure: true,
+    maxAge: ORIGIN_MAX_AGE,
+  })
+}

--- a/apps/backend/src/plugins/session-auth.ts
+++ b/apps/backend/src/plugins/session-auth.ts
@@ -4,7 +4,7 @@ import fastifyJwt from '@fastify/jwt'
 import Redis from 'ioredis'
 
 import { SessionService } from '../services/session.service'
-import { sendUnauthorizedError } from '@/api/helpers'
+import { sendServiceUnavailableError, sendUnauthorizedError } from '@/api/helpers'
 import { appConfig } from '@/lib/appconfig'
 import '@fastify/cookie'
 import { SESSION_COOKIE } from '@shared/session'
@@ -74,27 +74,39 @@ export default fp(async (fastify: FastifyInstance) => {
     // Resolve the session ID — prefer cookie, fall back to Bearer token
     const sessionId = cookieToken ?? bearerToken!
 
-    // Silent cookie migration: rewrite every authenticated request to the
-    // domain-scoped cookie shape and delete the legacy host-only variant.
-    // Also covers the older localStorage → Bearer-header migration by
-    // stamping the cookie when the client only sent a Bearer token. Runs on
-    // the hot path so every active user is migrated on their very next
-    // authenticated call. Remove once the migration window has elapsed.
-    setSessionCookie(reply, sessionId)
-
-    // Try to fetch an existing session from Redis
-    const sess = await sessionService.get(sessionId)
-    if (!sess) {
-      return sendUnauthorizedError(reply, 'Session expired')
+    // Session lookup + validation + migration-cookie stamp + TTL refresh all
+    // touch Redis (directly or indirectly). Wrap as one unit so any transient
+    // Redis failure (restart, network blip during backend deploy) returns a
+    // single distinguishable 503 — never fail-open, that would turn infra
+    // blips into auth bypasses.
+    let sess: SessionData | null
+    try {
+      sess = await sessionService.get(sessionId)
+      if (!sess) {
+        return sendUnauthorizedError(reply, 'Session expired')
+      }
+      if (req.user.tokenVersion !== sess.tokenVersion) {
+        return sendUnauthorizedError(reply, 'Token revoked')
+      }
+      // Refresh the session cookie on every authenticated request. Three
+      // jobs in one call:
+      //   1. Sliding TTL — resets Max-Age to 30d so active users stay
+      //      logged in as long as they keep using the app. Permanent
+      //      behavior, survives post-migration sunset.
+      //   2. Phase 1 shape migration — stamps the current domain-scoped
+      //      shape and (inside `clearLegacyCookie`) wipes the legacy
+      //      host-only slot when they're distinct.
+      //   3. Phase 0 Bearer → cookie migration — clients that sent only
+      //      an `Authorization: Bearer` header now carry a proper cookie
+      //      on their next request.
+      // Only runs after the full auth chain succeeds, so failed-auth
+      // responses don't re-stamp a cookie the client can't use.
+      setSessionCookie(reply, sessionId)
+      await sessionService.refreshTtl(sessionId)
+    } catch (err) {
+      req.log.error({ err, sessionId }, 'Redis error during authenticated request')
+      return sendServiceUnavailableError(reply, 'Session lookup failed')
     }
-
-    // Verify tokenVersion matches between JWT and session
-    if (req.user.tokenVersion !== sess.tokenVersion) {
-      return sendUnauthorizedError(reply, 'Token revoked')
-    }
-
-    // Refresh TTL on simple reads
-    await sessionService.refreshTtl(sessionId)
 
     req.session = sess
     req.deleteSession = async () => {

--- a/apps/backend/src/plugins/session-auth.ts
+++ b/apps/backend/src/plugins/session-auth.ts
@@ -7,7 +7,8 @@ import { SessionService } from '../services/session.service'
 import { sendUnauthorizedError } from '@/api/helpers'
 import { appConfig } from '@/lib/appconfig'
 import '@fastify/cookie'
-import { SESSION_COOKIE, SESSION_COOKIE_OPTS, SESSION_MAX_AGE } from '@shared/session'
+import { SESSION_COOKIE } from '@shared/session'
+import { getSessionCookie, setSessionCookie } from '@/lib/session'
 import { SessionData } from '@zod/user/user.dto'
 
 // Extend Fastify types
@@ -48,7 +49,7 @@ export default fp(async (fastify: FastifyInstance) => {
   // cookie. @fastify/jwt checks Bearer header first, then falls back to cookie.
   // Old clients still sending Authorization: Bearer get migrated to the cookie.
   fastify.decorate('authenticate', async (req: FastifyRequest, reply: FastifyReply) => {
-    const cookieToken = req.cookies[SESSION_COOKIE]
+    const cookieToken = getSessionCookie(req)
     const bearerToken = req.headers.authorization?.startsWith('Bearer ')
       ? req.headers.authorization.slice(7)
       : null
@@ -66,15 +67,13 @@ export default fp(async (fastify: FastifyInstance) => {
     // Resolve the session ID — prefer cookie, fall back to Bearer token
     const sessionId = cookieToken ?? bearerToken!
 
-    // Migrate old clients: set __session cookie so subsequent requests use it
-    if (!cookieToken && bearerToken) {
-      reply.setCookie(SESSION_COOKIE, sessionId, {
-        ...SESSION_COOKIE_OPTS,
-        httpOnly: false,
-        secure: appConfig.NODE_ENV !== 'development',
-        maxAge: SESSION_MAX_AGE,
-      })
-    }
+    // Silent cookie migration: rewrite every authenticated request to the
+    // domain-scoped cookie shape and delete the legacy host-only variant.
+    // Also covers the older localStorage → Bearer-header migration by
+    // stamping the cookie when the client only sent a Bearer token. Runs on
+    // the hot path so every active user is migrated on their very next
+    // authenticated call. Remove once the migration window has elapsed.
+    setSessionCookie(reply, sessionId)
 
     // Try to fetch an existing session from Redis
     const sess = await sessionService.get(sessionId)

--- a/apps/backend/src/plugins/session-auth.ts
+++ b/apps/backend/src/plugins/session-auth.ts
@@ -48,6 +48,13 @@ export default fp(async (fastify: FastifyInstance) => {
   // Auth hook reads JWT from Authorization header (if present) or __session
   // cookie. @fastify/jwt checks Bearer header first, then falls back to cookie.
   // Old clients still sending Authorization: Bearer get migrated to the cookie.
+  //
+  // TODO(2026-05-05): Retire the Bearer fallback together with
+  // `migrateLegacyToken()` in the frontend authStore. By that date every
+  // pre-cutover JWT has expired (cutover 2026-03-30, JWT TTL 30d) and the
+  // only clients that could benefit from Bearer auth are dead ones. Drop the
+  // `bearerToken` branch, simplify to `const sessionId = cookieToken!` after
+  // the missing-cookie guard.
   fastify.decorate('authenticate', async (req: FastifyRequest, reply: FastifyReply) => {
     const cookieToken = getSessionCookie(req)
     const bearerToken = req.headers.authorization?.startsWith('Bearer ')

--- a/apps/frontend/src/features/auth/stores/__tests__/authStore.spec.ts
+++ b/apps/frontend/src/features/auth/stores/__tests__/authStore.spec.ts
@@ -49,6 +49,7 @@ vi.mock('@/lib/bootstrap', () => ({
 vi.stubGlobal('__APP_CONFIG__', {
   API_BASE_URL: 'http://localhost:3000',
   NODE_ENV: 'production',
+  DOMAIN: 'example.org',
 })
 afterAll(() => vi.unstubAllGlobals())
 
@@ -333,5 +334,25 @@ describe('authStore localStorage auth flow', () => {
     expect(store.userId).toBeNull()
 
     bus.off('auth:logged-out', loggedOutSpy)
+  })
+
+  it('auth:logout clears both host-only and domain-scoped session cookie shapes', async () => {
+    const { bus } = await import('@/lib/bus')
+    const removeSpy = vi.spyOn(Cookies.prototype, 'remove')
+    const store = useAuthStore()
+    store.userId = 'u1'
+
+    bus.emit('auth:logout')
+
+    const sessionRemoves = removeSpy.mock.calls.filter(([name]) => name === SESSION_COOKIE)
+    // Phase 1 silent migration: delete both pre- and post-migration shapes
+    // because universal-cookie only wipes the slot whose attributes match.
+    expect(sessionRemoves).toContainEqual([SESSION_COOKIE, { path: '/' }])
+    expect(sessionRemoves).toContainEqual([
+      SESSION_COOKIE,
+      { path: '/', sameSite: 'lax', domain: '.example.org' },
+    ])
+
+    removeSpy.mockRestore()
   })
 })

--- a/apps/frontend/src/features/auth/stores/authStore.ts
+++ b/apps/frontend/src/features/auth/stores/authStore.ts
@@ -18,9 +18,23 @@ type AuthStoreResponse<T> =
   | SuccessResponse<T>
   | (ApiError & { code: AuthErrorCodes; restart: 'otp' | 'userid' })
 
-import { SESSION_COOKIE, SESSION_COOKIE_OPTS } from '@shared/session'
+import { SESSION_COOKIE, resolveSessionCookie } from '@shared/session'
+import { clearLegacyCookie } from '@/lib/session-legacy'
 
 const cookies = new Cookies()
+
+/**
+ * Remove the currently-active cookie shape (host-only in dev, domain-scoped
+ * in prod), then delegate the legacy host-only delete to `clearLegacyCookie`
+ * which no-ops when the active shape is already host-only.
+ */
+function removeSessionCookie() {
+  cookies.remove(
+    SESSION_COOKIE,
+    resolveSessionCookie(__APP_CONFIG__.NODE_ENV, __APP_CONFIG__.DOMAIN)
+  )
+  clearLegacyCookie(cookies, SESSION_COOKIE)
+}
 
 /**
  * One-time migration for users upgrading from the old frontend that stored
@@ -92,7 +106,7 @@ export const useAuthStore = defineStore('auth', {
           JSON.parse(atob(token.split('.')[1]!))
         } catch {
           // Malformed JWT — clear it
-          cookies.remove(SESSION_COOKIE, SESSION_COOKIE_OPTS)
+          removeSessionCookie()
           this.isInitialized = true
           return
         }
@@ -221,7 +235,7 @@ bus.on('auth:logout', () => {
   store.loginUser = null
   // Clear session cookie client-side so a failed server logout
   // doesn't leave the user appearing logged in on next page load.
-  cookies.remove(SESSION_COOKIE, SESSION_COOKIE_OPTS)
+  removeSessionCookie()
   localStorage.removeItem('authId')
   bus.emit('auth:logged-out')
 })

--- a/apps/frontend/src/features/auth/stores/authStore.ts
+++ b/apps/frontend/src/features/auth/stores/authStore.ts
@@ -42,7 +42,12 @@ function removeSessionCookie() {
  * the backend's authenticate hook picks it up and sets the __session cookie.
  * Cleans up localStorage after the first successful API response.
  *
- * TODO: Remove this function once all clients have migrated to cookie auth.
+ * TODO(2026-05-05): Retire together with the Bearer fallback in
+ * `apps/backend/src/plugins/session-auth.ts`. By that date every pre-cutover
+ * JWT (cutover: 2026-03-30, JWT TTL: 30d) has expired and this function can
+ * only return a dead token. Any remaining localStorage-only users get
+ * re-logged-in via magic link on next visit, which is what they'd have to
+ * do anyway.
  */
 function migrateLegacyToken(): string | null {
   const legacyToken = localStorage.getItem('token')

--- a/apps/frontend/src/lib/__tests__/api-refresh.spec.ts
+++ b/apps/frontend/src/lib/__tests__/api-refresh.spec.ts
@@ -18,6 +18,7 @@ vi.mock('@/router', () => ({
 vi.stubGlobal('__APP_CONFIG__', {
   API_BASE_URL: 'http://localhost:3000',
   NODE_ENV: 'production',
+  DOMAIN: 'example.org',
 })
 afterAll(() => vi.unstubAllGlobals())
 

--- a/apps/frontend/src/lib/api.ts
+++ b/apps/frontend/src/lib/api.ts
@@ -3,7 +3,8 @@ import Cookies from 'universal-cookie'
 import { bus } from './bus'
 import { VersionSchema, type VersionDTO } from '@zod/dto/version.dto'
 import type { VersionResponse } from '@zod/apiResponse.dto'
-import { SESSION_COOKIE, SESSION_COOKIE_OPTS } from '@shared/session'
+import { SESSION_COOKIE, resolveSessionCookie } from '@shared/session'
+import { clearLegacyCookie } from '@/lib/session-legacy'
 
 const baseURL = __APP_CONFIG__?.API_BASE_URL
 
@@ -251,8 +252,15 @@ api.interceptors.response.use(
         isRefreshing = false
         refreshSubscribers = []
 
-        // Clear session cookie so next page load doesn't re-enter the refresh loop
-        new Cookies().remove(SESSION_COOKIE, SESSION_COOKIE_OPTS)
+        // Clear session cookie so next page load doesn't re-enter the refresh
+        // loop. Remove the active shape; `clearLegacyCookie` additionally
+        // zaps the pre-migration host-only slot when it's a distinct slot.
+        const jar = new Cookies()
+        jar.remove(
+          SESSION_COOKIE,
+          resolveSessionCookie(__APP_CONFIG__.NODE_ENV, __APP_CONFIG__.DOMAIN)
+        )
+        clearLegacyCookie(jar, SESSION_COOKIE)
         // auth:logout handler in authStore clears state synchronously and then
         // emits auth:logged-out — the single place that drives navigation to Login.
         bus.emit('auth:logout')

--- a/apps/frontend/src/lib/session-legacy.ts
+++ b/apps/frontend/src/lib/session-legacy.ts
@@ -1,0 +1,29 @@
+/**
+ * Frontend adapter for the Phase 1 silent cookie migration (issue #1351).
+ *
+ * Closes over `__APP_CONFIG__` so logout / refresh-failure paths can zap the
+ * pre-migration host-only slot with a single call. Pairs with
+ * `apps/backend/src/lib/session-legacy.ts` — delete both files together once
+ * the migration window has elapsed; every import will fail loudly, pointing
+ * at call sites that still emit legacy behavior.
+ */
+import type Cookies from 'universal-cookie'
+import { canScopeToDomain } from '@shared/session'
+
+/**
+ * Options that identify the pre-migration host-only cookie slot. Browsers key
+ * cookies by (name, Domain, Path); matching Path is sufficient for deletion.
+ *
+ * Duplicated (verbatim) in the backend adapter rather than shared so that
+ * deleting this file removes every trace of the migration — no orphaned
+ * shared helper gets left behind by accident.
+ */
+const LEGACY_HOST_ONLY_COOKIE_OPTS = { path: '/' }
+
+export function clearLegacyCookie(cookies: Cookies, name: string): void {
+  // No-op when the active shape is itself host-only (dev / unusable DOMAIN)
+  // so the remove never targets the same slot as the just-removed active
+  // shape.
+  if (!canScopeToDomain(__APP_CONFIG__.NODE_ENV, __APP_CONFIG__.DOMAIN)) return
+  cookies.remove(name, LEGACY_HOST_ONLY_COOKIE_OPTS)
+}

--- a/apps/frontend/src/lib/session-legacy.ts
+++ b/apps/frontend/src/lib/session-legacy.ts
@@ -6,6 +6,12 @@
  * `apps/backend/src/lib/session-legacy.ts` — delete both files together once
  * the migration window has elapsed; every import will fail loudly, pointing
  * at call sites that still emit legacy behavior.
+ *
+ * TODO(2026-07-22): Retire this file + the backend sibling. The date is
+ * anchored to ~90 days after Phase 1 deploy (refresh-token TTL), by which
+ * point every active user is on the domain-scoped shape and any dormant
+ * host-only refresh token has expired. Bump this date forward if the PR
+ * #1353 merge slips materially past 2026-04-22.
  */
 import type Cookies from 'universal-cookie'
 import { canScopeToDomain } from '@shared/session'

--- a/packages/shared/session.ts
+++ b/packages/shared/session.ts
@@ -14,5 +14,50 @@ export const REFRESH_MAX_AGE = 60 * 60 * 24 * 90 // 90 days
 export const ORIGIN_COOKIE = '__o'
 export const ORIGIN_MAX_AGE = 60 * 60 * 24 * 365 * 10 // 10 years
 
-/** Base cookie options reused by frontend (universal-cookie) and backend (fastify). */
-export const SESSION_COOKIE_OPTS = { path: '/', sameSite: 'strict' as const }
+/**
+ * Base cookie options for the session cookie. `sameSite: 'lax'` lets magic
+ * links opened from email clients still carry the cookie on the top-level
+ * navigation; `strict` would block them.
+ */
+export const SESSION_COOKIE_OPTS = { path: '/', sameSite: 'lax' as const }
+
+const LOCAL_HOSTS = new Set(['localhost', '127.0.0.1', '::1'])
+
+function normalizeDomain(domain: string): string {
+  return domain.trim().replace(/^\.+/, '')
+}
+
+/**
+ * Decide whether the session cookie should carry a `Domain` attribute. Each
+ * branch documents a separate reason we would refuse to domain-scope the
+ * cookie. Self-normalizes the input so callers can pass either `example.org`
+ * or `.example.org` interchangeably.
+ *
+ * `nodeEnv` / `domain` are passed in so this module stays free of runtime
+ * config imports — packages/shared must not depend on apps/*.
+ */
+export function canScopeToDomain(nodeEnv: string, domain: string): boolean {
+  // Vite dev server serves from `localhost` regardless of the DOMAIN env
+  // value, so dev must stay host-only.
+  if (nodeEnv === 'development') return false
+  const normalized = normalizeDomain(domain)
+  // Empty after normalization — nothing to attach.
+  if (normalized.length === 0) return false
+  // Loopback literals — browsers silently drop `Domain=.localhost` etc.
+  if (LOCAL_HOSTS.has(normalized)) return false
+  // Single-label hosts — browsers silently drop `Domain=.example`.
+  if (!normalized.includes('.')) return false
+  return true
+}
+
+/**
+ * Compose the session cookie's options for the caller's environment. Attaches
+ * `Domain=.<apex>` when `canScopeToDomain` approves, otherwise returns host-
+ * only options. Callers that also need to gate on the same decision (e.g. a
+ * legacy-host-only clearCookie during the migration) call `canScopeToDomain`
+ * directly with the same inputs.
+ */
+export function resolveSessionCookie(nodeEnv: string, domain: string) {
+  if (!canScopeToDomain(nodeEnv, domain)) return { ...SESSION_COOKIE_OPTS }
+  return { ...SESSION_COOKIE_OPTS, domain: `.${normalizeDomain(domain)}` }
+}


### PR DESCRIPTION
## Summary
Implements a silent migration from host-only to domain-scoped session and refresh cookies, enabling cookies to be shared across subdomains (e.g., `api.example.org` and `app.example.org`). Active users are migrated automatically on their next authenticated request without being logged out.

## Key Changes

- **Cookie shape migration**: Updated `SESSION_COOKIE_OPTS` from `sameSite: 'strict'` to `sameSite: 'lax'` and added `sessionCookieOpts()` function to conditionally attach a `Domain` attribute (`.example.org`) in production while keeping host-only cookies in development
- **Dual-shape deletion strategy**: Every authenticated response now sets the new domain-scoped cookie and immediately clears the legacy host-only variant in the same response, ensuring browsers drop the old cookie on the next request
- **Backend auth routes**: Modified `setSessionCookie()`, `setRefreshCookie()`, `clearSessionCookie()`, and `clearRefreshCookie()` helpers to manage both cookie shapes during the migration window
- **Session auth middleware**: Updated to always set the new domain-scoped cookie shape on authenticated requests (hot path), automatically migrating even clients using Bearer tokens
- **Frontend cleanup**: Updated `authStore.ts` and `api.ts` to remove both cookie shapes on logout and token refresh failure, preventing stale variants from persisting
- **Test coverage**: Added comprehensive tests validating domain-scoped cookies in production, host-only cookies in development, and proper cleanup of both shapes during logout

## Implementation Details

- The migration leverages the fact that browsers key cookies by `(name, Domain, Path)`, so the legacy host-only and new domain-scoped variants occupy separate slots and can coexist briefly
- `sameSite: 'lax'` allows top-level navigations (e.g., magic links from email) to carry the cookie, whereas `strict` would block them
- Development environments skip the `Domain` attribute since browsers reject `.localhost` domains
- The migration runs on the hot path (every authenticated request), ensuring rapid adoption without requiring explicit user action

https://claude.ai/code/session_0196HFgp6gy94CaiGqjpVSUS