### PR TITLE
fix(terraform): trimspace ssh public_key to match Hetzner normalization

### DIFF
--- a/deployment/terraform/main.tf
+++ b/deployment/terraform/main.tf
@@ -62,7 +62,7 @@ resource "local_file" "ssh_public_key" {
 
 resource "hcloud_ssh_key" "this" {
   name       = "opencupid-staging"
-  public_key = tls_private_key.staging.public_key_openssh
+  public_key = trimspace(tls_private_key.staging.public_key_openssh)
 }
 
 


### PR DESCRIPTION
## Summary

- Wrap `tls_private_key.staging.public_key_openssh` in `trimspace()` when passing it to `hcloud_ssh_key.this` so the planned value matches what the Hetzner API stores (it strips the trailing `\n`).
- Fixes `Error: Provider produced inconsistent result after apply` on fresh-create of the staging SSH key under Terraform 1.14+'s stricter producer-consistency check.
- No changes to `local_file.ssh_public_key` or the cloud-init `authorized_keys` template — those intentionally keep the trailing newline (POSIX text-file + `authorized_keys` convention).

## Root cause

`tls_private_key.public_key_openssh` emits keys with a trailing `\n` (matches `ssh-keygen` output). The hcloud API normalizes this away on store. Terraform 1.14's consistency checker then sees planned ≠ applied and fails. Combination was latently broken since staging bootstrap (March) but only surfaces now because the resource went `(tainted)`, triggering the fresh-create path under a newer Terraform core.

## Test plan

- [ ] `terraform validate` passes
- [ ] `terraform plan` shows only the tainted `hcloud_ssh_key.this` being recreated (plus the server update referencing the new key ID)
- [ ] `terraform apply` completes without the "inconsistent result" error
- [ ] SSH into the recreated staging server using the regenerated key works

🤖 Generated with [Claude Code](https://claude.com/claude-code)