### PR TITLE
fix: drop top-level conversation field from PublicProfileWithContext (#1388)

### DIFF
--- a/.changeset/silver-tags-bloom.md
+++ b/.changeset/silver-tags-bloom.md
@@ -1,0 +1,6 @@
+---
+'@opencupid/backend': patch
+'@opencupid/frontend': patch
+---
+
+Drop top-level `conversation` field from `PublicProfileWithContext` (#1388)

--- a/apps/backend/src/api/mappers/profile.mappers.ts
+++ b/apps/backend/src/api/mappers/profile.mappers.ts
@@ -95,11 +95,9 @@ export function mapProfileWithContext(
   locale: string
 ): PublicProfileWithContext {
   const mapped = mapProfileToPublic(dbProfile, includeDatingContext, locale)
-  const conversation = dbProfile.conversationParticipants?.[0]?.conversation ?? null
   const interactionContext = mapInteractionContext(dbProfile, includeDatingContext)
   return {
     ...mapped,
-    conversation: conversation || null,
     interactionContext,
   } as PublicProfileWithContext
 }

--- a/apps/frontend/src/features/messaging/__tests__/SendMessageForm.spec.ts
+++ b/apps/frontend/src/features/messaging/__tests__/SendMessageForm.spec.ts
@@ -55,7 +55,6 @@ describe('SendMessageForm', () => {
     },
     introSocial: '',
     introDating: '',
-    conversation: null,
     interactionContext: {
       likedByMe: false,
       likedMeRevealed: false,

--- a/packages/shared/zod/profile/profile.dto.ts
+++ b/packages/shared/zod/profile/profile.dto.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod'
 
-import { ProfileSchema, ConversationSchema, UserSchema } from '../generated'
+import { ProfileSchema, UserSchema } from '../generated'
 
 import { PublicTagSchema, type PublicTag } from '../tag/tag.dto'
 import { PublicProfileImageSchema } from './profileimage.dto'
@@ -57,7 +57,6 @@ export const PublicProfileWithContextSchema = ProfileUnionSchema.and(
     tags: z.array(PublicTagSchema).default([]),
     introSocial: z.string().default(''),
     introDating: z.string().default(''),
-    conversation: ConversationSchema.nullable(),
     interactionContext: InteractionContextSchema,
   })
 )


### PR DESCRIPTION
The GET /api/profiles/:id response leaked raw Conversation row state
(including held PENDING status) alongside the policy projection in
interactionContext. The only reader was a dead ActionButtons.vue
component with zero importers, so the field is removed outright with
no replacement logic.