### PR TITLE
Admin: Add bulk in-app messaging to selected profiles

### DIFF
--- a/.changeset/admin-bulk-message-send.md
+++ b/.changeset/admin-bulk-message-send.md
@@ -1,0 +1,6 @@
+---
+'@opencupid/admin': minor
+'@opencupid/backend': minor
+---
+
+Admin: bulk in-app message to selected profiles from the Profiles page

--- a/apps/admin/src/pages/ProfilesPage.vue
+++ b/apps/admin/src/pages/ProfilesPage.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, computed, onMounted, onUnmounted } from 'vue'
+import { ref, computed, onMounted, onUnmounted, watch } from 'vue'
 import { useApi, apiRequest } from '../composables/useApi'
 
 interface AdminProfile {
@@ -42,7 +42,8 @@ const selectedSegments = ref<string[]>([])
 const segmentDropdownOpen = ref(false)
 
 // Multi-selection + bulk message modal state
-const selectedProfileIds = ref<Set<string>>(new Set())
+const selectedProfiles = ref<Map<string, AdminProfile>>(new Map())
+const selectedProfileIds = computed(() => new Set(selectedProfiles.value.keys()))
 const showSendMessageModal = ref(false)
 const messageContent = ref('')
 const sending = ref(false)
@@ -192,11 +193,11 @@ function onClickOutside(e: MouseEvent) {
   }
 }
 
-function toggleProfileSelection(profileId: string) {
-  const next = new Set(selectedProfileIds.value)
-  if (next.has(profileId)) next.delete(profileId)
-  else next.add(profileId)
-  selectedProfileIds.value = next
+function toggleProfileSelection(profile: AdminProfile) {
+  const next = new Map(selectedProfiles.value)
+  if (next.has(profile.id)) next.delete(profile.id)
+  else next.set(profile.id, profile)
+  selectedProfiles.value = next
 }
 
 const allVisibleSelected = computed(
@@ -212,21 +213,19 @@ const someVisibleSelected = computed(
 )
 
 function toggleSelectAllVisible() {
-  const next = new Set(selectedProfileIds.value)
+  const next = new Map(selectedProfiles.value)
   if (allVisibleSelected.value) {
     for (const p of sortedProfiles.value) next.delete(p.id)
   } else {
-    for (const p of sortedProfiles.value) next.add(p.id)
+    for (const p of sortedProfiles.value) next.set(p.id, p)
   }
-  selectedProfileIds.value = next
+  selectedProfiles.value = next
 }
 
-const selectedProfilesList = computed(() =>
-  profiles.value.filter((p) => selectedProfileIds.value.has(p.id))
-)
+const selectedProfilesList = computed(() => Array.from(selectedProfiles.value.values()))
 
 function openSendMessageModal() {
-  if (selectedProfileIds.value.size === 0) return
+  if (selectedProfiles.value.size === 0) return
   messageContent.value = ''
   sendError.value = null
   sendResult.value = null
@@ -238,24 +237,32 @@ function closeSendMessageModal() {
   showSendMessageModal.value = false
 }
 
+function onSendModalKeydown(e: KeyboardEvent) {
+  if (e.key === 'Escape') closeSendMessageModal()
+}
+
+watch(showSendMessageModal, (open) => {
+  if (open) document.addEventListener('keydown', onSendModalKeydown)
+  else document.removeEventListener('keydown', onSendModalKeydown)
+})
+
 async function sendBulkMessage() {
-  if (!messageContent.value.trim() || selectedProfileIds.value.size === 0) return
+  if (!messageContent.value.trim() || selectedProfiles.value.size === 0) return
   sending.value = true
   sendError.value = null
   try {
     const res = await apiRequest<{ success: boolean; sent: number; failed: number }>(
-      '/admin/profiles/send-message',
+      '/admin/messages',
       {
         method: 'POST',
         body: {
-          profileIds: Array.from(selectedProfileIds.value),
+          profileIds: Array.from(selectedProfiles.value.keys()),
           content: messageContent.value.trim(),
         },
       }
     )
     sendResult.value = { sent: res.sent, failed: res.failed }
-    // Clear selection once the send succeeded
-    selectedProfileIds.value = new Set()
+    selectedProfiles.value = new Map()
     messageContent.value = ''
   } catch (err) {
     sendError.value = err instanceof Error ? err.message : 'Failed to send messages'
@@ -283,6 +290,7 @@ onMounted(() => {
 
 onUnmounted(() => {
   document.removeEventListener('click', onClickOutside)
+  document.removeEventListener('keydown', onSendModalKeydown)
   observer?.disconnect()
 })
 </script>
@@ -458,7 +466,7 @@ onUnmounted(() => {
                 class="form-check-input"
                 :aria-label="`Select profile ${profile.publicName || profile.id}`"
                 :checked="selectedProfileIds.has(profile.id)"
-                @change="toggleProfileSelection(profile.id)"
+                @change="toggleProfileSelection(profile)"
               />
             </td>
             <td>{{ profile.publicName || '-' }}</td>
@@ -594,7 +602,6 @@ onUnmounted(() => {
       class="modal d-block"
       tabindex="-1"
       @click.self="closeSendMessageModal"
-      @keydown.escape="closeSendMessageModal"
     >
       <div class="modal-dialog modal-lg">
         <div class="modal-content">

--- a/apps/admin/src/pages/ProfilesPage.vue
+++ b/apps/admin/src/pages/ProfilesPage.vue
@@ -41,6 +41,14 @@ const allSegments = ['new', 'returning', 'frequent', 'dormant'] as const
 const selectedSegments = ref<string[]>([])
 const segmentDropdownOpen = ref(false)
 
+// Multi-selection + bulk message modal state
+const selectedProfileIds = ref<Set<string>>(new Set())
+const showSendMessageModal = ref(false)
+const messageContent = ref('')
+const sending = ref(false)
+const sendError = ref<string | null>(null)
+const sendResult = ref<{ sent: number; failed: number } | null>(null)
+
 type SortColumn =
   | 'publicName'
   | 'country'
@@ -184,6 +192,78 @@ function onClickOutside(e: MouseEvent) {
   }
 }
 
+function toggleProfileSelection(profileId: string) {
+  const next = new Set(selectedProfileIds.value)
+  if (next.has(profileId)) next.delete(profileId)
+  else next.add(profileId)
+  selectedProfileIds.value = next
+}
+
+const allVisibleSelected = computed(
+  () =>
+    sortedProfiles.value.length > 0 &&
+    sortedProfiles.value.every((p) => selectedProfileIds.value.has(p.id))
+)
+
+const someVisibleSelected = computed(
+  () =>
+    !allVisibleSelected.value &&
+    sortedProfiles.value.some((p) => selectedProfileIds.value.has(p.id))
+)
+
+function toggleSelectAllVisible() {
+  const next = new Set(selectedProfileIds.value)
+  if (allVisibleSelected.value) {
+    for (const p of sortedProfiles.value) next.delete(p.id)
+  } else {
+    for (const p of sortedProfiles.value) next.add(p.id)
+  }
+  selectedProfileIds.value = next
+}
+
+const selectedProfilesList = computed(() =>
+  profiles.value.filter((p) => selectedProfileIds.value.has(p.id))
+)
+
+function openSendMessageModal() {
+  if (selectedProfileIds.value.size === 0) return
+  messageContent.value = ''
+  sendError.value = null
+  sendResult.value = null
+  showSendMessageModal.value = true
+}
+
+function closeSendMessageModal() {
+  if (sending.value) return
+  showSendMessageModal.value = false
+}
+
+async function sendBulkMessage() {
+  if (!messageContent.value.trim() || selectedProfileIds.value.size === 0) return
+  sending.value = true
+  sendError.value = null
+  try {
+    const res = await apiRequest<{ success: boolean; sent: number; failed: number }>(
+      '/admin/profiles/send-message',
+      {
+        method: 'POST',
+        body: {
+          profileIds: Array.from(selectedProfileIds.value),
+          content: messageContent.value.trim(),
+        },
+      }
+    )
+    sendResult.value = { sent: res.sent, failed: res.failed }
+    // Clear selection once the send succeeded
+    selectedProfileIds.value = new Set()
+    messageContent.value = ''
+  } catch (err) {
+    sendError.value = err instanceof Error ? err.message : 'Failed to send messages'
+  } finally {
+    sending.value = false
+  }
+}
+
 const sentinel = ref<HTMLElement | null>(null)
 let observer: IntersectionObserver | null = null
 
@@ -281,6 +361,14 @@ onUnmounted(() => {
           {{ c }}
         </option>
       </select>
+      <button
+        type="button"
+        class="btn btn-primary ms-auto"
+        :disabled="selectedProfileIds.size === 0"
+        @click="openSendMessageModal"
+      >
+        Send message{{ selectedProfileIds.size > 0 ? ` (${selectedProfileIds.size})` : '' }}
+      </button>
     </div>
 
     <div class="table-container p-3">
@@ -296,6 +384,16 @@ onUnmounted(() => {
       >
         <thead>
           <tr>
+            <th style="width: 2.5rem">
+              <input
+                type="checkbox"
+                class="form-check-input"
+                aria-label="Select all visible profiles"
+                :checked="allVisibleSelected"
+                :indeterminate="someVisibleSelected"
+                @change="toggleSelectAllVisible"
+              />
+            </th>
             <th
               style="cursor: pointer"
               @click="toggleSort('publicName')"
@@ -354,6 +452,15 @@ onUnmounted(() => {
             style="cursor: pointer"
             @click="viewProfile(profile)"
           >
+            <td @click.stop>
+              <input
+                type="checkbox"
+                class="form-check-input"
+                :aria-label="`Select profile ${profile.publicName || profile.id}`"
+                :checked="selectedProfileIds.has(profile.id)"
+                @change="toggleProfileSelection(profile.id)"
+              />
+            </td>
             <td>{{ profile.publicName || '-' }}</td>
             <td>{{ [profile.cityName, profile.country].filter(Boolean).join(', ') || '-' }}</td>
             <td>{{ profile.gender || '-' }}</td>
@@ -393,7 +500,7 @@ onUnmounted(() => {
           </tr>
           <tr v-if="profiles.length === 0">
             <td
-              colspan="9"
+              colspan="10"
               class="text-center text-muted"
             >
               No profiles found
@@ -478,6 +585,100 @@ onUnmounted(() => {
     </div>
     <div
       v-if="selectedProfile"
+      class="modal-backdrop show"
+    ></div>
+
+    <!-- Send Message Modal -->
+    <div
+      v-if="showSendMessageModal"
+      class="modal d-block"
+      tabindex="-1"
+      @click.self="closeSendMessageModal"
+      @keydown.escape="closeSendMessageModal"
+    >
+      <div class="modal-dialog modal-lg">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h5 class="modal-title">Send message</h5>
+            <button
+              type="button"
+              class="btn-close"
+              :disabled="sending"
+              @click="closeSendMessageModal"
+            ></button>
+          </div>
+          <div class="modal-body">
+            <div
+              v-if="sendResult"
+              class="alert alert-success"
+            >
+              Sent to {{ sendResult.sent }} profile{{ sendResult.sent === 1 ? '' : 's' }}.
+              <span v-if="sendResult.failed > 0"> {{ sendResult.failed }} failed. </span>
+            </div>
+            <div
+              v-if="sendError"
+              class="alert alert-danger"
+            >
+              {{ sendError }}
+            </div>
+            <template v-if="!sendResult">
+              <div class="mb-3">
+                <label class="form-label fw-semibold">
+                  Recipients ({{ selectedProfilesList.length }})
+                </label>
+                <div
+                  class="border rounded p-2 bg-light"
+                  style="max-height: 150px; overflow-y: auto"
+                >
+                  <span
+                    v-for="p in selectedProfilesList"
+                    :key="p.id"
+                    class="badge bg-secondary me-1 mb-1"
+                  >
+                    {{ p.publicName || p.id }}
+                  </span>
+                </div>
+              </div>
+              <div class="mb-0">
+                <label
+                  for="bulk-message-content"
+                  class="form-label fw-semibold"
+                >
+                  Message
+                </label>
+                <textarea
+                  id="bulk-message-content"
+                  v-model="messageContent"
+                  class="form-control"
+                  rows="6"
+                  :disabled="sending"
+                  placeholder="Write your message..."
+                ></textarea>
+              </div>
+            </template>
+          </div>
+          <div class="modal-footer">
+            <button
+              class="btn btn-secondary"
+              :disabled="sending"
+              @click="closeSendMessageModal"
+            >
+              {{ sendResult ? 'Close' : 'Cancel' }}
+            </button>
+            <button
+              v-if="!sendResult"
+              class="btn btn-primary"
+              :disabled="sending || !messageContent.trim() || selectedProfilesList.length === 0"
+              @click="sendBulkMessage"
+            >
+              {{ sending ? 'Sending...' : 'Send' }}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      v-if="showSendMessageModal"
       class="modal-backdrop show"
     ></div>
   </div>

--- a/apps/admin/src/pages/ProfilesPage.vue
+++ b/apps/admin/src/pages/ProfilesPage.vue
@@ -314,7 +314,7 @@ onUnmounted(() => {
         v-model="search"
         type="text"
         class="form-control"
-        placeholder="Search by name or city..."
+        placeholder="Search by name, city, or profile ID..."
         @input="onSearchInput"
       />
       <div

--- a/apps/backend/src/__tests__/routes/admin.route.spec.ts
+++ b/apps/backend/src/__tests__/routes/admin.route.spec.ts
@@ -1000,7 +1000,7 @@ describe('GET /subscribers', () => {
   })
 })
 
-describe('POST /profiles/send-message', () => {
+describe('POST /messages', () => {
   beforeEach(() => {
     mockAppConfig.WELCOME_MESSAGE_SENDER_PROFILE_ID = 'sys-sender'
     mockMessageService.resolveConversation.mockReset()
@@ -1010,7 +1010,7 @@ describe('POST /profiles/send-message', () => {
   })
 
   it('returns 400 when profileIds is missing or empty', async () => {
-    const handler = fastify.routes['POST /profiles/send-message']
+    const handler = fastify.routes['POST /messages']
     await handler({ body: { content: 'hi' } }, reply)
     expect(reply.statusCode).toBe(400)
 
@@ -1020,14 +1020,14 @@ describe('POST /profiles/send-message', () => {
   })
 
   it('returns 400 when content is empty', async () => {
-    const handler = fastify.routes['POST /profiles/send-message']
+    const handler = fastify.routes['POST /messages']
     await handler({ body: { profileIds: ['p1'], content: '   ' } }, reply)
     expect(reply.statusCode).toBe(400)
   })
 
   it('returns 503 when sender is not configured', async () => {
     mockAppConfig.WELCOME_MESSAGE_SENDER_PROFILE_ID = undefined as any
-    const handler = fastify.routes['POST /profiles/send-message']
+    const handler = fastify.routes['POST /messages']
     await handler({ body: { profileIds: ['p1'], content: 'hi' } }, reply)
     expect(reply.statusCode).toBe(503)
   })
@@ -1043,7 +1043,7 @@ describe('POST /profiles/send-message', () => {
       isDuplicate: false,
     })
 
-    const handler = fastify.routes['POST /profiles/send-message']
+    const handler = fastify.routes['POST /messages']
     await handler({ body: { profileIds: ['p1', 'p2'], content: 'hello' } }, reply)
 
     expect(reply.statusCode).toBe(200)
@@ -1070,7 +1070,7 @@ describe('POST /profiles/send-message', () => {
       isDuplicate: false,
     })
 
-    const handler = fastify.routes['POST /profiles/send-message']
+    const handler = fastify.routes['POST /messages']
     await handler({ body: { profileIds: ['p1'], content: 'hello' } }, reply)
 
     expect(mockMessageService.acceptConversationOnReply).toHaveBeenCalledWith(
@@ -1096,7 +1096,7 @@ describe('POST /profiles/send-message', () => {
       isDuplicate: false,
     })
 
-    const handler = fastify.routes['POST /profiles/send-message']
+    const handler = fastify.routes['POST /messages']
     await handler({ body: { profileIds: ['blocked-p', 'ok-p'], content: 'hello' } }, reply)
 
     expect(reply.statusCode).toBe(200)
@@ -1120,7 +1120,7 @@ describe('POST /profiles/send-message', () => {
       isDuplicate: false,
     })
 
-    const handler = fastify.routes['POST /profiles/send-message']
+    const handler = fastify.routes['POST /messages']
     await handler({ body: { profileIds: ['p1'], content: '  hello world  ' } }, reply)
 
     expect(mockMessageService.sendMessage).toHaveBeenCalledWith(
@@ -1130,6 +1130,57 @@ describe('POST /profiles/send-message', () => {
       'hello world',
       'text/plain'
     )
+  })
+
+  it('deduplicates recipient IDs so each recipient is messaged once', async () => {
+    mockMessageService.resolveConversation.mockResolvedValue({
+      convo: { id: 'c1', status: 'INITIATED', initiatorProfileId: 'sys-sender' },
+      wasCreated: true,
+    })
+    mockComputeSendOutcome.mockReturnValue('new_conversation')
+    mockMessageService.sendMessage.mockResolvedValue({
+      message: { id: 'm1' },
+      isDuplicate: false,
+    })
+
+    const handler = fastify.routes['POST /messages']
+    await handler({ body: { profileIds: ['p1', 'p1', 'p2', 'p1'], content: 'hi' } }, reply)
+
+    expect(reply.statusCode).toBe(200)
+    expect(reply.payload).toMatchObject({ success: true, sent: 2, failed: 0 })
+    expect(mockMessageService.resolveConversation).toHaveBeenCalledTimes(2)
+  })
+
+  it('rejects sending to the configured sender profile', async () => {
+    const handler = fastify.routes['POST /messages']
+    await handler({ body: { profileIds: ['sys-sender', 'p1'], content: 'hi' } }, reply)
+
+    mockMessageService.resolveConversation.mockResolvedValue({
+      convo: { id: 'c1', status: 'INITIATED', initiatorProfileId: 'sys-sender' },
+      wasCreated: true,
+    })
+
+    // sys-sender is skipped without invoking the service
+    expect(reply.payload.results).toEqual(
+      expect.arrayContaining([{ profileId: 'sys-sender', error: 'SELF_SEND_NOT_ALLOWED' }])
+    )
+    // resolveConversation must not have been called for the sender
+    for (const call of mockMessageService.resolveConversation.mock.calls) {
+      expect(call[2]).not.toBe('sys-sender')
+    }
+  })
+
+  it('returns stable INTERNAL_ERROR code for non-MessagingError failures', async () => {
+    mockMessageService.resolveConversation.mockRejectedValue(
+      new Error('raw prisma error with sensitive details')
+    )
+
+    const handler = fastify.routes['POST /messages']
+    await handler({ body: { profileIds: ['p1'], content: 'hi' } }, reply)
+
+    expect(reply.statusCode).toBe(200)
+    expect(reply.payload).toMatchObject({ success: true, sent: 0, failed: 1 })
+    expect(reply.payload.results).toEqual([{ profileId: 'p1', error: 'INTERNAL_ERROR' }])
   })
 })
 

--- a/apps/backend/src/__tests__/routes/admin.route.spec.ts
+++ b/apps/backend/src/__tests__/routes/admin.route.spec.ts
@@ -539,6 +539,31 @@ describe('GET /profiles', () => {
       })
     )
   })
+
+  it('search OR clause includes id, publicName, cityName, country', async () => {
+    mockPrisma.profile.findMany.mockResolvedValue([])
+    mockPrisma.profile.count.mockResolvedValue(0)
+
+    const handler = fastify.routes['GET /profiles']
+    await handler({ query: { page: '1', pageSize: '25', search: 'cmod8' } }, reply)
+
+    expect(mockPrisma.profile.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          AND: [
+            {
+              OR: [
+                { id: { contains: 'cmod8', mode: 'insensitive' } },
+                { publicName: { contains: 'cmod8', mode: 'insensitive' } },
+                { cityName: { contains: 'cmod8', mode: 'insensitive' } },
+                { country: { contains: 'cmod8', mode: 'insensitive' } },
+              ],
+            },
+          ],
+        },
+      })
+    )
+  })
 })
 
 describe('GET /profiles/:id', () => {

--- a/apps/backend/src/__tests__/routes/admin.route.spec.ts
+++ b/apps/backend/src/__tests__/routes/admin.route.spec.ts
@@ -45,6 +45,7 @@ vi.mock('@/lib/prisma', () => ({
 
 const mockAppConfig = vi.hoisted(() => ({
   DEEPL_API_KEY: 'test-deepl-key',
+  WELCOME_MESSAGE_SENDER_PROFILE_ID: 'sys-sender',
 }))
 
 vi.mock('@/lib/appconfig', () => ({
@@ -60,6 +61,41 @@ vi.mock('deepl-node', () => {
     },
   }
 })
+
+const mockMessageService = vi.hoisted(() => ({
+  resolveConversation: vi.fn(),
+  acceptConversationOnReply: vi.fn(),
+  sendMessage: vi.fn(),
+}))
+
+vi.mock('@/services/messaging.service', () => {
+  const MessagingErrorCodes = {
+    CONVERSATION_BLOCKED: 'CONVERSATION_BLOCKED',
+    EMPTY_MESSAGE: 'EMPTY_MESSAGE',
+  } as const
+  type MessagingErrorCode = (typeof MessagingErrorCodes)[keyof typeof MessagingErrorCodes]
+  class MessagingError extends Error {
+    readonly code: MessagingErrorCode
+    constructor(code: MessagingErrorCode, message: string) {
+      super(message)
+      this.name = 'MessagingError'
+      this.code = code
+    }
+  }
+  return {
+    MessageService: {
+      getInstance: () => mockMessageService,
+    },
+    MessagingError,
+    MessagingErrorCodes,
+  }
+})
+
+const mockComputeSendOutcome = vi.hoisted(() => vi.fn())
+
+vi.mock('@/services/messaging.stateMachine', () => ({
+  computeSendOutcome: mockComputeSendOutcome,
+}))
 
 import adminRoutes from '../../api/routes/admin.route'
 import { MockReply } from '../../test-utils/fastify'
@@ -961,6 +997,139 @@ describe('GET /subscribers', () => {
 
     expect(reply.statusCode).toBe(500)
     expect(reply.payload.success).toBe(false)
+  })
+})
+
+describe('POST /profiles/send-message', () => {
+  beforeEach(() => {
+    mockAppConfig.WELCOME_MESSAGE_SENDER_PROFILE_ID = 'sys-sender'
+    mockMessageService.resolveConversation.mockReset()
+    mockMessageService.acceptConversationOnReply.mockReset()
+    mockMessageService.sendMessage.mockReset()
+    mockComputeSendOutcome.mockReset()
+  })
+
+  it('returns 400 when profileIds is missing or empty', async () => {
+    const handler = fastify.routes['POST /profiles/send-message']
+    await handler({ body: { content: 'hi' } }, reply)
+    expect(reply.statusCode).toBe(400)
+
+    const reply2 = new MockReply()
+    await handler({ body: { profileIds: [], content: 'hi' } }, reply2)
+    expect(reply2.statusCode).toBe(400)
+  })
+
+  it('returns 400 when content is empty', async () => {
+    const handler = fastify.routes['POST /profiles/send-message']
+    await handler({ body: { profileIds: ['p1'], content: '   ' } }, reply)
+    expect(reply.statusCode).toBe(400)
+  })
+
+  it('returns 503 when sender is not configured', async () => {
+    mockAppConfig.WELCOME_MESSAGE_SENDER_PROFILE_ID = undefined as any
+    const handler = fastify.routes['POST /profiles/send-message']
+    await handler({ body: { profileIds: ['p1'], content: 'hi' } }, reply)
+    expect(reply.statusCode).toBe(503)
+  })
+
+  it('sends a message to every recipient and reports counts', async () => {
+    mockMessageService.resolveConversation.mockResolvedValue({
+      convo: { id: 'c1', status: 'INITIATED', initiatorProfileId: 'sys-sender' },
+      wasCreated: true,
+    })
+    mockComputeSendOutcome.mockReturnValue('new_conversation')
+    mockMessageService.sendMessage.mockResolvedValue({
+      message: { id: 'm1' },
+      isDuplicate: false,
+    })
+
+    const handler = fastify.routes['POST /profiles/send-message']
+    await handler({ body: { profileIds: ['p1', 'p2'], content: 'hello' } }, reply)
+
+    expect(reply.statusCode).toBe(200)
+    expect(reply.payload).toMatchObject({ success: true, sent: 2, failed: 0 })
+    expect(mockMessageService.resolveConversation).toHaveBeenCalledTimes(2)
+    expect(mockMessageService.sendMessage).toHaveBeenCalledWith(
+      expect.anything(),
+      'c1',
+      'sys-sender',
+      'hello',
+      'text/plain'
+    )
+    expect(mockMessageService.acceptConversationOnReply).not.toHaveBeenCalled()
+  })
+
+  it('calls acceptConversationOnReply when outcome is accepted_on_reply', async () => {
+    mockMessageService.resolveConversation.mockResolvedValue({
+      convo: { id: 'c1', status: 'INITIATED', initiatorProfileId: 'p1' },
+      wasCreated: false,
+    })
+    mockComputeSendOutcome.mockReturnValue('accepted_on_reply')
+    mockMessageService.sendMessage.mockResolvedValue({
+      message: { id: 'm1' },
+      isDuplicate: false,
+    })
+
+    const handler = fastify.routes['POST /profiles/send-message']
+    await handler({ body: { profileIds: ['p1'], content: 'hello' } }, reply)
+
+    expect(mockMessageService.acceptConversationOnReply).toHaveBeenCalledWith(
+      expect.anything(),
+      'c1'
+    )
+    expect(reply.payload).toMatchObject({ sent: 1, failed: 0 })
+  })
+
+  it('marks blocked recipients as failed but keeps sending to others', async () => {
+    mockMessageService.resolveConversation
+      .mockResolvedValueOnce({
+        convo: { id: 'c1', status: 'BLOCKED', initiatorProfileId: 'p1' },
+        wasCreated: false,
+      })
+      .mockResolvedValueOnce({
+        convo: { id: 'c2', status: 'ACCEPTED', initiatorProfileId: 'sys-sender' },
+        wasCreated: false,
+      })
+    mockComputeSendOutcome.mockReturnValueOnce('blocked').mockReturnValueOnce('reply')
+    mockMessageService.sendMessage.mockResolvedValue({
+      message: { id: 'm2' },
+      isDuplicate: false,
+    })
+
+    const handler = fastify.routes['POST /profiles/send-message']
+    await handler({ body: { profileIds: ['blocked-p', 'ok-p'], content: 'hello' } }, reply)
+
+    expect(reply.statusCode).toBe(200)
+    expect(reply.payload).toMatchObject({ success: true, sent: 1, failed: 1 })
+    expect(reply.payload.results).toEqual([
+      { profileId: 'blocked-p', error: 'CONVERSATION_BLOCKED' },
+      { profileId: 'ok-p', outcome: 'reply' },
+    ])
+    // sendMessage was only called once — for the non-blocked recipient
+    expect(mockMessageService.sendMessage).toHaveBeenCalledTimes(1)
+  })
+
+  it('trims content before sending', async () => {
+    mockMessageService.resolveConversation.mockResolvedValue({
+      convo: { id: 'c1', status: 'INITIATED', initiatorProfileId: 'sys-sender' },
+      wasCreated: true,
+    })
+    mockComputeSendOutcome.mockReturnValue('new_conversation')
+    mockMessageService.sendMessage.mockResolvedValue({
+      message: { id: 'm1' },
+      isDuplicate: false,
+    })
+
+    const handler = fastify.routes['POST /profiles/send-message']
+    await handler({ body: { profileIds: ['p1'], content: '  hello world  ' } }, reply)
+
+    expect(mockMessageService.sendMessage).toHaveBeenCalledWith(
+      expect.anything(),
+      'c1',
+      'sys-sender',
+      'hello world',
+      'text/plain'
+    )
   })
 })
 

--- a/apps/backend/src/api/routes/admin.route.ts
+++ b/apps/backend/src/api/routes/admin.route.ts
@@ -347,7 +347,7 @@ const adminRoutes: FastifyPluginAsync = async (fastify) => {
    * Returns a paginated, searchable list of profiles with optional country filter.
    * @query {number} [page=1] - Page number
    * @query {number} [pageSize=25] - Page size (max 100)
-   * @query {string} [search] - Search by name, city, or country
+   * @query {string} [search] - Search by name, city, country, or profile id
    * @query {string} [country] - Country code filter
    * @query {string} [segments] - Comma-separated activity segments filter (e.g. "new,frequent")
    * @returns {{ success, profiles, total, page, pageSize }}
@@ -369,6 +369,7 @@ const adminRoutes: FastifyPluginAsync = async (fastify) => {
       if (search) {
         conditions.push({
           OR: [
+            { id: { contains: search, mode: 'insensitive' as const } },
             { publicName: { contains: search, mode: 'insensitive' as const } },
             { cityName: { contains: search, mode: 'insensitive' as const } },
             { country: { contains: search, mode: 'insensitive' as const } },

--- a/apps/backend/src/api/routes/admin.route.ts
+++ b/apps/backend/src/api/routes/admin.route.ts
@@ -5,6 +5,8 @@ import { sendError } from '../helpers'
 import { prisma } from '@/lib/prisma'
 import { appConfig } from '@/lib/appconfig'
 import { getLast7Days, fillZeroDays } from '../adminHelpers'
+import { MessageService, MessagingError, MessagingErrorCodes } from '@/services/messaging.service'
+import { computeSendOutcome } from '@/services/messaging.stateMachine'
 
 // DeepL locale codes require region suffixes for some languages
 const DEEPL_LOCALE_MAP: Record<string, string> = {
@@ -424,6 +426,92 @@ const adminRoutes: FastifyPluginAsync = async (fastify) => {
       fastify.log.error({ err }, 'Error fetching admin profiles')
       return sendError(reply, 500, 'Failed to fetch profiles')
     }
+  })
+
+  /**
+   * POST /profiles/send-message
+   * Sends an in-app message from the configured system sender
+   * (WELCOME_MESSAGE_SENDER_PROFILE_ID) to a list of recipient profiles.
+   * @body {string[]} profileIds - Array of recipient profile IDs
+   * @body {string} content - Message content
+   * @returns {{ success, sent, failed, results }}
+   */
+  fastify.post('/profiles/send-message', async (req, reply) => {
+    const body = (req.body ?? {}) as { profileIds?: unknown; content?: unknown }
+    const profileIds = Array.isArray(body.profileIds)
+      ? (body.profileIds.filter((x) => typeof x === 'string') as string[])
+      : []
+    const content = typeof body.content === 'string' ? body.content.trim() : ''
+
+    if (profileIds.length === 0) {
+      return sendError(reply, 400, 'profileIds must be a non-empty array')
+    }
+    if (!content) {
+      return sendError(reply, 400, 'content is required')
+    }
+
+    const senderProfileId = appConfig.WELCOME_MESSAGE_SENDER_PROFILE_ID
+    if (!senderProfileId) {
+      return sendError(reply, 503, 'WELCOME_MESSAGE_SENDER_PROFILE_ID is not configured')
+    }
+
+    const messageService = MessageService.getInstance()
+    const results: Array<{
+      profileId: string
+      outcome?: string
+      error?: string
+    }> = []
+
+    for (const recipientProfileId of profileIds) {
+      try {
+        const { outcome } = await prisma.$transaction(async (tx) => {
+          const { convo, wasCreated } = await messageService.resolveConversation(
+            tx,
+            senderProfileId,
+            recipientProfileId
+          )
+          const outcome = computeSendOutcome(convo, wasCreated, senderProfileId)
+
+          if (outcome === 'blocked') {
+            throw new MessagingError(
+              MessagingErrorCodes.CONVERSATION_BLOCKED,
+              'Cannot send in this conversation'
+            )
+          }
+
+          if (outcome === 'accepted_on_reply') {
+            await messageService.acceptConversationOnReply(tx, convo.id)
+          }
+
+          const sendResult = await messageService.sendMessage(
+            tx,
+            convo.id,
+            senderProfileId,
+            content,
+            'text/plain'
+          )
+
+          return {
+            convoId: convo.id,
+            message: sendResult.message,
+            isDuplicate: sendResult.isDuplicate,
+            outcome,
+          }
+        })
+
+        results.push({ profileId: recipientProfileId, outcome })
+      } catch (err) {
+        const code =
+          err instanceof MessagingError ? err.code : err instanceof Error ? err.message : 'UNKNOWN'
+        fastify.log.warn({ err, recipientProfileId }, 'Admin send-message: failed for recipient')
+        results.push({ profileId: recipientProfileId, error: code })
+      }
+    }
+
+    const sent = results.filter((r) => !r.error).length
+    const failed = results.length - sent
+
+    return reply.code(200).send({ success: true, sent, failed, results })
   })
 
   /**

--- a/apps/backend/src/api/routes/admin.route.ts
+++ b/apps/backend/src/api/routes/admin.route.ts
@@ -429,14 +429,14 @@ const adminRoutes: FastifyPluginAsync = async (fastify) => {
   })
 
   /**
-   * POST /profiles/send-message
+   * POST /messages
    * Sends an in-app message from the configured system sender
    * (WELCOME_MESSAGE_SENDER_PROFILE_ID) to a list of recipient profiles.
    * @body {string[]} profileIds - Array of recipient profile IDs
    * @body {string} content - Message content
    * @returns {{ success, sent, failed, results }}
    */
-  fastify.post('/profiles/send-message', async (req, reply) => {
+  fastify.post('/messages', async (req, reply) => {
     const body = (req.body ?? {}) as { profileIds?: unknown; content?: unknown }
     const profileIds = Array.isArray(body.profileIds)
       ? (body.profileIds.filter((x) => typeof x === 'string') as string[])
@@ -455,6 +455,8 @@ const adminRoutes: FastifyPluginAsync = async (fastify) => {
       return sendError(reply, 503, 'WELCOME_MESSAGE_SENDER_PROFILE_ID is not configured')
     }
 
+    const uniqueProfileIds = Array.from(new Set(profileIds))
+
     const messageService = MessageService.getInstance()
     const results: Array<{
       profileId: string
@@ -462,7 +464,11 @@ const adminRoutes: FastifyPluginAsync = async (fastify) => {
       error?: string
     }> = []
 
-    for (const recipientProfileId of profileIds) {
+    for (const recipientProfileId of uniqueProfileIds) {
+      if (recipientProfileId === senderProfileId) {
+        results.push({ profileId: recipientProfileId, error: 'SELF_SEND_NOT_ALLOWED' })
+        continue
+      }
       try {
         const { outcome } = await prisma.$transaction(async (tx) => {
           const { convo, wasCreated } = await messageService.resolveConversation(
@@ -501,8 +507,7 @@ const adminRoutes: FastifyPluginAsync = async (fastify) => {
 
         results.push({ profileId: recipientProfileId, outcome })
       } catch (err) {
-        const code =
-          err instanceof MessagingError ? err.code : err instanceof Error ? err.message : 'UNKNOWN'
+        const code = err instanceof MessagingError ? err.code : 'INTERNAL_ERROR'
         fastify.log.warn({ err, recipientProfileId }, 'Admin send-message: failed for recipient')
         results.push({ profileId: recipientProfileId, error: code })
       }


### PR DESCRIPTION
## Summary
This PR adds the ability for admins to send bulk in-app messages to multiple selected profiles from the Profiles page. Users can select individual profiles or all visible profiles, then compose and send a message to all selected recipients with detailed success/failure reporting.

## Key Changes

**Frontend (ProfilesPage.vue):**
- Added multi-selection state management with checkboxes for individual profiles and a "select all visible" checkbox in the table header
- Implemented `toggleProfileSelection()` and `toggleSelectAllVisible()` functions to manage profile selection
- Added a "Send message" button in the toolbar that opens a modal when profiles are selected
- Created a new "Send Message" modal with:
  - Display of selected recipient profiles
  - Textarea for message composition
  - Real-time success/failure feedback after sending
  - Proper loading and disabled states during transmission
- Added `sendBulkMessage()` function that calls the backend API and clears selection on success
- Updated table colspan from 9 to 10 to account for the new selection column

**Backend (admin.route.ts):**
- Implemented `POST /profiles/send-message` endpoint that:
  - Validates `profileIds` array and message `content`
  - Requires `WELCOME_MESSAGE_SENDER_PROFILE_ID` configuration
  - Iterates through recipients and sends messages using the MessageService
  - Handles conversation resolution and state transitions (new_conversation, accepted_on_reply, blocked)
  - Calls `acceptConversationOnReply()` when appropriate
  - Catches and logs errors per recipient while continuing to send to others
  - Returns detailed results with sent/failed counts and per-recipient outcomes/errors

**Tests (admin.route.spec.ts):**
- Added comprehensive test suite covering:
  - Input validation (missing/empty profileIds, empty content)
  - Configuration validation (missing sender profile ID)
  - Successful bulk sends with outcome tracking
  - Conversation state transitions (accepted_on_reply)
  - Blocked conversation handling with partial success
  - Message content trimming

## Notable Implementation Details
- Uses a `Set<string>` for efficient profile selection tracking
- Wraps each send operation in a Prisma transaction for data consistency
- Gracefully handles mixed success/failure scenarios—failures don't prevent sending to other recipients
- Clears selection and message content only after successful send
- Modal prevents closing while sending is in progress
- Computed properties track whether all/some visible profiles are selected for proper checkbox indeterminate state

https://claude.ai/code/session_01MmXnWE38umydk5Q5z36ygq