### PR TITLE
feat(admin): Daily Active chart + bar charts for interactions/matches/messages

### DIFF
--- a/.changeset/angry-lizards-bathe.md
+++ b/.changeset/angry-lizards-bathe.md
@@ -1,0 +1,6 @@
+---
+"@opencupid/admin": patch
+"@opencupid/backend": patch
+---
+
+feat(admin): Daily Active chart + bar charts for interactions/matches/messages

--- a/.changeset/ready-symbols-type.md
+++ b/.changeset/ready-symbols-type.md
@@ -1,2 +1,6 @@
 ---
+'@opencupid/admin': patch
+'@opencupid/backend': patch
 ---
+
+Admin dashboard: replace Daily Logins chart with Daily Active (from `lastSeenAt`); switch Interactions/Matches/Messages to bar charts.

--- a/apps/admin/src/pages/DashboardPage.vue
+++ b/apps/admin/src/pages/DashboardPage.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { ref, onMounted } from 'vue'
 import { useApi } from '../composables/useApi'
-import { Bar, Pie, Line } from 'vue-chartjs'
+import { Bar, Pie } from 'vue-chartjs'
 import {
   Chart as ChartJS,
   BarElement,
@@ -10,22 +10,9 @@ import {
   Tooltip,
   Legend,
   ArcElement,
-  LineElement,
-  PointElement,
-  Filler,
 } from 'chart.js'
 
-ChartJS.register(
-  BarElement,
-  CategoryScale,
-  LinearScale,
-  Tooltip,
-  Legend,
-  ArcElement,
-  LineElement,
-  PointElement,
-  Filler
-)
+ChartJS.register(BarElement, CategoryScale, LinearScale, Tooltip, Legend, ArcElement)
 
 interface SegmentCount {
   segment: string
@@ -50,7 +37,7 @@ interface DailyEntry {
 interface DailyStats {
   success: boolean
   dailySignups: DailyEntry[]
-  dailyLogins: DailyEntry[]
+  dailyLastSeen: DailyEntry[]
   dailyInteractions: DailyEntry[]
   dailyMatches: DailyEntry[]
   dailyMessages: DailyEntry[]
@@ -102,22 +89,6 @@ function buildSegmentPieData(counts: SegmentCount[]) {
       {
         data: counts.map((c) => c.count),
         backgroundColor: counts.map((c) => segmentColorMap[c.segment] ?? '#adb5bd'),
-      },
-    ],
-  }
-}
-
-function buildLineChartData(entries: DailyEntry[], color: string) {
-  return {
-    labels: entries.map((e) => e.date.slice(5)),
-    datasets: [
-      {
-        data: entries.map((e) => e.count),
-        borderColor: color,
-        backgroundColor: color + '33',
-        fill: true,
-        tension: 0.3,
-        pointRadius: 4,
       },
     ],
   }
@@ -225,10 +196,10 @@ onMounted(async () => {
       >
         <div class="card h-100">
           <div class="card-body">
-            <h6 class="card-title mb-3">Daily Logins (Last 7 Days)</h6>
+            <h6 class="card-title mb-3">Daily Active (Last 7 Days)</h6>
             <div style="height: 250px">
               <Bar
-                :data="buildChartData(dailyStats.dailyLogins, '#198754')"
+                :data="buildChartData(dailyStats.dailyLastSeen, '#198754')"
                 :options="chartOptions"
               />
             </div>
@@ -262,8 +233,8 @@ onMounted(async () => {
           <div class="card-body">
             <h6 class="card-title mb-3">Interactions (Last 7 Days)</h6>
             <div style="height: 250px">
-              <Line
-                :data="buildLineChartData(dailyStats.dailyInteractions, '#6f42c1')"
+              <Bar
+                :data="buildChartData(dailyStats.dailyInteractions, '#6f42c1')"
                 :options="chartOptions"
               />
             </div>
@@ -275,8 +246,8 @@ onMounted(async () => {
           <div class="card-body">
             <h6 class="card-title mb-3">Matches (Last 7 Days)</h6>
             <div style="height: 250px">
-              <Line
-                :data="buildLineChartData(dailyStats.dailyMatches, '#d63384')"
+              <Bar
+                :data="buildChartData(dailyStats.dailyMatches, '#d63384')"
                 :options="chartOptions"
               />
             </div>
@@ -288,8 +259,8 @@ onMounted(async () => {
           <div class="card-body">
             <h6 class="card-title mb-3">Messages (Last 7 Days)</h6>
             <div style="height: 250px">
-              <Line
-                :data="buildLineChartData(dailyStats.dailyMessages, '#fd7e14')"
+              <Bar
+                :data="buildChartData(dailyStats.dailyMessages, '#fd7e14')"
                 :options="chartOptions"
               />
             </div>

--- a/apps/backend/src/__tests__/routes/admin.route.spec.ts
+++ b/apps/backend/src/__tests__/routes/admin.route.spec.ts
@@ -148,13 +148,13 @@ describe('GET /stats', () => {
 })
 
 describe('GET /stats/daily', () => {
-  it('returns daily signups and logins with zero-filled days', async () => {
+  it('returns daily signups and last-seen counts with zero-filled days', async () => {
     mockPrisma.$queryRaw
       .mockResolvedValueOnce([{ date: '2026-02-20', count: BigInt(3) }]) // signups
       .mockResolvedValueOnce([
         { date: '2026-02-19', count: BigInt(7) },
         { date: '2026-02-21', count: BigInt(2) },
-      ]) // logins
+      ]) // last seen
       .mockResolvedValueOnce([{ date: '2026-03-29', count: BigInt(5) }]) // interactions
       .mockResolvedValueOnce([{ date: '2026-03-30', count: BigInt(2) }]) // matches
       .mockResolvedValueOnce([{ date: '2026-03-28', count: BigInt(10) }]) // messages
@@ -165,7 +165,7 @@ describe('GET /stats/daily', () => {
     expect(reply.statusCode).toBe(200)
     expect(reply.payload.success).toBe(true)
     expect(reply.payload.dailySignups).toHaveLength(7)
-    expect(reply.payload.dailyLogins).toHaveLength(7)
+    expect(reply.payload.dailyLastSeen).toHaveLength(7)
     expect(reply.payload.dailyInteractions).toHaveLength(7)
     expect(reply.payload.dailyMatches).toHaveLength(7)
     expect(reply.payload.dailyMessages).toHaveLength(7)
@@ -186,7 +186,7 @@ describe('GET /stats/daily', () => {
   it('returns all zeros when no data exists', async () => {
     mockPrisma.$queryRaw
       .mockResolvedValueOnce([]) // signups
-      .mockResolvedValueOnce([]) // logins
+      .mockResolvedValueOnce([]) // last seen
       .mockResolvedValueOnce([]) // interactions
       .mockResolvedValueOnce([]) // matches
       .mockResolvedValueOnce([]) // messages
@@ -196,7 +196,7 @@ describe('GET /stats/daily', () => {
 
     expect(reply.statusCode).toBe(200)
     expect(reply.payload.dailySignups.every((d: any) => d.count === 0)).toBe(true)
-    expect(reply.payload.dailyLogins.every((d: any) => d.count === 0)).toBe(true)
+    expect(reply.payload.dailyLastSeen.every((d: any) => d.count === 0)).toBe(true)
     expect(reply.payload.dailyInteractions.every((d: any) => d.count === 0)).toBe(true)
     expect(reply.payload.dailyMatches.every((d: any) => d.count === 0)).toBe(true)
     expect(reply.payload.dailyMessages.every((d: any) => d.count === 0)).toBe(true)

--- a/apps/backend/src/api/routes/admin.route.ts
+++ b/apps/backend/src/api/routes/admin.route.ts
@@ -22,30 +22,31 @@ const adminRoutes: FastifyPluginAsync = async (fastify) => {
 
   /**
    * GET /stats/daily
-   * Returns daily signup and login counts for the last 7 days.
-   * @returns {{ success, dailySignups, dailyLogins }}
+   * Returns daily signup and last-seen counts for the last 7 days.
+   * @returns {{ success, dailySignups, dailyLastSeen }}
    */
   fastify.get('/stats/daily', async (_req, reply) => {
     try {
       const days = getLast7Days()
       const since = days[0]
 
-      const [signupRows, loginRows, interactionRows, matchRows, messageRows] = await Promise.all([
-        prisma.$queryRaw<{ date: string; count: bigint }[]>`
+      const [signupRows, lastSeenRows, interactionRows, matchRows, messageRows] = await Promise.all(
+        [
+          prisma.$queryRaw<{ date: string; count: bigint }[]>`
             SELECT DATE("createdAt")::text AS date, COUNT(*)::bigint AS count
             FROM "User"
             WHERE "createdAt" >= ${since}::date
             GROUP BY DATE("createdAt")
             ORDER BY date
           `,
-        prisma.$queryRaw<{ date: string; count: bigint }[]>`
-            SELECT DATE("lastLoginAt")::text AS date, COUNT(*)::bigint AS count
-            FROM "User"
-            WHERE "lastLoginAt" >= ${since}::date
-            GROUP BY DATE("lastLoginAt")
+          prisma.$queryRaw<{ date: string; count: bigint }[]>`
+            SELECT DATE("lastSeenAt")::text AS date, COUNT(*)::bigint AS count
+            FROM "ProfileActivitySummary"
+            WHERE "lastSeenAt" >= ${since}::date
+            GROUP BY DATE("lastSeenAt")
             ORDER BY date
           `,
-        prisma.$queryRaw<{ date: string; count: bigint }[]>`
+          prisma.$queryRaw<{ date: string; count: bigint }[]>`
             SELECT DATE(first_at)::text AS date, COUNT(*)::bigint AS count
             FROM (
               SELECT LEAST("fromId","toId") AS a, GREATEST("fromId","toId") AS b,
@@ -57,7 +58,7 @@ const adminRoutes: FastifyPluginAsync = async (fastify) => {
             GROUP BY DATE(first_at)
             ORDER BY date
           `,
-        prisma.$queryRaw<{ date: string; count: bigint }[]>`
+          prisma.$queryRaw<{ date: string; count: bigint }[]>`
             SELECT DATE(GREATEST(a."createdAt", b."createdAt"))::text AS date,
                    COUNT(*)::bigint AS count
             FROM "LikedProfile" a
@@ -67,19 +68,20 @@ const adminRoutes: FastifyPluginAsync = async (fastify) => {
             GROUP BY DATE(GREATEST(a."createdAt", b."createdAt"))
             ORDER BY date
           `,
-        prisma.$queryRaw<{ date: string; count: bigint }[]>`
+          prisma.$queryRaw<{ date: string; count: bigint }[]>`
             SELECT DATE("createdAt")::text AS date, COUNT(*)::bigint AS count
             FROM "Message"
             WHERE "createdAt" >= ${since}::date
             GROUP BY DATE("createdAt")
             ORDER BY date
           `,
-      ])
+        ]
+      )
 
       return reply.code(200).send({
         success: true,
         dailySignups: fillZeroDays(signupRows, days),
-        dailyLogins: fillZeroDays(loginRows, days),
+        dailyLastSeen: fillZeroDays(lastSeenRows, days),
         dailyInteractions: fillZeroDays(interactionRows, days),
         dailyMatches: fillZeroDays(matchRows, days),
         dailyMessages: fillZeroDays(messageRows, days),


### PR DESCRIPTION
## Summary
- Replace the admin dashboard's **Daily Logins** chart with **Daily Active**, sourced from `ProfileActivitySummary.lastSeenAt` (extends #1356's `loginAt → lastSeenAt` migration to the dashboard).
- Backend `/admin/stats/daily`: rename response field `dailyLogins` → `dailyLastSeen`; query now reads from `ProfileActivitySummary` instead of `User.lastLoginAt`.
- Convert **Interactions**, **Matches**, **Messages** charts from line to bar, reusing the existing `buildChartData` helper. Drop the now-dead `buildLineChartData` plus unused chart.js registrations (`LineElement`, `PointElement`, `Filler`).

## Test plan
- [x] `pnpm --filter backend exec vitest run src/__tests__/routes/admin.route.spec.ts` — 52/52 passing
- [x] `pnpm --filter @opencupid/admin type-check` — clean
- [x] `pnpm --filter @opencupid/backend type-check` — clean
- [ ] Load `/dashboard` in the admin app and verify the Daily Active chart renders with lastSeenAt data, and Interactions/Matches/Messages render as bars

🤖 Generated with [Claude Code](https://claude.com/claude-code)