### PR TITLE
Migrate Prisma config from package.json to prisma.config.ts

### DIFF
--- a/.changeset/bronze-prisma-config.md
+++ b/.changeset/bronze-prisma-config.md
@@ -1,0 +1,5 @@
+---
+'@opencupid/backend': patch
+---
+
+Migrate deprecated `package.json#prisma` block to `prisma.config.ts` ahead of Prisma 7.

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -31,9 +31,6 @@
     "test:i18n": "npx i18n-check --locales ../../packages/shared/i18n/ -s en --only missingKeys --exclude **/api/**",
     "test:coverage": "pnpm run test --coverage --coverage.reporter=text-summary"
   },
-  "prisma": {
-    "seed": "node prisma/seed/tags.js"
-  },
   "dependencies": {
     "@bull-board/api": "^6.20.6",
     "@bull-board/fastify": "^6.20.6",

--- a/apps/backend/prisma.config.ts
+++ b/apps/backend/prisma.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'prisma/config'
+
+export default defineConfig({
+  migrations: {
+    seed: 'node prisma/seed/tags.js',
+  },
+})


### PR DESCRIPTION
## Summary
Migrates the Prisma seed configuration from the deprecated `package.json#prisma` block to the new `prisma.config.ts` configuration file, preparing for Prisma 7 compatibility.

## Key Changes
- Created new `apps/backend/prisma.config.ts` with seed configuration using Prisma's `defineConfig` API
- Removed the `prisma` block from `apps/backend/package.json` that previously defined the seed script
- Added changeset entry documenting this migration as a patch version bump

## Implementation Details
The seed configuration (`node prisma/seed/tags.js`) is preserved and moved to the new config file format. This change aligns with Prisma's migration away from `package.json` configuration toward dedicated config files, ensuring forward compatibility with Prisma 7.

https://claude.ai/code/session_01QaDxuHqjpSL5RWBwtLWZ8J