### PR TITLE
Narrow messaging response shapes and profile references

### DIFF
--- a/.changeset/slim-messaging-response-shapes.md
+++ b/.changeset/slim-messaging-response-shapes.md
@@ -1,0 +1,12 @@
+---
+'@opencupid/backend': minor
+'@opencupid/frontend': minor
+---
+
+Narrow messaging response shapes and DTOs to what consumers actually render (#1369).
+
+- Introduce `MessagingProfileRef` (id + publicName + thumbnail) as the messaging-owned profile reference, replacing `ProfileSummary` inside `MessageDTO.sender` and `ConversationSummary.partnerProfile`.
+- Make `SendMessageResponse` a discriminated union on `outcome`: the dominant `reply` arm now ships a small `ConversationPatch` instead of a full `ConversationSummary`, eliminating a redundant post-write lookup.
+- `MarkConversationReadResponse` now returns only `{ conversationId, lastReadAt }`.
+- Make `MessageDTO.isMine` required and map WS broadcasts per-recipient (fixes `isMine: undefined` on incoming WS messages).
+- Shrink Prisma includes for `MessageWithSender` and conversation summaries to only the fields the mappers read.

--- a/.changeset/slim-messaging-response-shapes.md
+++ b/.changeset/slim-messaging-response-shapes.md
@@ -1,6 +1,7 @@
 ---
 '@opencupid/backend': minor
 '@opencupid/frontend': minor
+'@opencupid/shared': minor
 ---
 
 Narrow messaging response shapes and DTOs to what consumers actually render (#1369).

--- a/apps/backend/src/__tests__/api/messaging.mappers.spec.ts
+++ b/apps/backend/src/__tests__/api/messaging.mappers.spec.ts
@@ -3,6 +3,7 @@ import {
   mapMessageToDTO,
   mapConversationParticipantToSummary,
   mapAttachmentDTO,
+  mapMessagingProfileRef,
 } from '../../api/mappers/messaging.mappers'
 vi.mock('@prisma/client', () => ({ Prisma: {}, PrismaClient: class {} }))
 vi.mock('@/lib/appconfig', () => ({
@@ -51,21 +52,32 @@ const participant: any = {
 }
 
 describe('messaging mappers', () => {
-  describe('mapMessageToDTO', () => {
-    it('maps a message with sender to DTO', () => {
-      const dto = mapMessageToDTO(msg)
-      expect(dto.id).toBe('m1')
-      expect(dto.sender.publicName).toBe('Me')
-      expect(dto.attachment).toBeNull()
-      expect(dto.isMine).toBeUndefined()
+  describe('mapMessagingProfileRef', () => {
+    it('returns null thumbnail when the profile has no images', () => {
+      const ref = mapMessagingProfileRef({ id: 'p1', publicName: 'Me', profileImages: [] })
+      expect(ref).toEqual({ id: 'p1', publicName: 'Me', thumbnail: null })
     })
 
-    it('sets isMine true when senderId matches profileId', () => {
+    it('builds a thumb-variant URL from the first image', () => {
+      const ref = mapMessagingProfileRef({
+        id: 'p1',
+        publicName: 'Me',
+        profileImages: [{ storagePath: 'alice/abc' }],
+      })
+      expect(ref.thumbnail).toEqual({ url: '/user-content/images/alice/abc-thumb.webp' })
+    })
+  })
+
+  describe('mapMessageToDTO', () => {
+    it('sets isMine true when senderId matches currentProfileId', () => {
       const dto = mapMessageToDTO(msg, 'p1')
       expect(dto.isMine).toBe(true)
+      expect(dto.sender.publicName).toBe('Me')
+      expect(dto.sender.thumbnail).toBeNull()
+      expect(dto.attachment).toBeNull()
     })
 
-    it('sets isMine false when senderId does not match profileId', () => {
+    it('sets isMine false when senderId does not match currentProfileId', () => {
       const dto = mapMessageToDTO(msg, 'p2')
       expect(dto.isMine).toBe(false)
     })
@@ -82,7 +94,7 @@ describe('messaging mappers', () => {
           createdAt: new Date(),
         },
       }
-      const dto = mapMessageToDTO(msgWithAttachment)
+      const dto = mapMessageToDTO(msgWithAttachment, 'p1')
       expect(dto.attachment).not.toBeNull()
       expect(dto.attachment!.mimeType).toBe('audio/webm')
     })
@@ -91,6 +103,7 @@ describe('messaging mappers', () => {
   it('maps participant to conversation summary', () => {
     const summary = mapConversationParticipantToSummary(participant, 'p1')
     expect(summary.partnerProfile.publicName).toBe('Them')
+    expect(summary.partnerProfile.thumbnail).toBeNull()
     expect(summary.lastMessage?.isMine).toBe(true)
   })
 

--- a/apps/backend/src/__tests__/routes/messaging.route.spec.ts
+++ b/apps/backend/src/__tests__/routes/messaging.route.spec.ts
@@ -49,13 +49,13 @@ vi.mock('../../utils/wsUtils', () => ({
 }))
 
 vi.mock('../../api/mappers/messaging.mappers', () => ({
-  mapMessageToDTO: vi.fn((m: any, currentProfileId?: string) => ({
+  mapMessageToDTO: vi.fn((m: any, currentProfileId: string) => ({
     ...m,
     id: m?.id ?? 'dto',
-    sender: m?.sender ?? { publicName: 'TestSender' },
+    sender: m?.sender ?? { publicName: 'TestSender', thumbnail: null },
     content: m?.content ?? '',
     mapped: true,
-    ...(currentProfileId !== undefined && { isMine: m?.senderId === currentProfileId }),
+    isMine: m?.senderId === currentProfileId,
   })),
   mapConversationParticipantToSummary: vi.fn(() => ({ id: 'summary', partnerProfile: {} })),
 }))
@@ -176,9 +176,10 @@ describe('POST /conversations/:id/mark-read', () => {
     expect(reply.statusCode).toBe(401)
   })
 
-  it('returns 404 when conversation not found', async () => {
+  it('marks conversation read and returns a patch with conversationId + lastReadAt', async () => {
     const handler = fastify.routes['POST /conversations/:id/mark-read']
-    mockMessageService.getConversationSummary.mockResolvedValue(null)
+    const lastReadAt = new Date('2024-06-01T00:00:00Z')
+    mockMessageService.markConversationRead.mockResolvedValue({ lastReadAt })
     await handler(
       { session: { profileId: 'p1' }, params: { id: 'ck1234567890abcd12345678' } } as any,
       reply as any
@@ -187,23 +188,14 @@ describe('POST /conversations/:id/mark-read', () => {
       'ck1234567890abcd12345678',
       'p1'
     )
-    expect(reply.statusCode).toBe(404)
-  })
-
-  it('marks conversation read and returns summary', async () => {
-    const handler = fastify.routes['POST /conversations/:id/mark-read']
-    mockMessageService.getConversationSummary.mockResolvedValue({})
-    await handler(
-      { session: { profileId: 'p1' }, params: { id: 'ck1234567890abcd12345678' } } as any,
-      reply as any
-    )
-    expect(mockMessageService.markConversationRead).toHaveBeenCalledWith(
-      'ck1234567890abcd12345678',
-      'p1'
-    )
+    // The narrow response should NOT hit getConversationSummary.
+    expect(mockMessageService.getConversationSummary).not.toHaveBeenCalled()
     expect(reply.statusCode).toBe(200)
-    expect(reply.payload.success).toBe(true)
-    expect(reply.payload.conversation.id).toBe('summary')
+    expect(reply.payload).toEqual({
+      success: true,
+      conversationId: 'ck1234567890abcd12345678',
+      lastReadAt,
+    })
   })
 })
 
@@ -250,8 +242,9 @@ describe('POST /message', () => {
     expect(reply.payload.message).toMatch('Invalid parameters')
   })
 
-  it('sends message and returns conversation with messageDTO', async () => {
+  it('reply outcome returns a conversationPatch instead of the full summary', async () => {
     const handler = fastify.routes['POST /message']
+    const updatedAt = new Date('2024-06-02T12:00:00Z')
     mockMessageService.resolveConversation.mockResolvedValue({
       convo: {
         id: 'conv1',
@@ -265,17 +258,22 @@ describe('POST /message', () => {
     mockMessageService.sendMessage.mockResolvedValue({
       message: { id: 'm1', senderId: 'p1' },
       isDuplicate: false,
-    })
-    mockMessageService.getConversationSummary.mockResolvedValue({
-      conversation: { status: 'ACTIVE' },
+      conversationUpdatedAt: updatedAt,
     })
 
     await handler({ session: { profileId: 'p1' }, body: validBody } as any, reply as any)
 
     expect(reply.statusCode).toBe(200)
     expect(reply.payload.success).toBe(true)
+    expect(reply.payload.outcome).toBe('reply')
     expect(reply.payload.message).toHaveProperty('isMine', true)
-    expect(reply.payload.conversation.id).toBe('summary')
+    // The dominant 'reply' arm must NOT re-fetch the conversation summary.
+    expect(mockMessageService.getConversationSummary).not.toHaveBeenCalled()
+    expect(reply.payload.conversation).toBeUndefined()
+    expect(reply.payload.conversationPatch).toEqual({
+      conversationId: 'conv1',
+      updatedAt,
+    })
     expect(mockMessageService.resolveConversation).toHaveBeenCalledWith(
       fastify.prisma,
       'p1',
@@ -290,7 +288,6 @@ describe('POST /message', () => {
       undefined
     )
     expect(mockMessageService.acceptConversationOnReply).not.toHaveBeenCalled()
-    expect(reply.payload.outcome).toBe('reply')
   })
 
   it('broadcasts via WS and falls back to notification when offline', async () => {
@@ -311,17 +308,20 @@ describe('POST /message', () => {
     mockMessageService.sendMessage.mockResolvedValue({
       message: { id: 'm1', senderId: 'p1' },
       isDuplicate: false,
-    })
-    mockMessageService.getConversationSummary.mockResolvedValue({
-      conversation: { status: 'ACTIVE' },
+      conversationUpdatedAt: new Date(),
     })
 
     await handler({ session: { profileId: 'p1' }, body: validBody } as any, reply as any)
 
+    // WS payload is mapped per-recipient: the recipient must see isMine: false,
+    // not the sender-side isMine or undefined.
     expect(broadcastToProfile).toHaveBeenCalledWith(
       fastify,
       'ck1234567890abcd12345678',
-      expect.objectContaining({ type: 'ws:new_message' })
+      expect.objectContaining({
+        type: 'ws:new_message',
+        payload: expect.objectContaining({ isMine: false }),
+      })
     )
     expect(mockNotifierService.notifyProfile).toHaveBeenCalledWith(
       'ck1234567890abcd12345678',
@@ -348,6 +348,7 @@ describe('POST /message', () => {
     mockMessageService.sendMessage.mockResolvedValue({
       message: { id: 'm1', senderId: 'p1' },
       isDuplicate: true,
+      conversationUpdatedAt: new Date(),
     })
     mockMessageService.getConversationSummary.mockResolvedValue({
       conversation: { status: 'ACTIVE' },
@@ -372,21 +373,23 @@ describe('POST /message', () => {
     ).rejects.toThrow('db down')
   })
 
-  it('re-throws when conversation summary not found (invariant breach)', async () => {
+  it('re-throws when conversation summary not found on non-reply outcomes (invariant breach)', async () => {
     const handler = fastify.routes['POST /message']
+    // new_conversation path needs the summary → missing summary is an invariant breach.
     mockMessageService.resolveConversation.mockResolvedValue({
       convo: {
         id: 'conv1',
-        status: 'ACCEPTED',
-        initiatorProfileId: 'other',
+        status: 'INITIATED',
+        initiatorProfileId: 'p1',
         profileAId: 'p1',
         profileBId: 'ck1234567890abcd12345678',
       },
-      wasCreated: false,
+      wasCreated: true,
     })
     mockMessageService.sendMessage.mockResolvedValue({
       message: { id: 'm1', senderId: 'p1' },
       isDuplicate: false,
+      conversationUpdatedAt: new Date(),
     })
     mockMessageService.getConversationSummary.mockResolvedValue(null)
 
@@ -412,6 +415,7 @@ describe('POST /message — outcomes', () => {
     mockMessageService.sendMessage.mockResolvedValue({
       message: { id: 'm1', senderId: senderProfileId },
       isDuplicate: options.isDuplicate ?? false,
+      conversationUpdatedAt: new Date('2024-06-01T00:00:00Z'),
     })
     mockMessageService.getConversationSummary.mockResolvedValue({
       conversation: { status: 'ACTIVE' },
@@ -502,6 +506,7 @@ describe('POST /message — outcomes', () => {
     mockMessageService.sendMessage.mockResolvedValueOnce({
       message: { id: 'm1', senderId: 'p1' },
       isDuplicate: false,
+      conversationUpdatedAt: new Date(),
     })
     mockMessageService.getConversationSummary.mockResolvedValueOnce({
       conversation: { status: 'ACTIVE' },
@@ -524,6 +529,7 @@ describe('POST /message — outcomes', () => {
     mockMessageService.sendMessage.mockResolvedValueOnce({
       message: { id: 'm2', senderId: 'p1' },
       isDuplicate: false,
+      conversationUpdatedAt: new Date(),
     })
     mockMessageService.getConversationSummary.mockResolvedValueOnce({
       conversation: { status: 'ACTIVE' },
@@ -550,6 +556,7 @@ describe('POST /message — outcomes', () => {
     mockMessageService.sendMessage.mockResolvedValueOnce({
       message: { id: 'm3', senderId: 'p1' },
       isDuplicate: false,
+      conversationUpdatedAt: new Date(),
     })
     mockMessageService.getConversationSummary.mockResolvedValueOnce({
       conversation: { status: 'ACTIVE' },
@@ -572,6 +579,7 @@ describe('POST /message — outcomes', () => {
     mockMessageService.sendMessage.mockResolvedValueOnce({
       message: { id: 'm-dup', senderId: 'p1' },
       isDuplicate: true,
+      conversationUpdatedAt: new Date(),
     })
     mockMessageService.getConversationSummary.mockResolvedValueOnce({
       conversation: { status: 'ACTIVE' },
@@ -610,6 +618,7 @@ describe('POST /voice', () => {
     mockMessageService.sendMessage.mockResolvedValue({
       message: { id: 'm1', senderId: 'p1' },
       isDuplicate: false,
+      conversationUpdatedAt: new Date(),
     })
     mockMessageService.getConversationSummary.mockResolvedValue({
       conversation: { status: 'ACTIVE' },
@@ -788,6 +797,7 @@ describe('POST /voice', () => {
     mockMessageService.sendMessage.mockResolvedValue({
       message: { id: 'm1', senderId: 'p1' },
       isDuplicate: true,
+      conversationUpdatedAt: new Date(),
     })
     mockMessageService.getConversationSummary.mockResolvedValue({
       conversation: { status: 'ACTIVE' },
@@ -847,6 +857,7 @@ describe('POST /voice — outcomes', () => {
     mockMessageService.sendMessage.mockResolvedValue({
       message: { id: 'mv1', senderId: senderProfileId },
       isDuplicate: options.isDuplicate ?? false,
+      conversationUpdatedAt: new Date('2024-06-01T00:00:00Z'),
     })
     mockMessageService.getConversationSummary.mockResolvedValue({
       conversation: { status: 'ACTIVE' },
@@ -952,6 +963,7 @@ describe('POST /voice — outcomes', () => {
     mockMessageService.sendMessage.mockResolvedValueOnce({
       message: { id: 'mv1', senderId: senderProfileId },
       isDuplicate: false,
+      conversationUpdatedAt: new Date(),
     })
     mockMessageService.getConversationSummary.mockResolvedValueOnce({
       conversation: { status: 'ACTIVE' },
@@ -971,6 +983,7 @@ describe('POST /voice — outcomes', () => {
     mockMessageService.sendMessage.mockResolvedValueOnce({
       message: { id: 'mv2', senderId: senderProfileId },
       isDuplicate: false,
+      conversationUpdatedAt: new Date(),
     })
     mockMessageService.getConversationSummary.mockResolvedValueOnce({
       conversation: { status: 'ACTIVE' },
@@ -994,6 +1007,7 @@ describe('POST /voice — outcomes', () => {
     mockMessageService.sendMessage.mockResolvedValueOnce({
       message: { id: 'mv3', senderId: senderProfileId },
       isDuplicate: false,
+      conversationUpdatedAt: new Date(),
     })
     mockMessageService.getConversationSummary.mockResolvedValueOnce({
       conversation: { status: 'ACTIVE' },
@@ -1013,6 +1027,7 @@ describe('POST /voice — outcomes', () => {
     mockMessageService.sendMessage.mockResolvedValueOnce({
       message: { id: 'mv-dup', senderId: senderProfileId },
       isDuplicate: true,
+      conversationUpdatedAt: new Date(),
     })
     mockMessageService.getConversationSummary.mockResolvedValueOnce({
       conversation: { status: 'ACTIVE' },

--- a/apps/backend/src/__tests__/services/messaging.service.spec.ts
+++ b/apps/backend/src/__tests__/services/messaging.service.spec.ts
@@ -77,11 +77,11 @@ describe('MessageService.listMessagesForConversation', () => {
           select: {
             id: true,
             publicName: true,
-            country: true,
-            cityName: true,
-            lat: true,
-            lon: true,
-            profileImages: { orderBy: { position: 'asc' } },
+            profileImages: {
+              orderBy: { position: 'asc' },
+              take: 1,
+              select: { storagePath: true },
+            },
           },
         },
         attachment: true,
@@ -370,13 +370,15 @@ describe('MessageService.sendMessage (new primitive)', () => {
   }
 
   function txForSend(opts: { duplicate?: any; created?: any } = {}): any {
+    const updatedAt = new Date('2024-06-01T00:00:00Z')
     return {
       message: {
         findFirst: vi.fn().mockResolvedValue(opts.duplicate ?? null),
         create: vi.fn().mockResolvedValue(opts.created ?? builtMsg),
       },
       conversation: {
-        update: vi.fn().mockResolvedValue(undefined),
+        update: vi.fn().mockResolvedValue({ updatedAt }),
+        findUniqueOrThrow: vi.fn().mockResolvedValue({ updatedAt }),
       },
     }
   }

--- a/apps/backend/src/api/mappers/messaging.mappers.ts
+++ b/apps/backend/src/api/mappers/messaging.mappers.ts
@@ -1,15 +1,16 @@
 import type {
-  ConversationParticipantWithConversationSummary,
   ConversationSummary,
   MessageAttachmentDTO,
   MessageDTO,
+  MessagingProfileRef,
 } from '@zod/messaging/messaging.dto'
-import { mapProfileSummary } from './profile.mappers'
 import {
   canSendMessageInConversation,
+  type ConversationParticipantWithSummary,
   type MessageWithSender,
 } from '../../services/messaging.service'
 import { mediaUrl } from '../../lib/media'
+import { imageBasePath } from '../../lib/media'
 
 function mapConversationMeta(c: { id: string; updatedAt: Date; createdAt: Date }) {
   return {
@@ -19,8 +20,30 @@ function mapConversationMeta(c: { id: string; updatedAt: Date; createdAt: Date }
   }
 }
 
+// Build the thumb variant URL server-side from the first (position-0) image.
+// The `thumb` variant is the 128×128 WebP produced by ImageService.
+function buildThumbnail(
+  profileImages: { storagePath: string }[]
+): MessagingProfileRef['thumbnail'] {
+  const first = profileImages[0]
+  if (!first) return null
+  return { url: mediaUrl(`${imageBasePath(first.storagePath)}-thumb.webp`) }
+}
+
+export function mapMessagingProfileRef(profile: {
+  id: string
+  publicName: string
+  profileImages: { storagePath: string }[]
+}): MessagingProfileRef {
+  return {
+    id: profile.id,
+    publicName: profile.publicName,
+    thumbnail: buildThumbnail(profile.profileImages),
+  }
+}
+
 export function mapConversationParticipantToSummary(
-  p: ConversationParticipantWithConversationSummary,
+  p: ConversationParticipantWithSummary,
   currentProfileId: string
 ): ConversationSummary {
   const partner = p.conversation.participants.find((cp) => cp.profileId !== currentProfileId)
@@ -52,11 +75,11 @@ export function mapConversationParticipantToSummary(
         }
       : null,
     conversation: mapConversationMeta(p.conversation),
-    partnerProfile: mapProfileSummary(partner.profile),
+    partnerProfile: mapMessagingProfileRef(partner.profile),
   }
 }
 
-export function mapMessageToDTO(m: MessageWithSender, currentProfileId?: string): MessageDTO {
+export function mapMessageToDTO(m: MessageWithSender, currentProfileId: string): MessageDTO {
   return {
     id: m.id,
     conversationId: m.conversationId,
@@ -64,9 +87,9 @@ export function mapMessageToDTO(m: MessageWithSender, currentProfileId?: string)
     content: m.content,
     messageType: m.messageType,
     createdAt: m.createdAt,
-    sender: mapProfileSummary(m.sender),
+    sender: mapMessagingProfileRef(m.sender),
     attachment: m.attachment ? mapAttachmentDTO(m.attachment) : null,
-    ...(currentProfileId !== undefined && { isMine: m.senderId === currentProfileId }),
+    isMine: m.senderId === currentProfileId,
   }
 }
 

--- a/apps/backend/src/api/routes/call.route.ts
+++ b/apps/backend/src/api/routes/call.route.ts
@@ -165,12 +165,10 @@ const callRoutes: FastifyPluginAsync = async (fastify) => {
         )
 
         if (!isDuplicate) {
-          const messageDTO = mapMessageToDTO(missedMsg)
-
           for (const p of conversation.participants) {
             broadcastToProfile(fastify, p.profileId, {
               type: 'ws:new_message',
-              payload: messageDTO,
+              payload: mapMessageToDTO(missedMsg, p.profileId),
             })
           }
         }
@@ -227,12 +225,10 @@ const callRoutes: FastifyPluginAsync = async (fastify) => {
           })
 
         if (!cancelIsDuplicate) {
-          const messageDTO = mapMessageToDTO(cancelMissedMsg)
-
           for (const p of conversation.participants) {
             broadcastToProfile(fastify, p.profileId, {
               type: 'ws:new_message',
-              payload: messageDTO,
+              payload: mapMessageToDTO(cancelMissedMsg, p.profileId),
             })
           }
         }

--- a/apps/backend/src/api/routes/messaging.route.ts
+++ b/apps/backend/src/api/routes/messaging.route.ts
@@ -16,7 +16,7 @@ import { mapConversationParticipantToSummary, mapMessageToDTO } from '../mappers
 import type {
   MessagesResponse,
   ConversationsResponse,
-  ConversationResponse,
+  MarkConversationReadResponse,
   SendMessageResponse,
 } from '@zod/apiResponse.dto'
 import { broadcastToProfile } from '@/utils/wsUtils'
@@ -92,11 +92,15 @@ const messageRoutes: FastifyPluginAsync = async (fastify) => {
       fileSize?: number
       duration?: number
     }
-  }): Promise<{ response: SendMessageResponse; messageDTO: MessageDTO; isDuplicate: boolean }> {
+  }): Promise<{
+    response: SendMessageResponse
+    message: Parameters<typeof mapMessageToDTO>[0]
+    isDuplicate: boolean
+  }> {
     const { senderProfileId, recipientProfileId, content, messageType, attachment } = input
 
-    const { convoId, message, isDuplicate, outcome } = await fastify.prisma.$transaction(
-      async (tx) => {
+    const { convoId, convoUpdatedAt, message, isDuplicate, outcome } =
+      await fastify.prisma.$transaction(async (tx) => {
         const { convo, wasCreated } = await messageService.resolveConversation(
           tx,
           senderProfileId,
@@ -126,34 +130,42 @@ const messageRoutes: FastifyPluginAsync = async (fastify) => {
 
         return {
           convoId: convo.id,
+          convoUpdatedAt: sendResult.conversationUpdatedAt,
           message: sendResult.message,
           isDuplicate: sendResult.isDuplicate,
           outcome,
         }
-      }
-    )
-
-    const conversation = await messageService.getConversationSummary(convoId, senderProfileId)
+      })
 
     if (outcome === 'new_conversation') {
       await interactionService.markMatchAsSeen(senderProfileId, recipientProfileId)
     }
 
+    const messageWithMine = mapMessageToDTO(message, senderProfileId)
+
+    if (outcome === 'reply') {
+      const response: SendMessageResponse = {
+        success: true,
+        outcome,
+        message: messageWithMine,
+        conversationPatch: { conversationId: convoId, updatedAt: convoUpdatedAt },
+      }
+      return { response, message, isDuplicate }
+    }
+
+    const conversation = await messageService.getConversationSummary(convoId, senderProfileId)
     if (!conversation) {
       throw new Error('Conversation summary not found')
     }
 
-    const messageDTO = mapMessageToDTO(message)
-    const messageWithMine = mapMessageToDTO(message, senderProfileId)
-
     const response: SendMessageResponse = {
       success: true,
-      conversation: mapConversationParticipantToSummary(conversation, senderProfileId),
-      message: messageWithMine,
       outcome,
+      message: messageWithMine,
+      conversation: mapConversationParticipantToSummary(conversation, senderProfileId),
     }
 
-    return { response, messageDTO, isDuplicate }
+    return { response, message, isDuplicate }
   }
 
   /*
@@ -169,27 +181,32 @@ const messageRoutes: FastifyPluginAsync = async (fastify) => {
   async function fireNewMessageNotifications(args: {
     senderProfileId: string
     recipientProfileId: string
-    messageDTO: MessageDTO
+    message: Parameters<typeof mapMessageToDTO>[0]
     buildEmailBody: () => Promise<string>
   }): Promise<void> {
-    const { senderProfileId, recipientProfileId, messageDTO, buildEmailBody } = args
+    const { senderProfileId, recipientProfileId, message, buildEmailBody } = args
+
+    // MessageDTO is viewer-specific: mapping here (rather than at the caller)
+    // yields isMine: false for the recipient instead of the stale undefined
+    // the shared sender-mapped DTO used to produce.
+    const recipientMessageDTO: MessageDTO = mapMessageToDTO(message, recipientProfileId)
 
     const isWsBroadcasted = broadcastToProfile(fastify, recipientProfileId, {
       type: 'ws:new_message',
-      payload: messageDTO,
+      payload: recipientMessageDTO,
     })
 
     if (isWsBroadcasted) return
 
     if (WebPushService.isWebPushConfigured()) {
-      webPushService.send(messageDTO, recipientProfileId).catch((err) => {
+      webPushService.send(recipientMessageDTO, recipientProfileId).catch((err) => {
         fastify.log.error(err, 'Web push failed')
       })
     }
 
     await notifierService.notifyProfile(recipientProfileId, 'new_message', {
       senderId: senderProfileId,
-      sender: messageDTO.sender.publicName,
+      sender: recipientMessageDTO.sender.publicName,
       message: await buildEmailBody(),
       link: `${appConfig.FRONTEND_URL}/inbox`,
     })
@@ -257,7 +274,7 @@ const messageRoutes: FastifyPluginAsync = async (fastify) => {
    * POST /conversations/:id/mark-read
    * Marks all messages in a conversation as read for the current profile.
    * @param {string} id - Conversation ID (CUID)
-   * @returns {ConversationResponse} Updated conversation summary
+   * @returns {MarkConversationReadResponse} { conversationId, lastReadAt }
    */
   fastify.post(
     '/conversations/:id/mark-read',
@@ -271,13 +288,14 @@ const messageRoutes: FastifyPluginAsync = async (fastify) => {
       const conversationId = id.data.id
 
       try {
-        await messageService.markConversationRead(conversationId, profileId)
-        const updated = await messageService.getConversationSummary(conversationId, profileId)
-        if (!updated) return sendError(reply, 404, 'Conversation not found')
-
-        const response: ConversationResponse = {
+        const updated = await messageService.markConversationRead(conversationId, profileId)
+        if (!updated.lastReadAt) {
+          throw new Error('markConversationRead did not set lastReadAt')
+        }
+        const response: MarkConversationReadResponse = {
           success: true,
-          conversation: mapConversationParticipantToSummary(updated, profileId),
+          conversationId,
+          lastReadAt: updated.lastReadAt,
         }
         return reply.code(200).send(response)
       } catch (error) {
@@ -308,7 +326,7 @@ const messageRoutes: FastifyPluginAsync = async (fastify) => {
       const { profileId, content } = body.data
 
       try {
-        const { response, messageDTO, isDuplicate } = await sendAndBuildResponse({
+        const { response, message, isDuplicate } = await sendAndBuildResponse({
           senderProfileId,
           recipientProfileId: profileId,
           content,
@@ -321,8 +339,8 @@ const messageRoutes: FastifyPluginAsync = async (fastify) => {
           await fireNewMessageNotifications({
             senderProfileId,
             recipientProfileId: profileId,
-            messageDTO,
-            buildEmailBody: async () => cleanMessageForNotification(messageDTO.content, 100),
+            message,
+            buildEmailBody: async () => cleanMessageForNotification(message.content, 100),
           })
         }
       } catch (error) {
@@ -447,7 +465,7 @@ const messageRoutes: FastifyPluginAsync = async (fastify) => {
         }
 
         try {
-          const { response, messageDTO, isDuplicate } = await sendAndBuildResponse({
+          const { response, message, isDuplicate } = await sendAndBuildResponse({
             senderProfileId,
             recipientProfileId: payload.data.profileId,
             content: payload.data.content,
@@ -466,7 +484,7 @@ const messageRoutes: FastifyPluginAsync = async (fastify) => {
             await fireNewMessageNotifications({
               senderProfileId,
               recipientProfileId: payload.data.profileId,
-              messageDTO,
+              message,
               buildEmailBody: async () => {
                 const recipientProfile = await fastify.prisma.profile.findUnique({
                   where: { id: payload.data.profileId },

--- a/apps/backend/src/services/messaging.service.ts
+++ b/apps/backend/src/services/messaging.service.ts
@@ -1,6 +1,5 @@
 import { Prisma } from '@prisma/client'
 import { prisma } from '@/lib/prisma'
-import type { ConversationParticipantWithConversationSummary } from '@zod/messaging/messaging.dto'
 import { Conversation } from '@zod/generated'
 import { blocklistWhereClause } from '@/db/includes/blocklistWhereClause'
 import i18next from 'i18next'
@@ -26,14 +25,25 @@ export class MessagingError extends Error {
   }
 }
 
+// Narrow projection that carries only what the thumb-URL builder reads
+// (`imageBasePath(storagePath)`). Keeps both messaging includes minimal.
+const thumbImageSelect = {
+  orderBy: { position: 'asc' as const },
+  take: 1,
+  select: { storagePath: true },
+}
+
 const conversationSummaryInclude = {
   conversation: {
     include: {
       participants: {
         include: {
           profile: {
-            include: {
-              profileImages: true,
+            select: {
+              id: true,
+              publicName: true,
+              isCallable: true,
+              profileImages: thumbImageSelect,
             },
           },
         },
@@ -46,20 +56,18 @@ const conversationSummaryInclude = {
       },
     },
   },
-}
+} satisfies Prisma.ConversationParticipantInclude
+
+export type ConversationParticipantWithSummary = Prisma.ConversationParticipantGetPayload<{
+  include: typeof conversationSummaryInclude
+}>
 
 export const messageWithSenderInclude = {
   sender: {
     select: {
       id: true,
       publicName: true,
-      country: true,
-      cityName: true,
-      lat: true,
-      lon: true,
-      profileImages: {
-        orderBy: { position: 'asc' },
-      },
+      profileImages: thumbImageSelect,
     },
   },
   attachment: true,
@@ -90,7 +98,7 @@ export class MessageService {
   async getConversationSummary(
     conversationId: string,
     profileId: string
-  ): Promise<ConversationParticipantWithConversationSummary | null> {
+  ): Promise<ConversationParticipantWithSummary | null> {
     return await prisma.conversationParticipant.findFirst({
       where: {
         conversationId,
@@ -247,7 +255,7 @@ export class MessageService {
       fileSize?: number
       duration?: number
     }
-  ): Promise<{ message: MessageWithSender; isDuplicate: boolean }> {
+  ): Promise<{ message: MessageWithSender; isDuplicate: boolean; conversationUpdatedAt: Date }> {
     const cleanContent = messageType === 'text/plain' ? content.trim() : content
 
     if (messageType === 'text/plain' && !cleanContent) {
@@ -268,7 +276,13 @@ export class MessageService {
         },
         include: messageWithSenderInclude,
       })
-      if (duplicate) return { message: duplicate, isDuplicate: true }
+      if (duplicate) {
+        const convo = await tx.conversation.findUniqueOrThrow({
+          where: { id: convoId },
+          select: { updatedAt: true },
+        })
+        return { message: duplicate, isDuplicate: true, conversationUpdatedAt: convo.updatedAt }
+      }
     }
 
     const message = await tx.message.create({
@@ -285,12 +299,13 @@ export class MessageService {
     // Bump parent conversation so inbox ordering (listConversationsForProfile
     // orders by updatedAt DESC) reflects the new activity. Prisma @updatedAt
     // only fires on direct updates, so creating a Message row is not enough.
-    await tx.conversation.update({
+    const bumped = await tx.conversation.update({
       where: { id: convoId },
       data: { updatedAt: new Date() },
+      select: { updatedAt: true },
     })
 
-    return { message, isDuplicate: false }
+    return { message, isDuplicate: false, conversationUpdatedAt: bumped.updatedAt }
   }
 
   async sendWelcomeMessage(recipientProfileId: string, locale: string) {
@@ -396,11 +411,6 @@ export class MessageService {
   sortProfilePair(a: string, b: string): [string, string] {
     return a < b ? [a, b] : [b, a]
   }
-}
-
-export type SendMessageSuccessResponse = {
-  conversation: ConversationParticipantWithConversationSummary
-  message: MessageWithSender
 }
 
 export type SendMessageErrorResponse = {

--- a/apps/frontend/src/features/app/components/MessageReceivedToast.vue
+++ b/apps/frontend/src/features/app/components/MessageReceivedToast.vue
@@ -49,7 +49,7 @@ const cleanMessageContent = computed(() => {
         v-if="message.sender.thumbnail"
         :src="message.sender.thumbnail.url"
         :alt="message.sender.publicName"
-        class="rounded"
+        class="fitted-image rounded"
       />
     </div>
     <div class="flex-grow-1 overflow-hidden">
@@ -62,3 +62,13 @@ const cleanMessageContent = computed(() => {
     </div>
   </div>
 </template>
+
+<style scoped>
+.fitted-image {
+  width: 100%;
+  height: 100%;
+  display: block;
+  object-fit: cover;
+  object-position: center;
+}
+</style>

--- a/apps/frontend/src/features/app/components/MessageReceivedToast.vue
+++ b/apps/frontend/src/features/app/components/MessageReceivedToast.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import { type MessageDTO } from '@zod/messaging/messaging.dto'
-import ProfileImage from '@/features/images/components/ProfileImage.vue'
 import { computed } from 'vue'
 defineEmits<{
   (e: 'closeToast'): void
@@ -46,9 +45,11 @@ const cleanMessageContent = computed(() => {
 <template>
   <div class="d-flex align-items-start clickable">
     <div class="profile-thumbnail me-2 flex-shrink-0">
-      <ProfileImage
-        :profile="message.sender"
-        variant="thumb"
+      <img
+        v-if="message.sender.thumbnail"
+        :src="message.sender.thumbnail.url"
+        :alt="message.sender.publicName"
+        class="rounded"
       />
     </div>
     <div class="flex-grow-1 overflow-hidden">

--- a/apps/frontend/src/features/app/components/__tests__/MessageReceivedToast.spec.ts
+++ b/apps/frontend/src/features/app/components/__tests__/MessageReceivedToast.spec.ts
@@ -16,11 +16,12 @@ function makeMessage(overrides: Partial<MessageDTO> = {}): MessageDTO {
     senderId: 'p2',
     content: 'Hey there!',
     messageType: 'text/plain',
-    createdAt: new Date().toISOString(),
+    createdAt: new Date() as unknown as Date,
     sender: {
       id: 'p2',
       publicName: 'Alice',
-    } as MessageDTO['sender'],
+      thumbnail: null,
+    },
     isMine: false,
     attachment: null,
     ...overrides,
@@ -62,5 +63,38 @@ describe('MessageReceivedToast', () => {
     })
 
     expect(wrapper.text()).toContain('Alice')
+  })
+
+  it('renders no thumbnail img when sender.thumbnail is null', () => {
+    const wrapper = mount(MessageReceivedToast, {
+      props: {
+        message: makeMessage({
+          sender: { id: 'p2', publicName: 'Alice', thumbnail: null },
+        }),
+        toastId: 1,
+      },
+    })
+
+    expect(wrapper.find('.profile-thumbnail img').exists()).toBe(false)
+  })
+
+  it('renders the thumbnail img when sender.thumbnail is present', () => {
+    const wrapper = mount(MessageReceivedToast, {
+      props: {
+        message: makeMessage({
+          sender: {
+            id: 'p2',
+            publicName: 'Alice',
+            thumbnail: { url: '/user-content/images/alice/xyz-thumb.webp' },
+          },
+        }),
+        toastId: 1,
+      },
+    })
+
+    const img = wrapper.find('.profile-thumbnail img')
+    expect(img.exists()).toBe(true)
+    expect(img.attributes('src')).toBe('/user-content/images/alice/xyz-thumb.webp')
+    expect(img.attributes('alt')).toBe('Alice')
   })
 })

--- a/apps/frontend/src/features/app/components/__tests__/MessageReceivedToast.spec.ts
+++ b/apps/frontend/src/features/app/components/__tests__/MessageReceivedToast.spec.ts
@@ -16,7 +16,7 @@ function makeMessage(overrides: Partial<MessageDTO> = {}): MessageDTO {
     senderId: 'p2',
     content: 'Hey there!',
     messageType: 'text/plain',
-    createdAt: new Date() as unknown as Date,
+    createdAt: new Date(),
     sender: {
       id: 'p2',
       publicName: 'Alice',

--- a/apps/frontend/src/features/messaging/components/ConversationSummaries.vue
+++ b/apps/frontend/src/features/messaging/components/ConversationSummaries.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import { type ConversationSummary } from '@zod/messaging/messaging.dto'
-import ProfileThumbnail from '@/features/images/components/ProfileThumbnail.vue'
 import { stripForPreview } from '@/lib/renderMessage'
 import { computed } from 'vue'
 
@@ -30,7 +29,14 @@ const haveConversations = computed(() => props.conversations.length > 0)
         @click="$emit('convo:select', convo)"
       >
         <div class="thumbnail me-2 flex-shrink-0">
-          <ProfileThumbnail :profile="convo.partnerProfile" />
+          <span class="profile-thumbnail d-inline-flex">
+            <img
+              v-if="convo.partnerProfile.thumbnail"
+              :src="convo.partnerProfile.thumbnail.url"
+              :alt="convo.partnerProfile.publicName"
+              class="img-fluid rounded"
+            />
+          </span>
         </div>
         <!--  extract into slot   -->
         <div class="overflow-hidden flex-grow-1 user-select-none">

--- a/apps/frontend/src/features/messaging/components/ConversationSummaries.vue
+++ b/apps/frontend/src/features/messaging/components/ConversationSummaries.vue
@@ -34,7 +34,7 @@ const haveConversations = computed(() => props.conversations.length > 0)
               v-if="convo.partnerProfile.thumbnail"
               :src="convo.partnerProfile.thumbnail.url"
               :alt="convo.partnerProfile.publicName"
-              class="img-fluid rounded"
+              class="fitted-image rounded"
             />
           </span>
         </div>
@@ -77,5 +77,12 @@ const haveConversations = computed(() => props.conversations.length > 0)
 .disabled {
   opacity: 0.5;
   pointer-events: none;
+}
+.fitted-image {
+  width: 100%;
+  height: 100%;
+  display: block;
+  object-fit: cover;
+  object-position: center;
 }
 </style>

--- a/apps/frontend/src/features/messaging/components/__tests__/ConversationSummaries.spec.ts
+++ b/apps/frontend/src/features/messaging/components/__tests__/ConversationSummaries.spec.ts
@@ -17,6 +17,7 @@ function makeConvo(overrides: Partial<ConversationSummary> = {}): ConversationSu
     partnerProfile: {
       id: 'p2',
       publicName: 'Alice',
+      thumbnail: null,
     } as ConversationSummary['partnerProfile'],
     lastMessage: {
       content: 'Hello there',

--- a/apps/frontend/src/features/messaging/components/__tests__/MessageBubble.spec.ts
+++ b/apps/frontend/src/features/messaging/components/__tests__/MessageBubble.spec.ts
@@ -33,7 +33,7 @@ const baseMessage = {
   attachment: null,
   conversationId: 'c1',
   senderId: 'p1',
-  sender: { id: 'p1', publicName: 'Alice', profileImages: [], location: { country: 'HU' } },
+  sender: { id: 'p1', publicName: 'Alice', thumbnail: null },
 } as MessageDTO
 
 describe('MessageBubble', () => {

--- a/apps/frontend/src/features/messaging/stores/__tests__/messageStore.spec.ts
+++ b/apps/frontend/src/features/messaging/stores/__tests__/messageStore.spec.ts
@@ -1,6 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createPinia, setActivePinia } from 'pinia'
-import type { ConversationSummary, MessageDTO } from '@zod/messaging/messaging.dto'
+import type {
+  ConversationPatch,
+  ConversationSummary,
+  MessageDTO,
+} from '@zod/messaging/messaging.dto'
+import type { SendMessageResponse } from '@zod/apiResponse.dto'
 
 const mockApi = vi.hoisted(() => ({
   get: vi.fn(),
@@ -43,10 +48,24 @@ function makeConvo(conversationId: string, partnerName: string): ConversationSum
     partnerProfile: {
       id: `partner-${conversationId}`,
       publicName: partnerName,
-      profileImages: [],
-      location: { country: '' },
+      thumbnail: null,
     },
     lastMessage: null,
+  }
+}
+
+function makeMessage(overrides: Partial<MessageDTO> = {}): MessageDTO {
+  return {
+    id: 'msg-1',
+    conversationId: 'convo-1',
+    senderId: 'profile-1',
+    content: 'Hello',
+    messageType: 'text/plain',
+    createdAt: new Date('2024-01-02'),
+    isMine: true,
+    sender: { id: 'profile-1', publicName: 'Me', thumbnail: null },
+    attachment: null,
+    ...overrides,
   }
 }
 
@@ -62,26 +81,8 @@ describe('messageStore', () => {
 
       // Setup: conversation exists in store with canReply = false (initiated by current user)
       const existingConvo: ConversationSummary = {
-        id: 'participant-1',
-        profileId: 'profile-1',
-        conversationId: 'convo-1',
-        lastReadAt: new Date('2024-01-01'),
-        isMuted: false,
-        isArchived: false,
+        ...makeConvo('convo-1', 'Partner'),
         canReply: false, // User initiated, waiting for reply
-        isCallable: true,
-        myIsCallable: true,
-        conversation: {
-          id: 'convo-1',
-          updatedAt: new Date('2024-01-01'),
-          createdAt: new Date('2024-01-01'),
-        },
-        partnerProfile: {
-          id: 'partner-profile-1',
-          publicName: 'Partner',
-          profileImages: [],
-          location: { country: '' },
-        },
         lastMessage: {
           content: 'Initial message',
           messageType: 'text/html',
@@ -92,21 +93,14 @@ describe('messageStore', () => {
       store.conversations = [existingConvo]
 
       // Incoming message from partner
-      const incomingMessage: MessageDTO = {
+      const incomingMessage: MessageDTO = makeMessage({
         id: 'msg-2',
-        conversationId: 'convo-1',
         senderId: 'partner-profile-1',
         content: 'Reply from partner',
         messageType: 'text/html',
-        createdAt: new Date('2024-01-02'),
         isMine: false,
-        sender: {
-          id: 'partner-profile-1',
-          publicName: 'Partner',
-          profileImages: [],
-          location: { country: '' },
-        },
-      }
+        sender: { id: 'partner-profile-1', publicName: 'Partner', thumbnail: null },
+      })
 
       // Act: handle incoming message
       await store.handleIncomingMessage(incomingMessage)
@@ -121,70 +115,31 @@ describe('messageStore', () => {
       const store = useMessageStore()
 
       const convo1: ConversationSummary = {
-        id: 'participant-1',
-        profileId: 'profile-1',
-        conversationId: 'convo-1',
-        lastReadAt: new Date('2024-01-01'),
-        isMuted: false,
-        isArchived: false,
+        ...makeConvo('convo-1', 'Partner 1'),
         canReply: true,
-        isCallable: true,
-        myIsCallable: true,
-        conversation: {
-          id: 'convo-1',
-          updatedAt: new Date('2024-01-01'),
-          createdAt: new Date('2024-01-01'),
-        },
-        partnerProfile: {
-          id: 'partner-1',
-          publicName: 'Partner 1',
-          profileImages: [],
-          location: { country: '' },
-        },
-        lastMessage: null,
       }
-
       const convo2: ConversationSummary = {
-        id: 'participant-2',
-        profileId: 'profile-1',
-        conversationId: 'convo-2',
-        lastReadAt: new Date('2024-01-02'),
-        isMuted: false,
-        isArchived: false,
+        ...makeConvo('convo-2', 'Partner 2'),
         canReply: true,
-        isCallable: true,
-        myIsCallable: true,
         conversation: {
           id: 'convo-2',
           updatedAt: new Date('2024-01-02'),
           createdAt: new Date('2024-01-02'),
         },
-        partnerProfile: {
-          id: 'partner-2',
-          publicName: 'Partner 2',
-          profileImages: [],
-          location: { country: '' },
-        },
-        lastMessage: null,
+        lastReadAt: new Date('2024-01-02'),
       }
 
       store.conversations = [convo1, convo2]
 
-      const incomingMessage: MessageDTO = {
-        id: 'msg-1',
+      const incomingMessage: MessageDTO = makeMessage({
         conversationId: 'convo-2',
         senderId: 'partner-2',
         content: 'New message',
         messageType: 'text/html',
         createdAt: new Date('2024-01-03'),
         isMine: false,
-        sender: {
-          id: 'partner-2',
-          publicName: 'Partner 2',
-          profileImages: [],
-          location: { country: '' },
-        },
-      }
+        sender: { id: 'partner-2', publicName: 'Partner 2', thumbnail: null },
+      })
 
       await store.handleIncomingMessage(incomingMessage)
 
@@ -197,42 +152,15 @@ describe('messageStore', () => {
       const store = useMessageStore()
       store.suppressMessageNotifications = false
 
-      const convo: ConversationSummary = {
-        id: 'participant-1',
-        profileId: 'profile-1',
-        conversationId: 'convo-1',
-        lastReadAt: new Date('2024-01-01'),
-        isMuted: false,
-        isArchived: false,
-        canReply: true,
-        isCallable: true,
-        myIsCallable: true,
-        conversation: {
-          id: 'convo-1',
-          updatedAt: new Date('2024-01-01'),
-          createdAt: new Date('2024-01-01'),
-        },
-        partnerProfile: {
-          id: 'partner-1',
-          publicName: 'Partner',
-          profileImages: [],
-          location: { country: '' },
-        },
-        lastMessage: null,
-      }
+      const convo: ConversationSummary = { ...makeConvo('convo-1', 'Partner'), canReply: true }
       store.conversations = [convo]
       store.activeConversation = null
 
-      const incomingMessage: MessageDTO = {
-        id: 'msg-1',
-        conversationId: 'convo-1',
+      const incomingMessage: MessageDTO = makeMessage({
         senderId: 'partner-1',
-        content: 'Hello',
-        messageType: 'text/html',
-        createdAt: new Date('2024-01-02'),
         isMine: false,
-        sender: { id: 'partner-1', publicName: 'Partner', profileImages: [], location: { country: '' } },
-      }
+        sender: { id: 'partner-1', publicName: 'Partner', thumbnail: null },
+      })
 
       await store.handleIncomingMessage(incomingMessage)
 
@@ -243,42 +171,15 @@ describe('messageStore', () => {
       const store = useMessageStore()
       store.suppressMessageNotifications = true
 
-      const convo: ConversationSummary = {
-        id: 'participant-1',
-        profileId: 'profile-1',
-        conversationId: 'convo-1',
-        lastReadAt: new Date('2024-01-01'),
-        isMuted: false,
-        isArchived: false,
-        canReply: true,
-        isCallable: true,
-        myIsCallable: true,
-        conversation: {
-          id: 'convo-1',
-          updatedAt: new Date('2024-01-01'),
-          createdAt: new Date('2024-01-01'),
-        },
-        partnerProfile: {
-          id: 'partner-1',
-          publicName: 'Partner',
-          profileImages: [],
-          location: { country: '' },
-        },
-        lastMessage: null,
-      }
+      const convo: ConversationSummary = { ...makeConvo('convo-1', 'Partner'), canReply: true }
       store.conversations = [convo]
       store.activeConversation = null
 
-      const incomingMessage: MessageDTO = {
-        id: 'msg-1',
-        conversationId: 'convo-1',
+      const incomingMessage: MessageDTO = makeMessage({
         senderId: 'partner-1',
-        content: 'Hello',
-        messageType: 'text/html',
-        createdAt: new Date('2024-01-02'),
         isMine: false,
-        sender: { id: 'partner-1', publicName: 'Partner', profileImages: [], location: { country: '' } },
-      }
+        sender: { id: 'partner-1', publicName: 'Partner', thumbnail: null },
+      })
 
       await store.handleIncomingMessage(incomingMessage)
 
@@ -345,13 +246,129 @@ describe('appendMessageIfNew', () => {
   })
 })
 
+describe('handleSendResponse (discriminated on outcome)', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+  })
+
+  it('reply outcome: applies the patch to the matching conversation and bumps updatedAt', () => {
+    const store = useMessageStore()
+    const convo = makeConvo('convo-1', 'Partner')
+    const other = makeConvo('convo-other', 'Other')
+    store.conversations = [other, convo]
+    store.activeConversation = convo
+
+    const message = makeMessage({
+      id: 'msg-42',
+      conversationId: 'convo-1',
+      content: 'Reply!',
+      senderId: 'profile-1',
+      isMine: true,
+    })
+    const patch: ConversationPatch = {
+      conversationId: 'convo-1',
+      updatedAt: new Date('2024-06-01T00:00:00Z'),
+    }
+    const response: SendMessageResponse = {
+      success: true,
+      outcome: 'reply',
+      message,
+      conversationPatch: patch,
+    }
+
+    const result = store.handleSendResponse({ data: response })
+
+    expect(result).toEqual({ success: true, data: message })
+    expect(store.conversations[0]!.conversationId).toBe('convo-1')
+    expect(store.conversations[0]!.conversation.updatedAt).toEqual(patch.updatedAt)
+    expect(store.conversations[0]!.lastMessage).toEqual({
+      content: 'Reply!',
+      messageType: 'text/plain',
+      createdAt: message.createdAt,
+      isMine: true,
+    })
+    expect(store.messages.map((m) => m.id)).toContain('msg-42')
+  })
+
+  it('reply outcome: ignores the patch when the conversation was dropped from the list (race)', () => {
+    const store = useMessageStore()
+    // The store no longer holds this conversation (e.g. it was filtered out by
+    // a concurrent fetch while the send was in flight). The patch arm must
+    // not crash and must not re-fetch.
+    store.conversations = [makeConvo('convo-other', 'Other')]
+    store.activeConversation = null
+
+    const response: SendMessageResponse = {
+      success: true,
+      outcome: 'reply',
+      message: makeMessage({ conversationId: 'convo-stale' }),
+      conversationPatch: {
+        conversationId: 'convo-stale',
+        updatedAt: new Date('2024-06-01T00:00:00Z'),
+      },
+    }
+
+    const result = store.handleSendResponse({ data: response })
+
+    expect(result.success).toBe(true)
+    expect(store.conversations).toHaveLength(1)
+    expect(store.conversations[0]!.conversationId).toBe('convo-other')
+    expect(store.messages).toHaveLength(0)
+  })
+
+  it('new_conversation outcome: upserts the full conversation and appends the message if active', () => {
+    const store = useMessageStore()
+    store.conversations = []
+
+    const convo = makeConvo('convo-new', 'New Partner')
+    store.activeConversation = convo
+
+    const message = makeMessage({ id: 'msg-new', conversationId: 'convo-new' })
+    const response: SendMessageResponse = {
+      success: true,
+      outcome: 'new_conversation',
+      message,
+      conversation: convo,
+    }
+
+    const result = store.handleSendResponse({ data: response })
+
+    expect(result).toEqual({ success: true, data: message })
+    expect(store.conversations[0]!.conversationId).toBe('convo-new')
+    expect(store.messages.map((m) => m.id)).toContain('msg-new')
+  })
+
+  it('accepted_on_reply outcome: upserts the conversation', () => {
+    const store = useMessageStore()
+    store.conversations = [makeConvo('convo-other', 'Other')]
+    store.activeConversation = null
+
+    const convo = makeConvo('convo-accepted', 'Partner')
+    const message = makeMessage({ id: 'msg-accept', conversationId: 'convo-accepted' })
+    const response: SendMessageResponse = {
+      success: true,
+      outcome: 'accepted_on_reply',
+      message,
+      conversation: convo,
+    }
+
+    const result = store.handleSendResponse({ data: response })
+
+    expect(result.success).toBe(true)
+    expect(store.conversations[0]!.conversationId).toBe('convo-accepted')
+    // Inactive conversation: message not appended to the visible thread.
+    expect(store.messages).toHaveLength(0)
+  })
+})
+
 describe('sendMessage', () => {
   beforeEach(() => {
     setActivePinia(createPinia())
     vi.clearAllMocks()
   })
 
-  it('sends a text message and bumps conversation to top', async () => {
+  it('reply outcome: applies patch and bumps the existing conversation to the top', async () => {
     const store = useMessageStore()
     const otherConvo = makeConvo('convo-other', 'Other')
     const convo = makeConvo('convo-1', 'Partner')
@@ -361,9 +378,13 @@ describe('sendMessage', () => {
     mockApi.post.mockResolvedValue({
       data: {
         success: true,
-        conversation: { ...convo, lastMessage: { id: 'msg-1', content: 'Hello' } },
-        message: { id: 'msg-1', conversationId: 'convo-1', content: 'Hello' },
-      },
+        outcome: 'reply',
+        message: makeMessage({ id: 'msg-1', conversationId: 'convo-1', content: 'Hello' }),
+        conversationPatch: {
+          conversationId: 'convo-1',
+          updatedAt: new Date('2024-06-02'),
+        },
+      } satisfies SendMessageResponse,
     })
 
     const result = await store.sendMessage('partner-convo-1', 'Hello')
@@ -374,23 +395,6 @@ describe('sendMessage', () => {
     expect(store.conversations[1]!.conversationId).toBe('convo-other')
     expect(store.messages.map((m) => m.id)).toContain('msg-1')
     expect(store.isSending).toBe(false)
-  })
-
-  it('returns StoreError when message is null in response', async () => {
-    const store = useMessageStore()
-    const convo = makeConvo('convo-1', 'Partner')
-
-    mockApi.post.mockResolvedValue({
-      data: {
-        success: true,
-        conversation: convo,
-        message: null,
-      },
-    })
-
-    const result = await store.sendMessage('partner-convo-1', 'Hello')
-
-    expect(result).toMatchObject({ success: false })
   })
 })
 
@@ -409,9 +413,13 @@ describe('sendVoiceMessage', () => {
     mockApi.post.mockResolvedValue({
       data: {
         success: true,
-        conversation: { ...convo, lastMessage: { id: 'voice-1' } },
-        message: { id: 'voice-1', conversationId: 'convo-1', content: '' },
-      },
+        outcome: 'reply',
+        message: makeMessage({ id: 'voice-1', conversationId: 'convo-1', content: '' }),
+        conversationPatch: {
+          conversationId: 'convo-1',
+          updatedAt: new Date('2024-06-02'),
+        },
+      } satisfies SendMessageResponse,
     })
 
     const blob = new Blob(['audio'], { type: 'audio/webm' })
@@ -420,6 +428,31 @@ describe('sendVoiceMessage', () => {
     expect(result).toEqual({ success: true, data: expect.objectContaining({ id: 'voice-1' }) })
     expect(mockApi.post).toHaveBeenCalledWith('/messages/voice', expect.any(FormData))
     expect(store.isSending).toBe(false)
+  })
+})
+
+describe('markAsRead', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+  })
+
+  it('applies lastReadAt patch to the matching conversation without a full replacement', async () => {
+    const store = useMessageStore()
+    const convo = makeConvo('convo-1', 'Partner')
+    store.conversations = [convo]
+
+    const lastReadAt = new Date('2024-06-02T10:00:00Z')
+    mockApi.post.mockResolvedValue({
+      data: { success: true, conversationId: 'convo-1', lastReadAt },
+    })
+
+    await store.markAsRead('convo-1')
+
+    expect(mockApi.post).toHaveBeenCalledWith('/messages/conversations/convo-1/mark-read')
+    expect(store.conversations[0]!.lastReadAt).toEqual(lastReadAt)
+    // Other fields on the entry are unchanged.
+    expect(store.conversations[0]!.partnerProfile.publicName).toBe('Partner')
   })
 })
 

--- a/apps/frontend/src/features/messaging/stores/messageStore.ts
+++ b/apps/frontend/src/features/messaging/stores/messageStore.ts
@@ -4,15 +4,15 @@ import { api, safeApiCall } from '@/lib/api'
 import { bus } from '@/lib/bus'
 
 import type {
+  ConversationPatch,
   ConversationSummary,
   MessageDTO,
-  MessageInConversation,
   SendMessagePayload,
 } from '@zod/messaging/messaging.dto'
 import type {
   MessagesResponse,
   ConversationsResponse,
-  ConversationResponse,
+  MarkConversationReadResponse,
   SendMessageResponse,
 } from '@zod/apiResponse.dto'
 import { storeError, type StoreError, type StoreResponse, storeSuccess } from '@/store/helpers'
@@ -64,7 +64,12 @@ export const useMessageStore = defineStore('message', {
         // and we can reply (fixes bug where both "My turn" and "Their turn" badges show)
         const updatedConvo: ConversationSummary = {
           ...convo,
-          lastMessage: message,
+          lastMessage: {
+            content: message.content,
+            messageType: message.messageType,
+            createdAt: message.createdAt,
+            isMine: message.isMine,
+          },
           canReply: true,
         }
         this.bumpConversation(updatedConvo)
@@ -91,16 +96,47 @@ export const useMessageStore = defineStore('message', {
       ]
     },
 
-    handleSendResponse(res: {
-      data: { conversation: ConversationSummary; message: MessageDTO | null }
-    }): StoreResponse<MessageDTO> | StoreError {
-      const { conversation, message } = res.data
-      if (!message) return storeError(new Error('Message not sent'))
+    // Upsert a conversation summary into the list, bumping to top.
+    upsertConversation(conversation: ConversationSummary) {
       this.bumpConversation(conversation)
-      if (this.activeConversation?.conversationId === conversation.conversationId) {
+    },
+
+    // Apply a reply delta to an existing conversation entry. The server
+    // already holds the canonical updatedAt; we reuse it for inbox ordering.
+    applyReplyToConversation(message: MessageDTO, patch: ConversationPatch) {
+      const idx = this.conversations.findIndex((c) => c.conversationId === patch.conversationId)
+      // Race: convo dropped from the list while the send was in flight.
+      // Ignore — no fallback fetch (see "Out of scope" in the design doc).
+      if (idx === -1) return
+      const existing = this.conversations[idx]!
+      const updated: ConversationSummary = {
+        ...existing,
+        conversation: { ...existing.conversation, updatedAt: patch.updatedAt },
+        lastMessage: {
+          content: message.content,
+          messageType: message.messageType,
+          createdAt: message.createdAt,
+          isMine: message.isMine,
+        },
+      }
+      this.bumpConversation(updated)
+      this.updateUnreadFlag()
+      if (this.activeConversation?.conversationId === patch.conversationId) {
         this.appendMessageIfNew(message)
       }
-      return storeSuccess(message)
+    },
+
+    handleSendResponse(res: { data: SendMessageResponse }): StoreResponse<MessageDTO> {
+      const body = res.data
+      if (body.outcome === 'reply') {
+        this.applyReplyToConversation(body.message, body.conversationPatch)
+      } else {
+        this.upsertConversation(body.conversation)
+        if (this.activeConversation?.conversationId === body.conversation.conversationId) {
+          this.appendMessageIfNew(body.message)
+        }
+      }
+      return storeSuccess(body.message)
     },
 
     // Update a conversation in the list
@@ -126,7 +162,7 @@ export const useMessageStore = defineStore('message', {
     async fetchMessages(
       conversationId: string,
       options?: { take?: number; cursor?: string }
-    ): Promise<StoreResponse<{ messages: MessageInConversation[] }>> {
+    ): Promise<StoreResponse<{ messages: MessageDTO[] }>> {
       try {
         const res = await safeApiCall(() =>
           api.get<MessagesResponse>(`/messages/${conversationId}`, {
@@ -148,7 +184,7 @@ export const useMessageStore = defineStore('message', {
     async fetchMessagesForConversation(
       conversationId: string,
       options?: { cursor?: string; append?: boolean }
-    ): Promise<MessageInConversation[]> {
+    ): Promise<MessageDTO[]> {
       try {
         const isLoadingOlder = Boolean(options?.append)
         if (isLoadingOlder) {
@@ -200,7 +236,7 @@ export const useMessageStore = defineStore('message', {
       return []
     },
 
-    async fetchOlderMessages(): Promise<MessageInConversation[]> {
+    async fetchOlderMessages(): Promise<MessageDTO[]> {
       if (
         !this.activeConversation ||
         !this.hasMoreMessages ||
@@ -239,13 +275,18 @@ export const useMessageStore = defineStore('message', {
 
     async markAsRead(convoId: string) {
       try {
-        const updateConvo = await safeApiCall(() =>
-          api.post<ConversationResponse>(`/messages/conversations/${convoId}/mark-read`)
+        const res = await safeApiCall(() =>
+          api.post<MarkConversationReadResponse>(`/messages/conversations/${convoId}/mark-read`)
         )
-        if (updateConvo.data.success) {
-          const updatedConvo: ConversationSummary = updateConvo.data.conversation
-          this.updateConvo(updatedConvo)
-          this.updateUnreadFlag()
+        if (res.data.success) {
+          const idx = this.conversations.findIndex(
+            (c) => c.conversationId === res.data.conversationId
+          )
+          if (idx !== -1) {
+            const existing = this.conversations[idx]!
+            this.conversations[idx] = { ...existing, lastReadAt: res.data.lastReadAt }
+            this.updateUnreadFlag()
+          }
         }
       } catch (error: any) {
         console.error('Failed to mark conversation as read:', error)

--- a/docs/superpowers/specs/2026-04-24-messaging-response-shapes-design.md
+++ b/docs/superpowers/specs/2026-04-24-messaging-response-shapes-design.md
@@ -1,0 +1,339 @@
+# Messaging response shapes — type-driven cleanup
+
+**Date:** 2026-04-24
+**Branch:** `feat/messaging-response-shapes`
+**Tracking issue:** [#1369](https://github.com/opencupid/opencupid/issues/1369)
+
+## Problem
+
+The `POST /api/messages/message` (and `/voice`) response is large and largely redundant. A typical reply produces ~3.4 KB JSON for a 5-character message body, dominated by image-variant URL lists. The same `MessageDTO` is also shipped over the WebSocket `ws:new_message` channel, multiplying the bloat by every connected recipient. Most of the payload is never read by the frontend.
+
+The naive fix would be to make fields optional and add null-checks at consumers. That repeats the underlying mistake. This design treats the bloat as a **type-design symptom** and fixes the types — the wire size, the Prisma includes, and the consumer code shrink as consequences.
+
+## Root causes (type-design failures)
+
+1. **`MessageDTO` carries `sender: ProfileSummary` for two unrelated jobs.** Bubble identity (covered by the existing `senderId` / `isMine` fields) and notification rendering (toast + webpush, where we need name + a thumb). Collapsing both jobs into "embed full ProfileSummary" forces every consumer to receive a shape vastly wider than it needs.
+
+2. **`ConversationSummary` is one type doing two jobs.** A *list item* (inbox entry, store array element) and an *update patch* (returned by `POST /message`, `POST .../mark-read`). The post-write case ships a full record when a delta would suffice — and on the dominant `reply` outcome, the store already holds the conversation; the response is largely redundant with state.
+
+3. **`ProfileSummary` is the wrong abstraction for messaging.** It was designed for browse / public-profile contexts where `location` and a full image set are needed. It has since been reused (and widened) by other features (e.g., the map). Reusing it inside messaging propagates a 5-variant × N-image payload into every message-related response, even though messaging only ever renders name + one thumbnail.
+
+Supporting symptoms (not the root, but cleaned up by the same change):
+
+4. **Service layer leaks Prisma payload types.** `getConversationSummary` returns `ConversationParticipantWithConversationSummary` (the Prisma `GetPayload` type) verbatim. The include must be wide enough to feed the widest mapper, so it pulls all images of both participants.
+5. **`MessageInConversation` and `MessageDTO` are de-facto duplicates** (differ by an optional `isMine`). `DbMessageInConversation` and `DbMessageAttachmentDTO` are orphans (no production importers).
+6. **WS `ws:new_message` reuses the HTTP `MessageDTO`**, so the same bloat ships per connected recipient.
+
+## Non-goals
+
+- Auditing or narrowing `ProfileSummary` itself. It has cross-feature consumers (map, browse) that would need separate review. This PR stops messaging from depending on it; the broader audit is a separate scope.
+- Replacing `messageStore.handleIncomingMessage`'s `fetchConversations()` fallback (when an unknown conversation arrives over WS) with a single-conversation `GET /messages/conversations/:id`. Same pattern (re-list when patch suffices), separate scope.
+- Adopting blurhash placeholders on messaging surfaces. The narrow design here deliberately omits blurhash from the messaging-side image shape, matching what the messaging components actually render today (no placeholder support). If we later want blurhash placeholders in toast / inbox, that's a focused UI change with its own type extension.
+- Changing how attachments (voice messages) are shaped on the wire. `MessageAttachmentDTO` is already minimal and used as-is.
+
+## Design
+
+### New shape: `MessagingProfileRef`
+
+A messaging-owned profile-identity type, derived from existing schemas. Used wherever messaging needs to identify a profile for rendering: `MessageDTO.sender` and `ConversationSummary.partnerProfile`.
+
+```ts
+// packages/shared/zod/messaging/messaging.dto.ts
+
+export const MessagingProfileRefSchema = z.object({
+  id: z.string(),
+  publicName: z.string(),
+  thumbnail: z.object({
+    url: z.string(),
+  }).nullable(),
+})
+export type MessagingProfileRef = z.infer<typeof MessagingProfileRefSchema>
+```
+
+Notes:
+
+- `thumbnail: { url } | null`. `null` is a real domain state ("profile has no image yet"), not missing data. No optional / `undefined`. No null-checks at render sites that use `v-if="sender.thumbnail"`.
+- No `blurhash`, no `mimeType`, no `altText`, no `position`, no `location`. None are read by any messaging consumer today (`ImageTag` reads only the variant URL; `BlurhashCanvas` is used only by the browse `ProfileCardComponent`).
+- Owned by `messaging.dto.ts`. The type name signals "do not reuse outside messaging" — the explicit antidote to the `ProfileSummary` reuse pattern.
+
+### Collapsed: `MessageDTO`
+
+`MessageInConversation`, `DbMessageInConversation`, `DbMessageAttachmentDTO` are removed. `MessageDTO` is the one shape:
+
+```ts
+export const MessageDTOSchema = MessageSchema.pick({
+  id: true,
+  conversationId: true,
+  senderId: true,
+  content: true,
+  messageType: true,
+  createdAt: true,
+}).extend({
+  sender: MessagingProfileRefSchema,
+  attachment: MessageAttachmentDTOSchema.nullable(),
+  isMine: z.boolean(), // required, not optional
+})
+export type MessageDTO = z.infer<typeof MessageDTOSchema>
+```
+
+`isMine` becomes **required**. Every `MessageDTO` is built for a specific viewer; making the field optional produced a real bug-shaped quirk where the WS broadcast mapped a `MessageDTO` without a `currentProfileId` and the recipient received `isMine: undefined`. The new contract is "you cannot construct a `MessageDTO` without saying who is viewing it" — so the WS broadcast maps per recipient (with the recipient's profileId, yielding `isMine: false`).
+
+### Narrowed: `ConversationSummary`
+
+Same field set as today, but `partnerProfile: MessagingProfileRef` instead of `ProfileSummary`. `lastMessage` shape unchanged (already minimal: `content / messageType / createdAt / isMine`). All other fields stay.
+
+```ts
+const ConversationSummarySchema = ConversationParticipantSchema.pick({
+  id: true,
+  profileId: true,
+  conversationId: true,
+  lastReadAt: true,
+  isMuted: true,
+  isArchived: true,
+}).extend({
+  conversation: ConversationSchema.pick({ id: true, updatedAt: true, createdAt: true }),
+  canReply: z.boolean(),
+  isCallable: z.boolean(),
+  myIsCallable: z.boolean(),
+  partnerProfile: MessagingProfileRefSchema,
+  lastMessage: MessageInConversationSummarySchema.nullable(),
+})
+```
+
+### New: `ConversationPatch`
+
+```ts
+export const ConversationPatchSchema = z.object({
+  conversationId: z.string(),
+  updatedAt: z.date(),
+})
+export type ConversationPatch = z.infer<typeof ConversationPatchSchema>
+```
+
+A small delta carrying enough information to re-bump an existing conversation entry in store state. `updatedAt` reflects the post-write value of the `Conversation.updatedAt` column (set by Prisma in the same transaction as the message insert) — not a value derived client-side from `message.createdAt`. The store has one canonical source for "when was this conversation last touched" (`conversation.updatedAt`), which is the same field used for inbox ordering across all code paths.
+
+### Discriminated response: `SendMessageResponse`
+
+The send is a state-machine operation; its `outcome` already classifies the result. The response shape now follows that classification.
+
+```ts
+// packages/shared/zod/apiResponse.dto.ts
+
+export type SendMessageResponse =
+  | (ApiSuccess & {
+      outcome: 'reply'
+      message: MessageDTO
+      conversationPatch: ConversationPatch
+    })
+  | (ApiSuccess & {
+      outcome: 'new_conversation' | 'accepted_on_reply'
+      message: MessageDTO
+      conversation: ConversationSummary
+    })
+```
+
+Key consequences:
+
+- The reply arm (the dominant case) ships `message` + a small patch, no `ConversationSummary`.
+- The non-reply arms ship the full `ConversationSummary` because the store may not yet hold the conversation.
+- `outcome` becomes the wire-level **discriminant**, not just a label. The store's handler does `switch (res.outcome)` and the type checker enforces correct field access per arm. No null checks. No fallbacks.
+- The duplicate `lastMessage` payload (today: same content/createdAt/messageType/isMine appears both in `message` and in `conversation.lastMessage`) goes away on the reply arm.
+
+### Narrowed: `MarkConversationReadResponse`
+
+`POST /messages/conversations/:id/mark-read` returns just the patch, not the full `ConversationSummary`:
+
+```ts
+export type MarkConversationReadResponse = ApiSuccess & {
+  conversationId: string
+  lastReadAt: Date
+}
+```
+
+Same root cause as the send response (full record returned where a delta suffices), trivial additional surface, fixed in the same PR.
+
+## Data flow under the new design
+
+### Backend: send (`POST /messages/message`, `/voice`)
+
+`sendAndBuildResponse` in [apps/backend/src/api/routes/messaging.route.ts](apps/backend/src/api/routes/messaging.route.ts) branches on `outcome`:
+
+```ts
+if (outcome === 'reply') {
+  // convo.updatedAt is the post-insert value from the same transaction
+  return {
+    success: true,
+    outcome,
+    message: messageDTO,
+    conversationPatch: { conversationId: convo.id, updatedAt: convo.updatedAt },
+  }
+}
+
+const conversation = await messageService.getConversationSummary(convo.id, senderProfileId)
+if (!conversation) throw new Error('Conversation summary not found')
+return {
+  success: true,
+  outcome,
+  message: messageDTO,
+  conversation: mapConversationParticipantToSummary(conversation, senderProfileId),
+}
+```
+
+This eliminates the `getConversationSummary` round-trip on the dominant path. The `convo` reference is the conversation row returned by `messageService.sendMessage` (or by `resolveConversation` in the same transaction); `sendAndBuildResponse`'s current return tuple needs to expose `convo.updatedAt` alongside `convoId` to support this — a small refactor inside the existing transaction block, not an additional query.
+
+### Backend: WS broadcast
+
+`fireNewMessageNotifications` currently builds one `messageDTO` (without `currentProfileId`) and broadcasts it to the recipient. Under the new contract, `MessageDTO` cannot be constructed without a viewer. The mapping is moved per-recipient:
+
+```ts
+const recipientMessageDTO = mapMessageToDTO(message, recipientProfileId) // isMine: false
+broadcastToProfile(fastify, recipientProfileId, {
+  type: 'ws:new_message',
+  payload: recipientMessageDTO,
+})
+```
+
+This is a one-line change with a real correctness benefit (recipient gets `isMine: false` instead of `undefined`).
+
+### Backend: includes (Prisma)
+
+`messageWithSenderInclude` shrinks to feed `MessagingProfileRef`:
+
+```ts
+export const messageWithSenderInclude = {
+  sender: {
+    select: {
+      id: true,
+      publicName: true,
+      profileImages: {
+        // Field projection finalized at implementation time against the actual
+        // ProfileImage schema; it carries only what the thumb-URL builder reads.
+        orderBy: { position: 'asc' },
+        take: 1,
+      },
+    },
+  },
+  attachment: true,
+} satisfies Prisma.MessageInclude
+```
+
+Removed scalars: `country`, `cityName`, `lat`, `lon`. The `profileImages` relation is reduced to a single row (the position-0 image) and projected to only the fields the thumb-URL builder reads — the exact `select` is a small mechanical task during implementation, not a design choice.
+
+`conversationSummaryInclude` shrinks similarly for the participants' profile images.
+
+### Backend: mappers
+
+- `mapMessageToDTO(m, currentProfileId: string)` — `currentProfileId` becomes required, returns `MessageDTO` with `isMine: boolean` (not optional). Builds `MessagingProfileRef` for `sender`. Resolves the thumb variant URL server-side.
+- `mapConversationParticipantToSummary` — builds `MessagingProfileRef` for `partnerProfile`.
+- `mapMessagingProfileRef(profile)` — new helper that produces `MessagingProfileRef` from the narrowed Prisma sender include. Used by both mappers above.
+- `mapProfileSummary` — unchanged. Other features still use it.
+
+### Frontend store ([apps/frontend/src/features/messaging/stores/messageStore.ts](apps/frontend/src/features/messaging/stores/messageStore.ts))
+
+The handler is rewritten as a `switch` on `outcome`. No null checks. The discriminated union does the work.
+
+```ts
+handleSendResponse(res: SendMessageResponse): StoreResponse<MessageDTO> {
+  if (res.outcome === 'reply') {
+    this.applyReplyToConversation(res.message, res.conversationPatch)
+  } else {
+    this.upsertConversation(res.conversation)
+    if (this.activeConversation?.conversationId === res.conversation.conversationId) {
+      this.appendMessageIfNew(res.message)
+    }
+  }
+  return storeSuccess(res.message)
+}
+
+applyReplyToConversation(message: MessageDTO, patch: ConversationPatch) {
+  const idx = this.conversations.findIndex(c => c.conversationId === patch.conversationId)
+  if (idx === -1) return // race: convo dropped while in-flight; ignore (no fallback fetch)
+  const existing = this.conversations[idx]!
+  const updated: ConversationSummary = {
+    ...existing,
+    conversation: { ...existing.conversation, updatedAt: patch.updatedAt },
+    lastMessage: {
+      content: message.content,
+      messageType: message.messageType,
+      createdAt: message.createdAt,
+      isMine: message.isMine,
+    },
+  }
+  this.bumpConversation(updated)
+  this.updateUnreadFlag()
+  if (this.activeConversation?.conversationId === patch.conversationId) {
+    this.appendMessageIfNew(message)
+  }
+}
+```
+
+`markAsRead` consumes `MarkConversationReadResponse` and applies the patch directly to the existing entry (no full-record replacement).
+
+`MessageInConversation` is removed from the store's return-type aliases — `fetchMessages*` return `MessageDTO[]`.
+
+### Frontend: `MessageReceivedToast.vue`
+
+Inline `<img>` reading `message.sender.thumbnail.url` directly. Drops the `<ProfileImage>` indirection at this site (the component is built around the multi-variant model and was overkill for a one-URL render).
+
+```vue
+<template>
+  <div class="d-flex align-items-start clickable">
+    <div class="profile-thumbnail me-2 flex-shrink-0">
+      <img
+        v-if="message.sender.thumbnail"
+        :src="message.sender.thumbnail.url"
+        :alt="message.sender.publicName"
+        class="rounded"
+      />
+    </div>
+    <!-- ... unchanged ... -->
+  </div>
+</template>
+```
+
+### Backend: webpush
+
+`webpush.service.ts` reads only `message.sender.publicName` and `message.content` / `message.conversationId`. Works unchanged with the new narrower `MessagingProfileRef`. No changes required.
+
+## Testing
+
+Unit tests update to match the new types:
+
+- `apps/backend/src/__tests__/api/messaging.mappers.spec.ts` — `mapMessageToDTO` now requires `currentProfileId`; assert `MessagingProfileRef` shape on `sender` and `partnerProfile`. Add a `mapMessagingProfileRef` direct test.
+- `apps/backend/src/__tests__/routes/messaging.route.spec.ts` — assert response is the discriminated union; explicit fixtures for each `outcome` arm. Assert the reply path does NOT call `getConversationSummary` (mock and assert call count = 0).
+- `apps/frontend/src/features/messaging/stores/__tests__/messageStore.spec.ts` — three new test cases for `handleSendResponse`, one per outcome arm. Cover the "stale convo dropped from list" race (reply patch arrives for a conversationId no longer in the list).
+- `apps/frontend/src/features/app/components/__tests__/MessageReceivedToast.spec.ts` — update to render from the inline `<img>` path; assert `null` thumbnail renders no image.
+- WS broadcast test (in `messaging.route.spec.ts`, alongside the existing `ws:new_message` assertions): assert the broadcast payload has `isMine: false` for the recipient (not `undefined`).
+
+No integration-test changes anticipated beyond fixture updates.
+
+## Migration / compatibility
+
+This is a breaking wire-shape change between server and frontend. Both ship together — the monorepo deploys atomically; no cross-version contract to preserve. Follow CLAUDE.md's "Data integrity" rule: no backwards-compatibility shims, no fallback paths.
+
+No database schema change. No migrations.
+
+## Out of scope (recorded follow-ups)
+
+- **Cross-feature `ProfileSummary` audit.** Same root pattern (over-reuse + widening) likely affects other features. Separate ticket.
+- **`GET /messages/conversations/:id`.** Would let `handleIncomingMessage` replace its `fetchConversations()` fallback with a targeted fetch. Same root family (re-list when patch/single-fetch suffices). Separate ticket.
+- **Blurhash placeholders on messaging surfaces.** If we want blur-up rendering in the toast / inbox, extend `MessagingProfileRef.thumbnail` to carry `blurhash` as part of that UI work, not preemptively.
+
+## Files touched
+
+**Shared types:**
+- `packages/shared/zod/messaging/messaging.dto.ts`
+- `packages/shared/zod/apiResponse.dto.ts`
+
+**Backend:**
+- `apps/backend/src/services/messaging.service.ts` (includes shrink)
+- `apps/backend/src/api/mappers/messaging.mappers.ts` (new helper, signature change)
+- `apps/backend/src/api/routes/messaging.route.ts` (outcome branching, per-recipient WS map)
+- Test files under `apps/backend/src/__tests__/`
+
+**Frontend:**
+- `apps/frontend/src/features/messaging/stores/messageStore.ts`
+- `apps/frontend/src/features/app/components/MessageReceivedToast.vue`
+- Test files under the matching `__tests__/` dirs
+
+No changes anticipated in `apps/admin` (does not consume messaging DTOs in production code per current trace).

--- a/packages/shared/zod/apiResponse.dto.ts
+++ b/packages/shared/zod/apiResponse.dto.ts
@@ -16,9 +16,9 @@ import type {
 } from '@zod/profile/profile.dto'
 import type { PublicTag, PopularTag } from '@zod/tag/tag.dto'
 import type {
+  ConversationPatch,
   ConversationSummary,
   MessageDTO,
-  SendMessageOutcome,
 } from '@zod/messaging/messaging.dto'
 import type { LoginUser, SettingsUser } from '@zod/user/user.dto'
 import type { LocationDTO } from '@zod/dto/location.dto'
@@ -68,12 +68,25 @@ export type MessagesResponse = ApiSuccess<{
   hasMore: boolean
 }>
 export type ConversationsResponse = ApiSuccess<{ conversations: ConversationSummary[] }>
-export type ConversationResponse = ApiSuccess<{ conversation: ConversationSummary }>
 
-export type SendMessageResponse = ApiSuccess<{
-  conversation: ConversationSummary
-  message: MessageDTO
-  outcome: SendMessageOutcome
+// Discriminated on `outcome`: the dominant 'reply' arm ships a small
+// conversation patch; the other arms ship the full ConversationSummary
+// because the store may not yet hold the conversation.
+export type SendMessageResponse =
+  | ApiSuccess<{
+      outcome: 'reply'
+      message: MessageDTO
+      conversationPatch: ConversationPatch
+    }>
+  | ApiSuccess<{
+      outcome: 'new_conversation' | 'accepted_on_reply'
+      message: MessageDTO
+      conversation: ConversationSummary
+    }>
+
+export type MarkConversationReadResponse = ApiSuccess<{
+  conversationId: string
+  lastReadAt: Date
 }>
 
 export type InitiateConversationResponse = ApiSuccess<{}>

--- a/packages/shared/zod/messaging/messaging.dto.ts
+++ b/packages/shared/zod/messaging/messaging.dto.ts
@@ -1,33 +1,10 @@
 import { z } from 'zod'
-import { ProfileSummarySchema } from '../profile/profile.dto'
 import {
   ConversationParticipantSchema,
   ConversationSchema,
   MessageSchema,
   MessageAttachmentSchema,
 } from '../generated'
-import { Prisma } from '@prisma/client'
-
-const conversationParticipantFields = {
-  id: true,
-  profileId: true,
-  conversationId: true,
-  lastReadAt: true,
-  isMuted: true,
-  isArchived: true,
-} as const
-
-// Message attachment DB shape
-const DbMessageAttachmentDTOSchema = MessageAttachmentSchema.pick({
-  id: true,
-  mimeType: true,
-  fileSize: true,
-  duration: true,
-  createdAt: true,
-  filePath: true,
-})
-
-export type DbMessageAttachmentDTO = z.infer<typeof DbMessageAttachmentDTOSchema>
 
 // Message attachment DTO
 const MessageAttachmentDTOSchema = MessageAttachmentSchema.pick({
@@ -42,8 +19,23 @@ const MessageAttachmentDTOSchema = MessageAttachmentSchema.pick({
 
 export type MessageAttachmentDTO = z.infer<typeof MessageAttachmentDTOSchema>
 
-// this is used in the db layer
-const DbMessageInConversationSchema = MessageSchema.pick({
+// Messaging-owned profile-identity reference. Intentionally narrow: only what
+// messaging surfaces (bubble identity, toast, inbox list) actually render.
+// Do not reuse outside messaging — that is the antidote to the ProfileSummary
+// over-reuse pattern.
+export const MessagingProfileRefSchema = z.object({
+  id: z.string(),
+  publicName: z.string(),
+  thumbnail: z
+    .object({
+      url: z.string(),
+    })
+    .nullable(),
+})
+
+export type MessagingProfileRef = z.infer<typeof MessagingProfileRefSchema>
+
+const MessageDTOSchema = MessageSchema.pick({
   id: true,
   conversationId: true,
   senderId: true,
@@ -51,30 +43,9 @@ const DbMessageInConversationSchema = MessageSchema.pick({
   messageType: true,
   createdAt: true,
 }).extend({
-  sender: ProfileSummarySchema,
-  attachment: DbMessageAttachmentDTOSchema.nullable().optional(),
-})
-export type DbMessageInConversation = z.infer<typeof DbMessageInConversationSchema>
-
-// this is used in the db layer
-const MessageInConversationSchema = MessageSchema.pick({
-  id: true,
-  conversationId: true,
-  senderId: true,
-  content: true,
-  messageType: true,
-  createdAt: true,
-}).extend({
-  sender: ProfileSummarySchema,
-  attachment: MessageAttachmentDTOSchema.nullable().optional(),
-})
-export type MessageInConversation = z.infer<typeof MessageInConversationSchema>
-
-// this is used in the dto layer
-const MessageDTOSchema = MessageInConversationSchema.extend({
-  sender: ProfileSummarySchema,
-  isMine: z.boolean().optional(),
-  attachment: MessageAttachmentDTOSchema.nullable().optional(),
+  sender: MessagingProfileRefSchema,
+  attachment: MessageAttachmentDTOSchema.nullable(),
+  isMine: z.boolean(),
 })
 export type MessageDTO = z.infer<typeof MessageDTOSchema>
 
@@ -83,7 +54,7 @@ const MessageInConversationSummarySchema = MessageSchema.pick({
   messageType: true,
   createdAt: true,
 }).extend({
-  isMine: z.boolean().optional(),
+  isMine: z.boolean(),
 })
 
 const ConversationSummarySchema = ConversationParticipantSchema.pick({
@@ -102,36 +73,20 @@ const ConversationSummarySchema = ConversationParticipantSchema.pick({
   canReply: z.boolean().default(false),
   isCallable: z.boolean().default(true),
   myIsCallable: z.boolean().default(true),
-  partnerProfile: ProfileSummarySchema,
+  partnerProfile: MessagingProfileRefSchema,
   lastMessage: MessageInConversationSummarySchema.nullable(),
 })
 
 export type ConversationSummary = z.infer<typeof ConversationSummarySchema>
 
-export type ConversationParticipantWithConversationSummary =
-  Prisma.ConversationParticipantGetPayload<{
-    include: {
-      conversation: {
-        include: {
-          participants: {
-            include: {
-              profile: {
-                include: {
-                  profileImages: true
-                }
-              }
-            }
-          }
-          messages: {
-            take: 1
-            orderBy: {
-              createdAt: 'desc'
-            }
-          }
-        }
-      }
-    }
-  }>
+// Small delta returned by the 'reply' send arm. updatedAt reflects the
+// post-write value of Conversation.updatedAt (set in the same transaction as
+// the message insert), used for inbox ordering.
+export const ConversationPatchSchema = z.object({
+  conversationId: z.string(),
+  updatedAt: z.date(),
+})
+export type ConversationPatch = z.infer<typeof ConversationPatchSchema>
 
 export const SendMessagePayloadSchema = z.object({
   profileId: z.string().cuid(),
@@ -158,7 +113,3 @@ export type SendOutcome = 'new_conversation' | 'accepted_on_reply' | 'reply' | '
 // 'blocked' is never returned on success — it becomes a 403 via MessagingError
 // at the route layer, so the client's SendMessageResponse.outcome can't see it.
 export type SendMessageOutcome = Exclude<SendOutcome, 'blocked'>
-
-// export type ConversationParticipantWithExtras = ConversationParticipantWithConversationSummary & {
-//   unreadCount: number,
-// }


### PR DESCRIPTION
## Summary
Refactored messaging DTOs and API responses to reduce data transfer and complexity by introducing a messaging-specific profile reference type and making `SendMessageResponse` a discriminated union that optimizes the dominant "reply" outcome.

## Key Changes

### DTOs and Types
- Introduced `MessagingProfileRef` schema (id + publicName + thumbnail) as the messaging-owned profile reference, replacing `ProfileSummary` in:
  - `MessageDTO.sender`
  - `ConversationSummary.partnerProfile`
- Removed unused Prisma type exports (`ConversationParticipantWithConversationSummary`, `DbMessageInConversation`, `MessageInConversation`)
- Added `ConversationPatch` type for small conversation deltas (conversationId + updatedAt)
- Made `SendMessageResponse` a discriminated union on `outcome`:
  - `reply` outcome: ships `ConversationPatch` instead of full `ConversationSummary`
  - `new_conversation` and `accepted_on_reply` outcomes: ship full `ConversationSummary`

### Backend Changes
- Updated `messageWithSenderInclude` to select only thumbnail-relevant image data (first image, storagePath only)
- Added `mapMessagingProfileRef()` mapper to build thumbnail URLs server-side from profile images
- Modified `sendMessage()` route to return `conversationPatch` for reply outcomes, avoiding unnecessary `getConversationSummary()` call
- Updated `markConversationRead()` route to return narrow response (conversationId + lastReadAt) instead of full summary
- Updated `fireNewMessageNotifications()` to map messages viewer-specifically (isMine: false for recipient)

### Frontend Changes
- Updated `handleSendResponse()` in messageStore to discriminate on outcome and apply appropriate state updates
- Added `applyReplyToConversation()` method to apply small patches to existing conversations
- Added `upsertConversation()` method for full conversation upserts
- Updated test fixtures to use new `MessagingProfileRef` shape with `thumbnail` field
- Removed unused `ProfileImage` and `ProfileThumbnail` component imports from messaging views
- Updated message toast and conversation list components to render thumbnail URLs directly

### Test Updates
- Refactored test helpers (`makeConvo()`, `makeMessage()`) to reduce boilerplate
- Added comprehensive tests for `handleSendResponse()` discriminated outcomes
- Updated mock mappers to reflect new profile reference shape
- Added tests for thumbnail rendering in message toast component

## Implementation Details
- The `reply` outcome optimization eliminates a database query on the dominant send path (existing conversation reply)
- Thumbnail URLs are built server-side using `imageBasePath()` and the `-thumb.webp` variant
- Profile image selection is narrowed to first image only (position-ordered) to minimize data transfer
- Race condition handling: if a conversation is dropped from the store while a send is in flight, the patch is silently ignored (no fallback fetch)
- `isMine` flag is now always present in `MessageDTO` (required, not optional)

https://claude.ai/code/session_01XrrhGFKzvkcaDoEvuAqiwY