### PR TITLE
fix(auth): stop issuing magic-link tokens for blocked users

### DIFF
--- a/.changeset/sturdy-gates-shut.md
+++ b/.changeset/sturdy-gates-shut.md
@@ -1,0 +1,5 @@
+---
+'@opencupid/backend': patch
+---
+
+Stop issuing magic-link login tokens for users with `User.isBlocked = true`. Previously `isBlocked` had no effect on the auth path — blocked users could still request and redeem login links.

--- a/apps/backend/src/__tests__/services/user.service.spec.ts
+++ b/apps/backend/src/__tests__/services/user.service.spec.ts
@@ -71,16 +71,29 @@ describe('UserService.validateLoginToken', () => {
 })
 
 describe('UserService.setLoginToken', () => {
-  it('updates existing user', async () => {
+  it('updates existing user and gates the update on isBlocked=false', async () => {
     const user = { id: 'u1', isRegistrationConfirmed: true }
     mockPrisma.user.findUnique.mockResolvedValue(user)
     const res = await service.setLoginToken({ email: 'a@a.com' }, '123', 'en', 'test.local')
     expect(res.user).toBe(user)
     expect(res.isNewUser).toBe(false)
-    expect(mockPrisma.user.update).toHaveBeenCalledWith({
-      where: { id: 'u1' },
+    expect(mockPrisma.user.updateMany).toHaveBeenCalledWith({
+      where: { id: 'u1', isBlocked: false },
       data: { loginToken: '123', loginTokenExp: expect.any(Date) },
     })
+  })
+
+  it('refuses to issue a login token to a blocked user', async () => {
+    // Contract: setLoginToken passes isBlocked=false in the updateMany filter so
+    // no new login token is persisted for a blocked user. This is the
+    // server-side gate preventing magic links from being sent to blocked
+    // accounts — see apps/backend/src/api/routes/auth.route.ts.
+    const blockedUser = { id: 'u-blocked', isRegistrationConfirmed: true, isBlocked: true }
+    mockPrisma.user.findUnique.mockResolvedValue(blockedUser)
+    await service.setLoginToken({ email: 'blocked@example.com' }, 'tok', 'en', 'test.local')
+    expect(mockPrisma.user.updateMany).toHaveBeenCalledTimes(1)
+    const call = mockPrisma.user.updateMany.mock.calls[0][0]
+    expect(call.where).toEqual({ id: 'u-blocked', isBlocked: false })
   })
 
   it('creates new user when missing', async () => {

--- a/apps/backend/src/services/user.service.ts
+++ b/apps/backend/src/services/user.service.ts
@@ -86,11 +86,13 @@ export class UserService {
     if (userExists) {
       // Check if registration completed already or we're dealing with a new user
       const isNewUser = userExists.isRegistrationConfirmed === false
-      await prisma.user.update({
-        where: { id: userExists.id },
+      // Skip issuing a new login token for blocked users. updateMany (vs update)
+      // treats a no-match filter as a no-op instead of throwing P2025.
+      await prisma.user.updateMany({
+        where: { id: userExists.id, isBlocked: false },
         data: {
-          loginToken: otp, // Clear the reset token
-          loginTokenExp: tokenExpiration, // Clear the expiration
+          loginToken: otp,
+          loginTokenExp: tokenExpiration,
         },
       })
       return { user: userExists, isNewUser }

--- a/apps/backend/src/test-utils/prisma.ts
+++ b/apps/backend/src/test-utils/prisma.ts
@@ -5,6 +5,7 @@ export function createMockPrisma() {
     user: {
       findUnique: vi.fn(),
       update: vi.fn(),
+      updateMany: vi.fn(),
       create: vi.fn(),
       count: vi.fn(),
     },


### PR DESCRIPTION
## Summary

- Narrow the `setLoginToken` update filter to `{ id, isBlocked: false }` so no new login token is persisted for blocked users.
- Before this fix, `User.isBlocked` had no effect on the auth path: admin UI could flip the flag but blocked users could still request AND redeem magic links.

## Scope (emergency hotfix)

This closes only the **issuance** side of the gap. Known follow-ups for a separate PR:

- [ ] `validateLoginToken` still has no `isBlocked` check — a blocked user with an outstanding token (issued before block, within 15-min TTL) can still redeem.
- [ ] Per-request middleware (`session-auth.ts`) never reads `User.isBlocked`, so existing active sessions survive a block. Admin block action should also bump `tokenVersion` and purge `session:*` keys in Redis.
- [ ] Frontend does not yet surface an `AUTH_BLOCKED` error code.
- [ ] Unit test for the blocked-user issuance path.

## Test plan

- [ ] Flip a test user to `isBlocked = true` in the dev DB.
- [ ] POST `/auth/send-magic-link` with that user's email.
- [ ] Verify in DB that `loginToken` / `loginTokenExp` on the user row are **not** updated (no new token written).
- [ ] Confirm a non-blocked user's login flow is unaffected end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)