### PR TITLE
ci(sentry): upload sourcemaps from the same build that ships

### DIFF
--- a/.changeset/itchy-adults-shop.md
+++ b/.changeset/itchy-adults-shop.md
@@ -1,0 +1,5 @@
+---
+
+---
+
+ci(sentry): upload sourcemaps from the same build that ships

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -172,3 +172,28 @@ jobs:
           cache-from: type=gha,scope=${{ matrix.service }}
           cache-to: type=gha,mode=max,scope=${{ matrix.service }}
           tags: ${{ steps.tags.outputs.tags }}
+
+      # Re-run the builder stage with a local export so the *exact* dist/ that
+      # was baked into the pushed image can be picked up by the
+      # sentry-sourcemaps workflow. Building source maps in a separate workflow
+      # would risk producing different chunk hashes (different Node patch,
+      # different native binaries, etc.) and orphaning the deployed bundles.
+      - name: Export builder stage for sourcemap upload
+        if: matrix.service == 'frontend' || matrix.service == 'backend'
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ matrix.context }}
+          file: ${{ matrix.dockerfile }}
+          target: builder
+          platforms: linux/amd64
+          cache-from: type=gha,scope=${{ matrix.service }}
+          outputs: type=local,dest=./builder-out
+
+      - name: Upload dist artifact for sourcemap upload
+        if: matrix.service == 'frontend' || matrix.service == 'backend'
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.service }}-dist
+          path: ./builder-out/app/apps/${{ matrix.service }}/dist
+          if-no-files-found: error
+          retention-days: 7

--- a/.github/workflows/sentry-sourcemaps.yml
+++ b/.github/workflows/sentry-sourcemaps.yml
@@ -4,18 +4,15 @@ on:
   workflow_run:
     workflows: ['Docker Build']
     types: [completed]
-  workflow_dispatch:
 
 permissions:
   contents: read
+  actions: read
 
 jobs:
   sentry-sourcemaps:
     runs-on: ubuntu-latest
-    if: >-
-      (github.event_name == 'workflow_dispatch') ||
-      (github.event.workflow_run.conclusion == 'success')
-    continue-on-error: true
+    if: github.event.workflow_run.conclusion == 'success'
     steps:
       - name: Check Sentry secrets
         id: secrets-check
@@ -27,24 +24,15 @@ jobs:
             echo "has_secrets=true" >> "$GITHUB_OUTPUT"
           fi
 
+      # Check out the same SHA the Docker Build ran against so the package.json
+      # version we extract matches the version that was just baked into the
+      # pushed images. The default workflow_run checkout would use the default
+      # branch HEAD instead, which can drift past the released commit.
       - name: Checkout code
         if: steps.secrets-check.outputs.has_secrets == 'true'
         uses: actions/checkout@v6
-
-      - name: Install pnpm
-        if: steps.secrets-check.outputs.has_secrets == 'true'
-        uses: pnpm/action-setup@v4
-
-      - name: Setup Node.js
-        if: steps.secrets-check.outputs.has_secrets == 'true'
-        uses: actions/setup-node@v6
         with:
-          node-version: '22'
-          cache: 'pnpm'
-
-      - name: Install dependencies
-        if: steps.secrets-check.outputs.has_secrets == 'true'
-        run: pnpm install --frozen-lockfile
+          ref: ${{ github.event.workflow_run.head_sha }}
 
       - name: Extract frontend version
         if: steps.secrets-check.outputs.has_secrets == 'true'
@@ -56,27 +44,45 @@ jobs:
         id: backend-version
         run: echo "version=$(node -p "require('./apps/backend/package.json').version")" >> "$GITHUB_OUTPUT"
 
-      - name: Build frontend
+      - name: Download frontend dist artifact
         if: steps.secrets-check.outputs.has_secrets == 'true'
-        run: pnpm --filter frontend build-only
+        id: download-frontend
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: frontend-dist
+          path: ./apps/frontend/dist
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build backend
+      - name: Download backend dist artifact
         if: steps.secrets-check.outputs.has_secrets == 'true'
-        run: pnpm --filter backend prisma:generate && pnpm --filter backend build
+        id: download-backend
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: backend-dist
+          path: ./apps/backend/dist
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install sentry-cli
+        if: steps.secrets-check.outputs.has_secrets == 'true' && (steps.download-frontend.outcome == 'success' || steps.download-backend.outcome == 'success')
+        run: npm install -g @sentry/cli
 
       - name: Upload frontend sourcemaps
-        if: steps.secrets-check.outputs.has_secrets == 'true'
+        if: steps.secrets-check.outputs.has_secrets == 'true' && steps.download-frontend.outcome == 'success'
         run: |
           VERSION="${{ steps.frontend-version.outputs.version }}"
-          pnpm exec sentry-cli --url $SENTRY_URL releases \
+          sentry-cli --url $SENTRY_URL releases \
             --org $SENTRY_ORG new --project $SENTRY_PROJECT "frontend@${VERSION}"
-          pnpm exec sentry-cli --url $SENTRY_URL releases \
+          sentry-cli --url $SENTRY_URL releases \
             --org $SENTRY_ORG files "frontend@${VERSION}" upload-sourcemaps \
             --project $SENTRY_PROJECT \
             --url-prefix '~/' \
-            --log-level=debug \
+            --log-level=info \
             ./apps/frontend/dist
-          pnpm exec sentry-cli --url $SENTRY_URL releases \
+          sentry-cli --url $SENTRY_URL releases \
             --org $SENTRY_ORG finalize "frontend@${VERSION}"
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
@@ -85,18 +91,18 @@ jobs:
           SENTRY_PROJECT: ${{ vars.SENTRY_PROJECT }}
 
       - name: Upload backend sourcemaps
-        if: steps.secrets-check.outputs.has_secrets == 'true'
+        if: steps.secrets-check.outputs.has_secrets == 'true' && steps.download-backend.outcome == 'success'
         run: |
           VERSION="${{ steps.backend-version.outputs.version }}"
-          pnpm exec sentry-cli --url $SENTRY_URL releases \
+          sentry-cli --url $SENTRY_URL releases \
             --org $SENTRY_ORG new --project $SENTRY_PROJECT "api@${VERSION}"
-          pnpm exec sentry-cli --url $SENTRY_URL releases \
+          sentry-cli --url $SENTRY_URL releases \
             --org $SENTRY_ORG files "api@${VERSION}" upload-sourcemaps \
             --project $SENTRY_PROJECT \
             --url-prefix '~/' \
-            --log-level=debug \
+            --log-level=info \
             ./apps/backend/dist
-          pnpm exec sentry-cli --url $SENTRY_URL releases \
+          sentry-cli --url $SENTRY_URL releases \
             --org $SENTRY_ORG finalize "api@${VERSION}"
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}


### PR DESCRIPTION
The sentry-sourcemaps workflow was rebuilding the frontend/backend on the
GitHub runner, which risks producing different Vite chunk hashes than the
Docker image (different Node patch version, different native binaries),
silently orphaning the deployed bundles with no matching .map.

Have docker-build export the builder stage's dist/ as an artifact, then
have sentry-sourcemaps download that exact directory and run sentry-cli
against it. Also pin the checkout to the workflow_run head SHA so the
extracted package.json version matches the just-released commit, drop
continue-on-error so silent failures surface, and remove workflow_dispatch
(re-trigger via Docker Build instead).