### PR TITLE
fix(frontend): bump @sentry/vue to 10.50.0, drop session replay (#1373)

### DIFF
--- a/.changeset/iron-replay-quiet.md
+++ b/.changeset/iron-replay-quiet.md
@@ -1,0 +1,5 @@
+---
+'@opencupid/frontend': patch
+---
+
+Bump @sentry/vue to 10.50.0, disable Replay session sampling on iOS-affected routes, revert OsmPoiMap sentry-block band-aid (#1373)

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -27,7 +27,7 @@
     "@fortawesome/free-solid-svg-icons": "7.2.0",
     "@fortawesome/vue-fontawesome": "3.1.3",
     "@openreplay/tracker": "^17.2.6",
-    "@sentry/vue": "9.36.0",
+    "@sentry/vue": "10.50.0",
     "@tolgee/format-icu": "^6.4.0",
     "@tolgee/vue": "^6.4.0",
     "@types/qrcode": "1.5.6",

--- a/apps/frontend/src/features/map/components/OsmPoiMap.vue
+++ b/apps/frontend/src/features/map/components/OsmPoiMap.vue
@@ -27,7 +27,7 @@ defineExpose({ flyToMarker })
   <div class="osm-poi-map-wrapper">
     <div
       ref="mapEl"
-      class="osm-poi-map sentry-block"
+      class="osm-poi-map"
     />
 
     <Teleport

--- a/apps/frontend/src/main.ts
+++ b/apps/frontend/src/main.ts
@@ -1,4 +1,3 @@
-
 import '@/css/fonts.scss'
 import '@/css/bootstrap.scss'
 import '@/css/main.scss'
@@ -25,7 +24,6 @@ import { createBootstrap } from 'bootstrap-vue-next'
 
 import App from './App.vue'
 import router from './router'
-
 
 function initOpenReplay() {
   const { OPENREPLAY_PROJECT_KEY, OPENREPLAY_INGEST_POINT } = __APP_CONFIG__
@@ -58,7 +56,7 @@ async function initSentry(app: ReturnType<typeof createApp>) {
       integrations: [Sentry.browserTracingIntegration({ router }), Sentry.replayIntegration()],
       tracesSampleRate: 1.0,
       tracePropagationTargets: ['localhost', __APP_CONFIG__.FRONTEND_URL],
-      replaysSessionSampleRate: 0.1,
+      replaysSessionSampleRate: 0,
       replaysOnErrorSampleRate: 1.0,
     })
     Sentry.setTag('frontend_origin', __APP_CONFIG__.DOMAIN)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -379,8 +379,8 @@ importers:
         specifier: ^17.2.6
         version: 17.2.6
       '@sentry/vue':
-        specifier: 9.36.0
-        version: 9.36.0(pinia@3.0.4(typescript@5.9.3)(vue@3.5.28(typescript@5.9.3)))(vue@3.5.28(typescript@5.9.3))
+        specifier: 10.50.0
+        version: 10.50.0(pinia@3.0.4(typescript@5.9.3)(vue@3.5.28(typescript@5.9.3)))(vue@3.5.28(typescript@5.9.3))
       '@tolgee/format-icu':
         specifier: ^6.4.0
         version: 6.4.0
@@ -2588,24 +2588,24 @@ packages:
   '@sec-ant/readable-stream@0.4.1':
     resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
 
-  '@sentry-internal/browser-utils@9.36.0':
-    resolution: {integrity: sha512-4cGT7c4kr4DMRlcnErgWiL/uLwHvD8A52w6ffJkT/Bj7olSUjFCo8RKIEsDiJqk8No3yfoS6dRbudMZUIFuDTA==}
+  '@sentry-internal/browser-utils@10.50.0':
+    resolution: {integrity: sha512-42bxyRTxnCmYlWnvz4CxikuQNanw8UNma2WJrtxJ0f1MAJV2GhQGSHDLnA+lvFlmiz6qct3pfen/NXGyOTegTA==}
     engines: {node: '>=18'}
 
-  '@sentry-internal/feedback@9.36.0':
-    resolution: {integrity: sha512-0FNKlP2/CWbitAqtLKVPuSqMs8h7jMJm812wSA0gPpCBVMoX+mWEKQh3pYHYekHVfI0muieX9CWYlup0McXaJA==}
+  '@sentry-internal/feedback@10.50.0':
+    resolution: {integrity: sha512-0k9XZF0wn86f77mIO2U3gNNyDZooy139CnEanRzHinrN106vVzvBZ6TUEQoHtoO1fqQxr+nWWVrqV/PXUqk47w==}
     engines: {node: '>=18'}
 
-  '@sentry-internal/replay-canvas@9.36.0':
-    resolution: {integrity: sha512-/RrYKvQ80gzjEJoHWMFXqYPlQS8ovEUWG2KeSJQdFtvL+/M/864jfxTA21hgHJC/5GbnOq4V541C1P5YVXwg6w==}
+  '@sentry-internal/replay-canvas@10.50.0':
+    resolution: {integrity: sha512-jx6RKBmcJSWdI92qDGS/sBv1w+7Cww879Z/moX7bw7ipHa/Ts3iDcB3rgZwvhmi17U+mvYsbJeL2DXkPo3TjPw==}
     engines: {node: '>=18'}
 
-  '@sentry-internal/replay@9.36.0':
-    resolution: {integrity: sha512-BKxDz4r7bC23d9+zx3a0qkjWLa4zgE/8tXSfcSVYwhczEzTNXYOPxIodYm2IzgVgN9NwUE1m9Cf+/xlKKQLyFQ==}
+  '@sentry-internal/replay@10.50.0':
+    resolution: {integrity: sha512-51FYNfnvVLAWw1rrEWPFfwHuMRb9mkVCFGA4J9/un7SpeGBsQDziGB0Di4fsCxI7+EdSBpfLHPF0csKtCCw0oQ==}
     engines: {node: '>=18'}
 
-  '@sentry/browser@9.36.0':
-    resolution: {integrity: sha512-DCn6VoJCWMjZm5sOfD2+2EgEVdr+H/8Hqs080ruWZo1MZzIUmF1+qnG7AtYeIlm93OydU0PLjvYeWo0zttgGvg==}
+  '@sentry/browser@10.50.0':
+    resolution: {integrity: sha512-1f6rAvET6myiTaSeYqvaaBwvq1LfxqWjAPIoAW/NVC9bPMkeEcuvgDajHrnZMrBeWoJ81NMyoLkyX+iOc7MoFA==}
     engines: {node: '>=18'}
 
   '@sentry/cli@1.77.3':
@@ -2617,8 +2617,8 @@ packages:
     resolution: {integrity: sha512-xCLip2mBwCdRrvXHtVEULX0NffUTYZZBhEUGht0WFL+GNdNQ7gmBOGOczhZlrf2hgFFtDO0fs1xiP9bqq5orEQ==}
     engines: {node: '>=18'}
 
-  '@sentry/core@9.36.0':
-    resolution: {integrity: sha512-LU6EmsXPxi8QFkrx0fCqhXicsJA6uUWCD0VrxePZzs+Xs0SgVNDxOgRELVrZa4LPomQJBR5wmm3Duozp9JkHcQ==}
+  '@sentry/core@10.50.0':
+    resolution: {integrity: sha512-J4A+vzUO3adl0TkFCjaN1+4miamrjHiEIYuLHiuu1lmAjq5WIVw32ObvAh4yMwNtxyaEMosTrrh5M6f12XSJFg==}
     engines: {node: '>=18'}
 
   '@sentry/node-core@10.39.0':
@@ -2662,13 +2662,16 @@ packages:
       '@opentelemetry/sdk-trace-base': ^1.30.1 || ^2.1.0
       '@opentelemetry/semantic-conventions': ^1.39.0
 
-  '@sentry/vue@9.36.0':
-    resolution: {integrity: sha512-rz0yv//WQm18OTIwcVtLfo7YGRd61q981kW3mo7secbXwK15MrfIHNLRiTQvyms3Cby/MvXPZuxCPR6WpMRLgA==}
+  '@sentry/vue@10.50.0':
+    resolution: {integrity: sha512-xo2Nq+74KRh3OuZBVnejDiRZaqbnuUKUi6h2hRefFLnbsN3aU76NR0CekWzaabpczWvQRhLn7DC0s0m+pXeDAQ==}
     engines: {node: '>=18'}
     peerDependencies:
+      '@tanstack/vue-router': ^1.64.0
       pinia: 2.x || 3.x
       vue: 3.5.28
     peerDependenciesMeta:
+      '@tanstack/vue-router':
+        optional: true
       pinia:
         optional: true
 
@@ -10056,31 +10059,31 @@ snapshots:
 
   '@sec-ant/readable-stream@0.4.1': {}
 
-  '@sentry-internal/browser-utils@9.36.0':
+  '@sentry-internal/browser-utils@10.50.0':
     dependencies:
-      '@sentry/core': 9.36.0
+      '@sentry/core': 10.50.0
 
-  '@sentry-internal/feedback@9.36.0':
+  '@sentry-internal/feedback@10.50.0':
     dependencies:
-      '@sentry/core': 9.36.0
+      '@sentry/core': 10.50.0
 
-  '@sentry-internal/replay-canvas@9.36.0':
+  '@sentry-internal/replay-canvas@10.50.0':
     dependencies:
-      '@sentry-internal/replay': 9.36.0
-      '@sentry/core': 9.36.0
+      '@sentry-internal/replay': 10.50.0
+      '@sentry/core': 10.50.0
 
-  '@sentry-internal/replay@9.36.0':
+  '@sentry-internal/replay@10.50.0':
     dependencies:
-      '@sentry-internal/browser-utils': 9.36.0
-      '@sentry/core': 9.36.0
+      '@sentry-internal/browser-utils': 10.50.0
+      '@sentry/core': 10.50.0
 
-  '@sentry/browser@9.36.0':
+  '@sentry/browser@10.50.0':
     dependencies:
-      '@sentry-internal/browser-utils': 9.36.0
-      '@sentry-internal/feedback': 9.36.0
-      '@sentry-internal/replay': 9.36.0
-      '@sentry-internal/replay-canvas': 9.36.0
-      '@sentry/core': 9.36.0
+      '@sentry-internal/browser-utils': 10.50.0
+      '@sentry-internal/feedback': 10.50.0
+      '@sentry-internal/replay': 10.50.0
+      '@sentry-internal/replay-canvas': 10.50.0
+      '@sentry/core': 10.50.0
 
   '@sentry/cli@1.77.3':
     dependencies:
@@ -10096,7 +10099,7 @@ snapshots:
 
   '@sentry/core@10.39.0': {}
 
-  '@sentry/core@9.36.0': {}
+  '@sentry/core@10.50.0': {}
 
   '@sentry/node-core@10.39.0(@opentelemetry/api@1.9.0)(@opentelemetry/context-async-hooks@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.211.0(@opentelemetry/api@1.9.0))(@opentelemetry/resources@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.39.0)':
     dependencies:
@@ -10164,10 +10167,10 @@ snapshots:
       '@opentelemetry/semantic-conventions': 1.39.0
       '@sentry/core': 10.39.0
 
-  '@sentry/vue@9.36.0(pinia@3.0.4(typescript@5.9.3)(vue@3.5.28(typescript@5.9.3)))(vue@3.5.28(typescript@5.9.3))':
+  '@sentry/vue@10.50.0(pinia@3.0.4(typescript@5.9.3)(vue@3.5.28(typescript@5.9.3)))(vue@3.5.28(typescript@5.9.3))':
     dependencies:
-      '@sentry/browser': 9.36.0
-      '@sentry/core': 9.36.0
+      '@sentry/browser': 10.50.0
+      '@sentry/core': 10.50.0
       vue: 3.5.28(typescript@5.9.3)
     optionalDependencies:
       pinia: 3.0.4(typescript@5.9.3)(vue@3.5.28(typescript@5.9.3))


### PR DESCRIPTION
The same iOS-WebKit "Maximum call stack size exceeded" RangeError in
Sentry Replay's rrweb that PR #1291 attempted to fix on PublicProfile
has now resurfaced on /magic-link, a page with a trivially shallow
DOM. PR #1291's `sentry-block` band-aid on OsmPoiMap moved the stack
ceiling but didn't remove the recursion. Recurrence on a shallow DOM
falsifies the depth-of-DOM theory.

- Bump @sentry/vue 9.36.0 -> 10.50.0 to pick up rrweb fixes.
- Set replaysSessionSampleRate to 0; keep replaysOnErrorSampleRate
  at 1.0 so on-error replays still capture, but background session
  replay (the recursion's exposure surface) is off.
- Revert the sentry-block class on OsmPoiMap.vue so the map is no
  longer hidden from replay.