### PR TITLE
fix(frontend): use MIME-type accept so camera capture works in Firefox/Android (#234)

### DIFF
--- a/.changeset/camera-capture-firefox-fix.md
+++ b/.changeset/camera-capture-firefox-fix.md
@@ -1,0 +1,5 @@
+---
+'@opencupid/frontend': patch
+---
+
+Fix "Take Photo" button opening the gallery instead of the camera in Firefox/Android (#234). The image upload input now uses MIME-type values in `accept` so the `capture` attribute is honored across browsers.

--- a/apps/frontend/src/features/images/__tests__/UploadButton.spec.ts
+++ b/apps/frontend/src/features/images/__tests__/UploadButton.spec.ts
@@ -84,4 +84,27 @@ describe('UploadButton', () => {
     const input = wrapper.find('input')
     expect(input.attributes('capture')).toBeUndefined()
   })
+
+  // Firefox on Android only honors `capture` when `accept` lists media MIME
+  // types — file extensions like `.jpg` are ignored and fall back to the
+  // gallery picker. See issue #234.
+  it('uses MIME-type accept values so capture works in Firefox/Android', () => {
+    const wrapper = mount(UploadButton, {
+      props: { capture: 'user' },
+      global: {
+        stubs: {
+          BFormFile: {
+            props: ['accept', 'capture'],
+            template: '<input :accept="accept" :capture="capture" />',
+          },
+          AvatarUploadIcon: true,
+          IconCamera2: true,
+          IconPhoto: true,
+        },
+      },
+    })
+    const accept = wrapper.find('input').attributes('accept') ?? ''
+    expect(accept).toContain('image/')
+    expect(accept).not.toMatch(/\.(jpe?g|png)/i)
+  })
 })

--- a/apps/frontend/src/features/images/__tests__/UploadButton.spec.ts
+++ b/apps/frontend/src/features/images/__tests__/UploadButton.spec.ts
@@ -104,7 +104,12 @@ describe('UploadButton', () => {
       },
     })
     const accept = wrapper.find('input').attributes('accept') ?? ''
-    expect(accept).toContain('image/')
-    expect(accept).not.toMatch(/\.(jpe?g|png)/i)
+    const acceptedMimeTypes = accept
+      .split(',')
+      .map((value) => value.trim())
+      .filter(Boolean)
+      .sort()
+
+    expect(acceptedMimeTypes).toEqual(['image/jpeg', 'image/png'])
   })
 })

--- a/apps/frontend/src/features/images/components/UploadButton.vue
+++ b/apps/frontend/src/features/images/components/UploadButton.vue
@@ -28,7 +28,7 @@ const idAttr = computed(() => 'image-upload-input' + (captureAttr.value ?? ''))
     >
       <BFormFile
         :id="idAttr"
-        accept=".jpg,.jpeg,.png"
+        accept="image/jpeg,image/png"
         ref="fileInput"
         autofocus
         @change="$emit('file:change', $event)"


### PR DESCRIPTION
Firefox on Android only honors the `capture` attribute on a file input
when the `accept` attribute lists media MIME types — file extensions
like `.jpg` are ignored, so tapping "Take Photo" opened the gallery
instead of the camera. Switch the accept value to image MIME types
(`image/jpeg,image/png`), which preserves the same file-type
restriction while letting the capture intent reach the camera app.