### PR TITLE
feat(admin): bulk-send append + WS broadcast (#1377)

### DIFF
--- a/.changeset/admin-broadcast-append.md
+++ b/.changeset/admin-broadcast-append.md
@@ -1,0 +1,5 @@
+---
+'@opencupid/backend': minor
+---
+
+Admin bulk-send: append to existing INITIATED conversations and broadcast to recipients via WebSocket (#1377)

--- a/apps/backend/src/__tests__/routes/admin.route.spec.ts
+++ b/apps/backend/src/__tests__/routes/admin.route.spec.ts
@@ -97,6 +97,18 @@ vi.mock('@/services/messaging.stateMachine', () => ({
   computeSendOutcome: mockComputeSendOutcome,
 }))
 
+const mockBroadcastToProfile = vi.hoisted(() => vi.fn())
+
+vi.mock('@/utils/wsUtils', () => ({
+  broadcastToProfile: mockBroadcastToProfile,
+}))
+
+const mockMapMessageToDTO = vi.hoisted(() => vi.fn((m: any) => ({ ...m, mapped: true })))
+
+vi.mock('../../api/mappers/messaging.mappers', () => ({
+  mapMessageToDTO: mockMapMessageToDTO,
+}))
+
 import adminRoutes from '../../api/routes/admin.route'
 import { MockReply } from '../../test-utils/fastify'
 
@@ -1083,9 +1095,28 @@ describe('POST /messages', () => {
     )
     // System sender is never quarantined: computeSendOutcome must be called with
     // senderIsQuarantined=false so the bulk-send path never produces 'pending'.
+    // Also assert isAdminBroadcast=true so the self-initiated INITIATED override
+    // (#1377) is in effect — without it admins can't follow up to unanswered
+    // welcome threads.
     for (const call of mockComputeSendOutcome.mock.calls) {
       expect(call[3]).toBe(false)
+      expect(call[4]).toBe(true)
     }
+    // WS broadcast fires once per successful recipient with the mapped DTO.
+    expect(mockBroadcastToProfile).toHaveBeenCalledTimes(2)
+    expect(mockBroadcastToProfile).toHaveBeenCalledWith(
+      expect.anything(),
+      'p1',
+      expect.objectContaining({
+        type: 'ws:new_message',
+        payload: expect.objectContaining({ mapped: true }),
+      })
+    )
+    expect(mockBroadcastToProfile).toHaveBeenCalledWith(
+      expect.anything(),
+      'p2',
+      expect.objectContaining({ type: 'ws:new_message' })
+    )
     expect(mockMessageService.acceptConversationOnReply).not.toHaveBeenCalled()
   })
 
@@ -1137,6 +1168,35 @@ describe('POST /messages', () => {
     ])
     // sendMessage was only called once — for the non-blocked recipient
     expect(mockMessageService.sendMessage).toHaveBeenCalledTimes(1)
+    // Likewise, only the non-blocked recipient gets a WS broadcast.
+    expect(mockBroadcastToProfile).toHaveBeenCalledTimes(1)
+    expect(mockBroadcastToProfile).toHaveBeenCalledWith(
+      expect.anything(),
+      'ok-p',
+      expect.objectContaining({ type: 'ws:new_message' })
+    )
+  })
+
+  it('skips WS broadcast when the message was deduplicated', async () => {
+    mockMessageService.resolveConversation.mockResolvedValue({
+      convo: { id: 'c1', status: 'ACCEPTED', initiatorProfileId: 'sys-sender' },
+      wasCreated: false,
+    })
+    mockComputeSendOutcome.mockReturnValue('reply')
+    // Same content sent twice within dedup window: service returns the prior
+    // message and isDuplicate=true. The WS broadcast must NOT fire — the
+    // recipient already got the original.
+    mockMessageService.sendMessage.mockResolvedValue({
+      message: { id: 'm1' },
+      isDuplicate: true,
+    })
+
+    const handler = fastify.routes['POST /messages']
+    await handler({ body: { profileIds: ['p1'], content: 'hello' } }, reply)
+
+    expect(reply.statusCode).toBe(200)
+    expect(reply.payload).toMatchObject({ sent: 1, failed: 0 })
+    expect(mockBroadcastToProfile).not.toHaveBeenCalled()
   })
 
   it('trims content before sending', async () => {

--- a/apps/backend/src/__tests__/routes/admin.route.spec.ts
+++ b/apps/backend/src/__tests__/routes/admin.route.spec.ts
@@ -65,6 +65,7 @@ vi.mock('deepl-node', () => {
 const mockMessageService = vi.hoisted(() => ({
   resolveConversation: vi.fn(),
   acceptConversationOnReply: vi.fn(),
+  promoteConversation: vi.fn(),
   sendMessage: vi.fn(),
 }))
 
@@ -116,6 +117,10 @@ class AdminMockFastify {
   public routes: Record<string, any> = {}
   public hooks: Record<string, any[]> = {}
   public log = { error: vi.fn(), warn: vi.fn(), info: vi.fn() }
+  // Mirrors the WS plugin's profileId → Set<socket> map. Tests pre-populate
+  // entries for recipients they want to receive a broadcast; absent entries
+  // mean "offline" and exercise the pre-check path that skips broadcasting.
+  public connections: Map<string, Set<unknown>> = new Map()
 
   get(path: string, opts: any, handler?: any) {
     this.routes[`GET ${path}`] = typeof opts === 'function' ? opts : handler
@@ -1038,12 +1043,20 @@ describe('GET /subscribers', () => {
 })
 
 describe('POST /messages', () => {
+  // Helper: register a fake socket for `profileId` so the pre-check sees the
+  // recipient as online and the WS broadcast runs.
+  function bringOnline(profileId: string) {
+    fastify.connections.set(profileId, new Set([{}]))
+  }
+
   beforeEach(() => {
     mockAppConfig.WELCOME_MESSAGE_SENDER_PROFILE_ID = 'sys-sender'
     mockMessageService.resolveConversation.mockReset()
     mockMessageService.acceptConversationOnReply.mockReset()
+    mockMessageService.promoteConversation.mockReset()
     mockMessageService.sendMessage.mockReset()
     mockComputeSendOutcome.mockReset()
+    fastify.connections.clear()
   })
 
   it('returns 400 when profileIds is missing or empty', async () => {
@@ -1079,6 +1092,9 @@ describe('POST /messages', () => {
       message: { id: 'm1' },
       isDuplicate: false,
     })
+    // Both recipients online — exercises the broadcast path.
+    bringOnline('p1')
+    bringOnline('p2')
 
     const handler = fastify.routes['POST /messages']
     await handler({ body: { profileIds: ['p1', 'p2'], content: 'hello' } }, reply)
@@ -1156,6 +1172,7 @@ describe('POST /messages', () => {
       message: { id: 'm2' },
       isDuplicate: false,
     })
+    bringOnline('ok-p')
 
     const handler = fastify.routes['POST /messages']
     await handler({ body: { profileIds: ['blocked-p', 'ok-p'], content: 'hello' } }, reply)
@@ -1258,6 +1275,63 @@ describe('POST /messages', () => {
     for (const call of mockMessageService.resolveConversation.mock.calls) {
       expect(call[2]).not.toBe('sys-sender')
     }
+  })
+
+  // accept_and_promote_pending fires when a quarantined user previously sent into
+  // the system sender's profile (creating a PENDING with the user as initiator,
+  // system sender as silent recipient). The admin's bulk-send to that user must
+  // promote the convo + add the system sender as a participant — exactly the
+  // same handling as messaging.route.ts user-to-user.
+  it('promotes + accepts when outcome is accept_and_promote_pending', async () => {
+    mockMessageService.resolveConversation.mockResolvedValue({
+      convo: { id: 'c1', status: 'PENDING', initiatorProfileId: 'p1' },
+      wasCreated: false,
+    })
+    mockComputeSendOutcome.mockReturnValue('accept_and_promote_pending')
+    mockMessageService.sendMessage.mockResolvedValue({
+      message: { id: 'm1' },
+      isDuplicate: false,
+    })
+
+    const handler = fastify.routes['POST /messages']
+    await handler({ body: { profileIds: ['p1'], content: 'hello' } }, reply)
+
+    // promote first, then accept — order matters because acceptConversationOnReply's
+    // updateMany is guarded on status='INITIATED', which is the post-promote state.
+    expect(mockMessageService.promoteConversation).toHaveBeenCalledWith(
+      expect.anything(),
+      'c1',
+      'sys-sender'
+    )
+    expect(mockMessageService.acceptConversationOnReply).toHaveBeenCalledWith(
+      expect.anything(),
+      'c1'
+    )
+    expect(reply.payload).toMatchObject({ sent: 1, failed: 0 })
+  })
+
+  // Pre-check: if the recipient has no active WebSocket connections, skip the
+  // broadcast entirely so we don't fire the warn-log inside broadcastToProfile.
+  // Bulk-sends to mostly-offline audiences would otherwise generate hundreds of
+  // warning lines — see #1382 review thread.
+  it('skips WS broadcast when recipient has no active sockets (no log noise)', async () => {
+    mockMessageService.resolveConversation.mockResolvedValue({
+      convo: { id: 'c1', status: 'INITIATED', initiatorProfileId: 'sys-sender' },
+      wasCreated: true,
+    })
+    mockComputeSendOutcome.mockReturnValue('new_conversation')
+    mockMessageService.sendMessage.mockResolvedValue({
+      message: { id: 'm1' },
+      isDuplicate: false,
+    })
+    // No bringOnline() — recipient is offline.
+
+    const handler = fastify.routes['POST /messages']
+    await handler({ body: { profileIds: ['offline-p'], content: 'hello' } }, reply)
+
+    expect(reply.statusCode).toBe(200)
+    expect(reply.payload).toMatchObject({ sent: 1, failed: 0 })
+    expect(mockBroadcastToProfile).not.toHaveBeenCalled()
   })
 
   it('returns stable INTERNAL_ERROR code for non-MessagingError failures', async () => {

--- a/apps/backend/src/__tests__/services/messaging.stateMachine.spec.ts
+++ b/apps/backend/src/__tests__/services/messaging.stateMachine.spec.ts
@@ -7,44 +7,107 @@ function convo(status: any, initiatorProfileId: string) {
 
 describe('computeSendOutcome', () => {
   it('wasCreated + quarantined → pending', () => {
-    expect(computeSendOutcome(convo('PENDING', 'alice'), true, 'alice', true)).toBe('pending')
+    expect(computeSendOutcome(convo('PENDING', 'alice'), true, 'alice', true, false)).toBe(
+      'pending'
+    )
   })
 
   it('wasCreated + not quarantined → new_conversation', () => {
-    expect(computeSendOutcome(convo('INITIATED', 'alice'), true, 'alice', false)).toBe(
+    expect(computeSendOutcome(convo('INITIATED', 'alice'), true, 'alice', false, false)).toBe(
       'new_conversation'
     )
   })
 
   it('existing PENDING, sender = initiator → pending (regardless of quarantine)', () => {
-    expect(computeSendOutcome(convo('PENDING', 'alice'), false, 'alice', true)).toBe('pending')
-    expect(computeSendOutcome(convo('PENDING', 'alice'), false, 'alice', false)).toBe('pending')
+    expect(computeSendOutcome(convo('PENDING', 'alice'), false, 'alice', true, false)).toBe(
+      'pending'
+    )
+    expect(computeSendOutcome(convo('PENDING', 'alice'), false, 'alice', false, false)).toBe(
+      'pending'
+    )
   })
 
   it('existing PENDING, sender ≠ initiator → accept_and_promote_pending', () => {
-    expect(computeSendOutcome(convo('PENDING', 'alice'), false, 'bob', false)).toBe(
+    expect(computeSendOutcome(convo('PENDING', 'alice'), false, 'bob', false, false)).toBe(
       'accept_and_promote_pending'
     )
   })
 
   it('existing INITIATED, sender ≠ initiator → accepted_on_reply', () => {
-    expect(computeSendOutcome(convo('INITIATED', 'alice'), false, 'bob', false)).toBe(
+    expect(computeSendOutcome(convo('INITIATED', 'alice'), false, 'bob', false, false)).toBe(
       'accepted_on_reply'
     )
   })
 
   it('existing ACCEPTED → reply', () => {
-    expect(computeSendOutcome(convo('ACCEPTED', 'alice'), false, 'alice', false)).toBe('reply')
-    expect(computeSendOutcome(convo('ACCEPTED', 'alice'), false, 'bob', false)).toBe('reply')
+    expect(computeSendOutcome(convo('ACCEPTED', 'alice'), false, 'alice', false, false)).toBe(
+      'reply'
+    )
+    expect(computeSendOutcome(convo('ACCEPTED', 'alice'), false, 'bob', false, false)).toBe(
+      'reply'
+    )
   })
 
-  it('existing INITIATED, sender = initiator → blocked', () => {
-    expect(computeSendOutcome(convo('INITIATED', 'alice'), false, 'alice', false)).toBe('blocked')
+  it('existing INITIATED, sender = initiator, NOT admin → blocked', () => {
+    expect(computeSendOutcome(convo('INITIATED', 'alice'), false, 'alice', false, false)).toBe(
+      'blocked'
+    )
   })
 
   it('BLOCKED / ARCHIVED / DISCARDED → blocked', () => {
-    expect(computeSendOutcome(convo('BLOCKED', 'alice'), false, 'alice', false)).toBe('blocked')
-    expect(computeSendOutcome(convo('ARCHIVED', 'alice'), false, 'alice', false)).toBe('blocked')
-    expect(computeSendOutcome(convo('DISCARDED', 'alice'), false, 'alice', false)).toBe('blocked')
+    expect(computeSendOutcome(convo('BLOCKED', 'alice'), false, 'alice', false, false)).toBe(
+      'blocked'
+    )
+    expect(computeSendOutcome(convo('ARCHIVED', 'alice'), false, 'alice', false, false)).toBe(
+      'blocked'
+    )
+    expect(computeSendOutcome(convo('DISCARDED', 'alice'), false, 'alice', false, false)).toBe(
+      'blocked'
+    )
+  })
+
+  describe('isAdminBroadcast capability (#1377)', () => {
+    // Override semantics: admin-broadcast bypasses the self-initiated INITIATED
+    // anti-spam rule, but does NOT override BLOCKED/ARCHIVED/DISCARDED — those
+    // represent recipient choices that admin must respect.
+
+    it('existing INITIATED, sender = initiator, isAdminBroadcast → reply (override)', () => {
+      expect(computeSendOutcome(convo('INITIATED', 'alice'), false, 'alice', false, true)).toBe(
+        'reply'
+      )
+    })
+
+    it('does NOT override BLOCKED, even when isAdminBroadcast', () => {
+      expect(computeSendOutcome(convo('BLOCKED', 'alice'), false, 'alice', false, true)).toBe(
+        'blocked'
+      )
+    })
+
+    it('does NOT override ARCHIVED, even when isAdminBroadcast', () => {
+      expect(computeSendOutcome(convo('ARCHIVED', 'alice'), false, 'alice', false, true)).toBe(
+        'blocked'
+      )
+    })
+
+    it('does NOT override DISCARDED, even when isAdminBroadcast', () => {
+      expect(computeSendOutcome(convo('DISCARDED', 'alice'), false, 'alice', false, true)).toBe(
+        'blocked'
+      )
+    })
+
+    it('does NOT alter non-blocked outcomes', () => {
+      // Unchanged: ACCEPTED is still 'reply', whether or not admin.
+      expect(computeSendOutcome(convo('ACCEPTED', 'alice'), false, 'alice', false, true)).toBe(
+        'reply'
+      )
+      // Unchanged: PENDING-by-initiator is still 'pending'.
+      expect(computeSendOutcome(convo('PENDING', 'alice'), false, 'alice', false, true)).toBe(
+        'pending'
+      )
+      // Unchanged: new conversation creation still wins over the override branch.
+      expect(computeSendOutcome(convo('INITIATED', 'alice'), true, 'alice', false, true)).toBe(
+        'new_conversation'
+      )
+    })
   })
 })

--- a/apps/backend/src/api/routes/admin.route.ts
+++ b/apps/backend/src/api/routes/admin.route.ts
@@ -7,6 +7,8 @@ import { appConfig } from '@/lib/appconfig'
 import { getLast7Days, fillZeroDays } from '../adminHelpers'
 import { MessageService, MessagingError, MessagingErrorCodes } from '@/services/messaging.service'
 import { computeSendOutcome } from '@/services/messaging.stateMachine'
+import { mapMessageToDTO } from '../mappers/messaging.mappers'
+import { broadcastToProfile } from '@/utils/wsUtils'
 
 // DeepL locale codes require region suffixes for some languages
 const DEEPL_LOCALE_MAP: Record<string, string> = {
@@ -471,7 +473,7 @@ const adminRoutes: FastifyPluginAsync = async (fastify) => {
         continue
       }
       try {
-        const { outcome } = await prisma.$transaction(async (tx) => {
+        const { message, isDuplicate, outcome } = await prisma.$transaction(async (tx) => {
           const { convo, wasCreated } = await messageService.resolveConversation(
             tx,
             senderProfileId,
@@ -507,6 +509,22 @@ const adminRoutes: FastifyPluginAsync = async (fastify) => {
             outcome,
           }
         })
+
+        // Push the message to the recipient over WebSocket if they're online.
+        // Admin broadcasts intentionally do NOT fall back to push/email — that's
+        // a separate product decision (#1377 follow-up). Skip on duplicate (the
+        // dedup window in sendMessage already returned the prior message row).
+        // Failures here must not roll back the persisted send.
+        if (!isDuplicate) {
+          try {
+            broadcastToProfile(fastify, recipientProfileId, {
+              type: 'ws:new_message',
+              payload: mapMessageToDTO(message),
+            })
+          } catch (err) {
+            fastify.log.warn({ err, recipientProfileId }, 'Admin send-message: WS broadcast failed')
+          }
+        }
 
         results.push({ profileId: recipientProfileId, outcome })
       } catch (err) {

--- a/apps/backend/src/api/routes/admin.route.ts
+++ b/apps/backend/src/api/routes/admin.route.ts
@@ -477,8 +477,9 @@ const adminRoutes: FastifyPluginAsync = async (fastify) => {
             senderProfileId,
             recipientProfileId
           )
-          // System sender (WELCOME_MESSAGE_SENDER_PROFILE_ID) is never quarantined.
-          const outcome = computeSendOutcome(convo, wasCreated, senderProfileId, false)
+          // System sender (WELCOME_MESSAGE_SENDER_PROFILE_ID) is never quarantined,
+          // and admin broadcast bypasses the self-initiated re-send block (#1377).
+          const outcome = computeSendOutcome(convo, wasCreated, senderProfileId, false, true)
 
           if (outcome === 'blocked') {
             throw new MessagingError(

--- a/apps/backend/src/api/routes/admin.route.ts
+++ b/apps/backend/src/api/routes/admin.route.ts
@@ -490,6 +490,16 @@ const adminRoutes: FastifyPluginAsync = async (fastify) => {
             )
           }
 
+          // Mirror messaging.route.ts state-transition handling. Required when a
+          // quarantined user previously sent into the system sender's profile —
+          // that creates a PENDING with the user as initiator and the system
+          // sender as the silent recipient. Bulk-send to that user resolves the
+          // PENDING; without these calls the convo would stay PENDING and the
+          // system sender would never become a participant.
+          if (outcome === 'accept_and_promote_pending') {
+            await messageService.promoteConversation(tx, convo.id, senderProfileId)
+            await messageService.acceptConversationOnReply(tx, convo.id)
+          }
           if (outcome === 'accepted_on_reply') {
             await messageService.acceptConversationOnReply(tx, convo.id)
           }
@@ -514,8 +524,12 @@ const adminRoutes: FastifyPluginAsync = async (fastify) => {
         // Admin broadcasts intentionally do NOT fall back to push/email — that's
         // a separate product decision (#1377 follow-up). Skip on duplicate (the
         // dedup window in sendMessage already returned the prior message row).
+        // Pre-check active sockets to avoid log spam from broadcastToProfile,
+        // which warns on every offline recipient — bulk-sends to mostly-offline
+        // audiences would otherwise generate hundreds of warning lines.
         // Failures here must not roll back the persisted send.
-        if (!isDuplicate) {
+        const hasActiveSockets = (fastify.connections?.get(recipientProfileId)?.size ?? 0) > 0
+        if (!isDuplicate && hasActiveSockets) {
           try {
             broadcastToProfile(fastify, recipientProfileId, {
               type: 'ws:new_message',

--- a/apps/backend/src/api/routes/messaging.route.ts
+++ b/apps/backend/src/api/routes/messaging.route.ts
@@ -114,7 +114,13 @@ const messageRoutes: FastifyPluginAsync = async (fastify) => {
           recipientProfileId,
           { createAsPending: senderIsQuarantined }
         )
-        const outcome = computeSendOutcome(convo, wasCreated, senderProfileId, senderIsQuarantined)
+        const outcome = computeSendOutcome(
+          convo,
+          wasCreated,
+          senderProfileId,
+          senderIsQuarantined,
+          false
+        )
 
         if (outcome === 'blocked') {
           throw new MessagingError(

--- a/apps/backend/src/services/messaging.service.ts
+++ b/apps/backend/src/services/messaging.service.ts
@@ -320,7 +320,7 @@ export class MessageService {
       const { convo, wasCreated } = await this.resolveConversation(tx, senderId, recipientProfileId)
       // System welcome sender is never quarantined — hardcode `false`. NOT an admin
       // broadcast either: if a welcome already exists, we want the 'blocked' outcome
-      // so the early-return below skips silently (line 327).
+      // so the early-return below skips silently.
       const outcome = computeSendOutcome(convo, wasCreated, senderId, false, false)
       // If the welcome sender already has an INITIATED convo with this recipient
       // (own pending invite) or anything BLOCKED, skip silently — we never want

--- a/apps/backend/src/services/messaging.service.ts
+++ b/apps/backend/src/services/messaging.service.ts
@@ -318,8 +318,10 @@ export class MessageService {
     const content = simpleMarkdownToHtml(mdContent)
     return await prisma.$transaction(async (tx) => {
       const { convo, wasCreated } = await this.resolveConversation(tx, senderId, recipientProfileId)
-      // System welcome sender is never quarantined — hardcode `false`.
-      const outcome = computeSendOutcome(convo, wasCreated, senderId, false)
+      // System welcome sender is never quarantined — hardcode `false`. NOT an admin
+      // broadcast either: if a welcome already exists, we want the 'blocked' outcome
+      // so the early-return below skips silently (line 327).
+      const outcome = computeSendOutcome(convo, wasCreated, senderId, false, false)
       // If the welcome sender already has an INITIATED convo with this recipient
       // (own pending invite) or anything BLOCKED, skip silently — we never want
       // the welcome flow to enforce state-machine transitions or duplicate sends.

--- a/apps/backend/src/services/messaging.stateMachine.ts
+++ b/apps/backend/src/services/messaging.stateMachine.ts
@@ -11,16 +11,24 @@ export type SendOutcome =
 /**
  * Classifies a send against the conversation state machine.
  *
- * | Condition                                                 | Outcome                       |
- * | --------------------------------------------------------- | ----------------------------- |
- * | wasCreated AND sender quarantined                         | 'pending'                     |
- * | wasCreated AND NOT quarantined                            | 'new_conversation'            |
- * | existing PENDING AND sender = initiator                   | 'pending'                     |
- * | existing PENDING AND sender ≠ initiator                   | 'accept_and_promote_pending'  |
- * | existing INITIATED AND sender ≠ initiator                 | 'accepted_on_reply'           |
- * | existing ACCEPTED                                         | 'reply'                       |
- * | existing INITIATED AND sender = initiator                 | 'blocked'                     |
- * | BLOCKED / ARCHIVED / DISCARDED                            | 'blocked'                     |
+ * | Condition                                                          | Outcome                       |
+ * | ------------------------------------------------------------------ | ----------------------------- |
+ * | wasCreated AND sender quarantined                                  | 'pending'                     |
+ * | wasCreated AND NOT quarantined                                     | 'new_conversation'            |
+ * | existing PENDING AND sender = initiator                            | 'pending'                     |
+ * | existing PENDING AND sender ≠ initiator                            | 'accept_and_promote_pending'  |
+ * | existing INITIATED AND sender ≠ initiator                          | 'accepted_on_reply'           |
+ * | existing ACCEPTED                                                  | 'reply'                       |
+ * | existing INITIATED AND sender = initiator AND NOT isAdminBroadcast | 'blocked'                     |
+ * | existing INITIATED AND sender = initiator AND isAdminBroadcast     | 'reply'                       |
+ * | BLOCKED / ARCHIVED / DISCARDED                                     | 'blocked'                     |
+ *
+ * The self-initiated INITIATED block is an anti-spam rule for human users — don't
+ * pile messages onto an unresponsive contact. Admin broadcast traffic legitimately
+ * needs to follow up with the same recipients (e.g. announcements after the
+ * welcome message), so isAdminBroadcast=true bypasses that one rule. It does NOT
+ * override BLOCKED / ARCHIVED / DISCARDED — admins must not be able to override
+ * a recipient's explicit block.
  *
  * DISCARDED should never be observed in practice (resolveConversation filters it),
  * but it's included for defensive completeness.
@@ -29,7 +37,8 @@ export function computeSendOutcome(
   convo: Pick<Conversation, 'status' | 'initiatorProfileId'>,
   wasCreated: boolean,
   senderProfileId: string,
-  senderIsQuarantined: boolean
+  senderIsQuarantined: boolean,
+  isAdminBroadcast: boolean
 ): SendOutcome {
   if (wasCreated) {
     return senderIsQuarantined ? 'pending' : 'new_conversation'
@@ -41,5 +50,12 @@ export function computeSendOutcome(
     return 'accepted_on_reply'
   }
   if (convo.status === 'ACCEPTED') return 'reply'
+  if (
+    isAdminBroadcast &&
+    convo.status === 'INITIATED' &&
+    convo.initiatorProfileId === senderProfileId
+  ) {
+    return 'reply'
+  }
   return 'blocked'
 }


### PR DESCRIPTION
## Summary
- State machine: admin broadcasts can append to their own unanswered INITIATED conversations (bypasses the user-to-user anti-spam rule that would otherwise reject every recipient with an unanswered welcome message).
- Admin bulk-send: WebSocket broadcast to recipients on each successful send, so online users see realtime updates without refreshing.

## Background
Discovered during UAT of #1368: admin bulk-send to most users returned `CONVERSATION_BLOCKED` because the welcome-message system sender already had an unanswered INITIATED conversation with them. The user-to-user anti-spam rule treats self-initiated INITIATED as 'blocked' — correct for humans, wrong for admin announcements. Issue #1377 documents the design decision; this PR implements it.

A second gap surfaced once the override worked: the admin bulk-send route persisted messages but never notified the recipient. Online users only saw the message on next inbox load. Fixed by mirroring the WS step from the user-to-user route.

## Implementation
- `computeSendOutcome` grows a 5th `isAdminBroadcast: boolean` parameter. When `true`, the self-initiated INITIATED branch returns `'reply'` instead of `'blocked'`. **Does NOT** override BLOCKED / ARCHIVED / DISCARDED — admins must not be able to override a recipient's explicit block.
- All three call sites pass the flag explicitly. Welcome-message path keeps `false` to preserve its silent-skip-on-existing semantics.
- Admin route adds `broadcastToProfile` after the transaction commits per recipient, skipping on duplicate. **No push/email fallback** — admin broadcasts to email is a separate product/legal call (out of scope here).

## Test plan
- [x] `messaging.stateMachine.spec`: 13 tests covering both branches of `isAdminBroadcast` (override on INITIATED self-initiated; no override for BLOCKED/ARCHIVED/DISCARDED; non-blocked outcomes unchanged)
- [x] `admin.route.spec`: WS broadcast fires per successful recipient with the mapped DTO; does NOT fire for blocked recipients; does NOT fire on duplicate; `isAdminBroadcast=true` pinned at the call site
- [x] Full backend test suite green (590/590)
- [x] Backend type-check clean
- [x] Manual UAT: admin bulk-send to a recipient with prior unanswered welcome message now appends successfully + recipient sees the message in realtime via WS

## Stacked on #1368
This PR is based on `feat/abuse-detection` since it depends on `computeSendOutcome`'s existing 4-arg signature and the admin bulk-send route from that branch's UAT fixes. Please merge #1368 first; GitHub will retarget this PR's base to main automatically.

Closes #1377 (state machine half + WS half — push/email fan-out for admin broadcasts is a separate follow-up if desired)

🤖 Generated with [Claude Code](https://claude.com/claude-code)