### PR TITLE
fix(frontend): show the matched profile, not the initiator, after like-back

### DIFF
--- a/.changeset/violet-clouds-match.md
+++ b/.changeset/violet-clouds-match.md
@@ -1,0 +1,5 @@
+---
+'@opencupid/frontend': patch
+---
+
+Fix initiator's own profile appearing in their own match list after a like-back, and stale "received like" entry lingering after the like becomes mutual.

--- a/apps/frontend/src/features/interaction/stores/__tests__/useInteractionStore.spec.ts
+++ b/apps/frontend/src/features/interaction/stores/__tests__/useInteractionStore.spec.ts
@@ -1,0 +1,146 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createPinia, setActivePinia } from 'pinia'
+import type {
+  InteractionEdge,
+  InteractionEdgePair,
+  ReceivedLike,
+} from '@zod/interaction/interaction.dto'
+import type { ProfileSummary } from '@zod/profile/profile.dto'
+
+const mockApi = vi.hoisted(() => ({
+  get: vi.fn(),
+  post: vi.fn(),
+  patch: vi.fn(),
+  delete: vi.fn(),
+}))
+
+const mockBus = vi.hoisted(() => ({
+  on: vi.fn(),
+  off: vi.fn(),
+  emit: vi.fn(),
+}))
+
+vi.mock('@/lib/api', () => ({
+  api: mockApi,
+  safeApiCall: async <T>(fn: () => Promise<T>) => fn(),
+}))
+
+vi.mock('@/lib/bus', () => ({
+  bus: mockBus,
+}))
+
+import { useInteractionStore } from '../useInteractionStore'
+
+const SELF_ID = 'self-profile-id'
+const OTHER_ID = 'other-profile-id'
+
+function profile(id: string, publicName: string): ProfileSummary {
+  return {
+    id,
+    publicName,
+    profileImages: [],
+    location: { country: '' },
+  }
+}
+
+function edge(p: ProfileSummary, isMatch: boolean): InteractionEdge {
+  return {
+    profile: p,
+    isMatch,
+    isNew: true,
+    isAnonymous: false,
+    createdAt: '2026-01-01T00:00:00.000Z',
+  }
+}
+
+function pair(isMatch: boolean): InteractionEdgePair {
+  return {
+    isMatch,
+    from: edge(profile(SELF_ID, 'Me'), isMatch),
+    to: edge(profile(OTHER_ID, 'Other'), isMatch),
+  }
+}
+
+beforeEach(() => {
+  setActivePinia(createPinia())
+  mockApi.post.mockReset()
+})
+
+describe('useInteractionStore.sendLike', () => {
+  it('on a non-match, pushes the TARGET into sent (not the initiator)', async () => {
+    mockApi.post.mockResolvedValueOnce({ data: { success: true, pair: pair(false) } })
+    const store = useInteractionStore()
+
+    const res = await store.sendLike(OTHER_ID, false)
+
+    expect(res.success).toBe(true)
+    expect(store.sent).toHaveLength(1)
+    expect(store.sent[0]?.profile.id).toBe(OTHER_ID)
+    expect(store.matches).toHaveLength(0)
+  })
+
+  it('on a match, pushes the TARGET into matches (not the initiator)', async () => {
+    mockApi.post.mockResolvedValueOnce({ data: { success: true, pair: pair(true) } })
+    const store = useInteractionStore()
+
+    const res = await store.sendLike(OTHER_ID, false)
+
+    expect(res.success).toBe(true)
+    expect(store.matches).toHaveLength(1)
+    expect(store.matches[0]?.profile.id).toBe(OTHER_ID)
+    expect(store.matches[0]?.isMatch).toBe(true)
+    expect(store.sent).toHaveLength(0)
+  })
+
+  it('on a match, increments newMatchesCount for the initiator', async () => {
+    mockApi.post.mockResolvedValueOnce({ data: { success: true, pair: pair(true) } })
+    const store = useInteractionStore()
+    expect(store.newMatchesCount).toBe(0)
+
+    await store.sendLike(OTHER_ID, false)
+
+    expect(store.newMatchesCount).toBe(1)
+  })
+
+  it('on a match, removes the now-mutual entry from receivedLikes', async () => {
+    const stalePending: ReceivedLike = {
+      profile: profile(OTHER_ID, 'Other'),
+      isMatch: false,
+      isNew: true,
+      isAnonymous: false,
+      createdAt: '2026-01-01T00:00:00.000Z',
+    }
+    const unrelatedPending: ReceivedLike = {
+      profile: profile('someone-else', 'Stranger'),
+      isMatch: false,
+      isNew: true,
+      isAnonymous: false,
+      createdAt: '2026-01-01T00:00:00.000Z',
+    }
+    mockApi.post.mockResolvedValueOnce({ data: { success: true, pair: pair(true) } })
+    const store = useInteractionStore()
+    store.receivedLikes = [stalePending, unrelatedPending]
+
+    await store.sendLike(OTHER_ID, false)
+
+    expect(store.receivedLikes).toHaveLength(1)
+    expect(store.receivedLikes[0]?.profile?.id).toBe('someone-else')
+  })
+
+  it('on a non-match, leaves receivedLikes untouched', async () => {
+    const pending: ReceivedLike = {
+      profile: profile(OTHER_ID, 'Other'),
+      isMatch: false,
+      isNew: true,
+      isAnonymous: false,
+      createdAt: '2026-01-01T00:00:00.000Z',
+    }
+    mockApi.post.mockResolvedValueOnce({ data: { success: true, pair: pair(false) } })
+    const store = useInteractionStore()
+    store.receivedLikes = [pending]
+
+    await store.sendLike(OTHER_ID, false)
+
+    expect(store.receivedLikes).toHaveLength(1)
+  })
+})

--- a/apps/frontend/src/features/interaction/stores/useInteractionStore.ts
+++ b/apps/frontend/src/features/interaction/stores/useInteractionStore.ts
@@ -78,9 +78,11 @@ export const useInteractionStore = defineStore('interaction', {
         const pair = InteractionEdgePairSchema.parse(res.data.pair)
 
         if (pair.isMatch) {
-          this.matches.push(pair.from)
+          this.matches.push(pair.to)
+          this.receivedLikes = this.receivedLikes.filter((e) => e.profile?.id !== targetId)
+          this.newMatchesCount++
         } else {
-          this.sent.push(pair.from)
+          this.sent.push(pair.to)
         }
 
         return storeSuccess(pair)


### PR DESCRIPTION
## Summary
- After liking a profile back into a mutual match, `useInteractionStore.sendLike` was pushing `pair.from` (the initiator's own edge) into `matches`/`sent` instead of `pair.to` (the target's edge), so the user saw their own profile in their own "matches" / "you have likes" lists right after a like-back. Switched both branches to push `pair.to`.
- Compounded by `receivedLikes` not being cleaned up after the like-back closed a mutual loop — the now-mutual entry lingered in the "you have a new like" slot until the next forced refetch, which never came. Added a local filter that drops the matching `targetId` from `receivedLikes` on a successful match.
- Also incremented `newMatchesCount` on the initiator's side so they get the same "new match!" indicator that the recipient already gets via the WebSocket `new_match` handler — symmetric behavior on both sides of the same logical event.

## Why it slipped through
The shared `InteractionEdgePair` type names its sides `from`/`to` from the *like edge's* perspective (sender → recipient). From the initiator's UI, the *interesting other party* is `to`, but a natural reading of the field name suggests `from = "from my side"`. The store had no unit tests guarding this choice, so nothing caught it.

## Test plan
- [ ] `pnpm --filter frontend exec vitest run src/features/interaction` → 11/11 green (5 new spec cases for `sendLike` + 6 existing for `InteractionButtons`)
- [ ] `pnpm --filter frontend lint` clean
- [ ] Manual repro: clean DB, A likes B, B likes A back; B's UI no longer shows B in their own "matches" list, the previously-pending received like from A disappears, and the "new match" indicator appears for B.

🤖 Generated with [Claude Code](https://claude.com/claude-code)