### PR TITLE
Return ApiError-shaped body for rate limit responses

### DIFF
--- a/.changeset/rate-limit-apierror-shape.md
+++ b/.changeset/rate-limit-apierror-shape.md
@@ -1,0 +1,5 @@
+---
+'@opencupid/backend': patch
+---
+
+Return ApiError-shaped body for 429 rate-limit responses so frontend handlers that narrow on `success === false` recognize them correctly (#1362)

--- a/apps/backend/src/__tests__/plugins/rate-limiter.spec.ts
+++ b/apps/backend/src/__tests__/plugins/rate-limiter.spec.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import Fastify, { type FastifyInstance } from 'fastify'
+import rateLimiterPlugin from '../../plugins/rate-limiter'
+import { rateLimitConfig } from '../../api/helpers'
+
+let fastify: FastifyInstance
+
+beforeEach(async () => {
+  fastify = Fastify()
+  await fastify.register(rateLimiterPlugin)
+  fastify.get('/ping', { config: rateLimitConfig(fastify, '1 minute', 1) }, async () => ({
+    ok: true,
+  }))
+  fastify.get('/boom', async () => {
+    throw new Error('kaboom')
+  })
+  await fastify.ready()
+})
+
+afterEach(async () => {
+  await fastify.close()
+})
+
+describe('rate-limiter plugin', () => {
+  it('returns an ApiError-shaped body with HTTP 429 when the limit is exceeded', async () => {
+    const first = await fastify.inject({ method: 'GET', url: '/ping' })
+    expect(first.statusCode).toBe(200)
+
+    const second = await fastify.inject({ method: 'GET', url: '/ping' })
+    expect(second.statusCode).toBe(429)
+
+    const body = second.json()
+    expect(body).toEqual({
+      success: false,
+      message: 'Rate limit exceeded.',
+    })
+    expect(body).not.toHaveProperty('statusCode')
+    expect(body).not.toHaveProperty('error')
+  })
+
+  it('delegates non-rate-limit errors to the default Fastify error handler', async () => {
+    const res = await fastify.inject({ method: 'GET', url: '/boom' })
+    expect(res.statusCode).toBe(500)
+    expect(res.json()).toMatchObject({
+      statusCode: 500,
+      error: 'Internal Server Error',
+      message: 'kaboom',
+    })
+  })
+})

--- a/apps/backend/src/plugins/rate-limiter.ts
+++ b/apps/backend/src/plugins/rate-limiter.ts
@@ -1,18 +1,31 @@
 import fp from 'fastify-plugin'
 import ratelimit from '@fastify/rate-limit'
 
-export default fp(async fastify => {
+class RateLimitError extends Error {
+  statusCode: number
+  constructor(statusCode: number, message = 'Rate limit exceeded.') {
+    super(message)
+    this.name = 'RateLimitError'
+    this.statusCode = statusCode
+  }
+}
+
+export default fp(async (fastify) => {
   await fastify.register(ratelimit, {
     global: false,
-    keyGenerator: req => {
+    keyGenerator: (req) => {
       return req.user?.userId || req.ip // fallback to IP if unauthenticated
     },
-    errorResponseBuilder: (req, context) => {
-      return {
-        statusCode: 429,
-        error: 'Too Many Requests',
-        message: `Rate limit exceeded.`,
-      }
-    },
+    errorResponseBuilder: (_req, context) => new RateLimitError(context.statusCode),
+  })
+
+  fastify.setErrorHandler((err, _req, reply) => {
+    if (err instanceof RateLimitError) {
+      return reply.code(err.statusCode).send({
+        success: false,
+        message: err.message,
+      })
+    }
+    reply.send(err)
   })
 })


### PR DESCRIPTION
## Summary
Updated the rate-limiter plugin to return responses in the ApiError format (with `success` and `message` fields) for 429 rate-limit errors, ensuring frontend error handlers that narrow on `success === false` can properly recognize and handle rate-limit responses.

## Changes
- **Created `RateLimitError` class**: A custom error class that extends `Error` and includes a `statusCode` property to distinguish rate-limit errors from other errors
- **Updated error response builder**: Changed from returning a plain object to throwing a `RateLimitError` instance
- **Added custom error handler**: Implemented a Fastify error handler that:
  - Catches `RateLimitError` instances and returns an ApiError-shaped response with `success: false` and `message` fields
  - Delegates all other errors to Fastify's default error handler
- **Added comprehensive tests**: Created test suite verifying:
  - Rate-limit responses return HTTP 429 with proper ApiError shape (no `statusCode` or `error` fields in the response body)
  - Non-rate-limit errors are handled by the default Fastify error handler

## Implementation Details
The solution uses a custom error class to mark rate-limit errors distinctly, allowing the error handler to differentiate them from other server errors and apply the appropriate response format. This maintains backward compatibility for other error types while standardizing rate-limit responses to match the frontend's ApiError expectations.

https://claude.ai/code/session_01A9mRpDCxDM7fxTNJqvnYjL