### PR TITLE
ci: simplify docker-build, align Sentry sourcemap upload to pushed images

### DIFF
--- a/.changeset/quiet-maps-align.md
+++ b/.changeset/quiet-maps-align.md
@@ -1,0 +1,5 @@
+---
+'@opencupid/frontend': patch
+---
+
+Include `apps/frontend/package.json` in the nginx runtime image so CI can read the shipped version directly from the image.

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -39,7 +39,7 @@ jobs:
           RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
           PREFIX="ghcr.io/${REPO}"
-          SHA=$(git rev-parse --short HEAD)
+          SHA=$(git rev-parse --short=7 HEAD)
 
           echo "### Build matrix" >> "$GITHUB_STEP_SUMMARY"
           echo "| Service | Version | Build? |" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -15,30 +15,35 @@ permissions:
   packages: write
 
 jobs:
-  detect:
+  build:
     runs-on: ubuntu-latest
-    outputs:
-      matrix: ${{ steps.check.outputs.matrix }}
-      has-builds: ${{ steps.check.outputs.has-builds }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Log in to GitHub Container Registry (GHCR)
-        if: github.event_name == 'release'
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Detect which images need building
-        id: check
+      - name: Build and push images
         env:
           FORCE_IMAGES: ${{ github.event.inputs.images || '' }}
+          REPO: ${{ github.repository }}
+          EVENT: ${{ github.event_name }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
-          PREFIX="ghcr.io/${{ github.repository }}"
-          SERVICES=()
+          PREFIX="ghcr.io/${REPO}"
+          SHA=$(git rev-parse --short HEAD)
+
+          echo "### Build matrix" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Service | Version | Build? |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|---------|---------|--------|" >> "$GITHUB_STEP_SUMMARY"
 
           for SVC in backend frontend admin ingress; do
             VERSION=$(node -p "require('./apps/${SVC}/package.json').version")
@@ -61,114 +66,32 @@ jobs:
               fi
             fi
 
-            if [[ "$BUILD" == "true" ]]; then
-              SERVICES+=("$SVC")
+            if [[ "$BUILD" != "true" ]]; then
+              echo "| ${SVC} | ${VERSION} | ⏭️ |" >> "$GITHUB_STEP_SUMMARY"
+              continue
             fi
-          done
+            echo "| ${SVC} | ${VERSION} | ✅ |" >> "$GITHUB_STEP_SUMMARY"
 
-          # Build the matrix JSON
-          if [[ ${#SERVICES[@]} -eq 0 ]]; then
-            echo "matrix={\"include\":[]}" >> "$GITHUB_OUTPUT"
-            echo "has-builds=false" >> "$GITHUB_OUTPUT"
-            echo "ℹ️ No images need building"
-          else
-            MATRIX='{"include":['
-            FIRST=true
-            for SVC in "${SERVICES[@]}"; do
-              VERSION=$(node -p "require('./apps/${SVC}/package.json').version")
-              case "$SVC" in
-                ingress) CTX="apps/ingress" ;;
-                *)       CTX="." ;;
-              esac
-              if [[ "$FIRST" != "true" ]]; then MATRIX+=","; fi
-              MATRIX+="{\"service\":\"${SVC}\",\"dockerfile\":\"apps/${SVC}/Dockerfile\",\"context\":\"${CTX}\",\"version\":\"${VERSION}\"}"
-              FIRST=false
-            done
-            MATRIX+=']}'
-            echo "matrix=${MATRIX}" >> "$GITHUB_OUTPUT"
-            echo "has-builds=true" >> "$GITHUB_OUTPUT"
-          fi
+            case "$SVC" in
+              ingress) CTX="apps/ingress" ;;
+              *)       CTX="." ;;
+            esac
 
-      - name: Summary
-        env:
-          FORCE_IMAGES: ${{ github.event.inputs.images || '' }}
-        run: |
-          PREFIX="ghcr.io/${{ github.repository }}"
-          echo "### Build matrix" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Service | Version | Build? |" >> "$GITHUB_STEP_SUMMARY"
-          echo "|---------|---------|--------|" >> "$GITHUB_STEP_SUMMARY"
-          for SVC in backend frontend admin ingress; do
-            VERSION=$(node -p "require('./apps/${SVC}/package.json').version")
-            TAG="${PREFIX}-${SVC}:${VERSION}"
-            BUILD="⏭️"
-            if [[ -n "$FORCE_IMAGES" ]]; then
-              if [[ "$FORCE_IMAGES" == "all" || "$FORCE_IMAGES" == *"$SVC"* ]]; then
-                BUILD="✅"
-              fi
-            else
-              if ! docker manifest inspect "$TAG" > /dev/null 2>&1; then
-                BUILD="✅"
-              fi
+            TAG_ARGS=(
+              -t "${PREFIX}-${SVC}:${VERSION}"
+              -t "${PREFIX}-${SVC}:${SHA}"
+              -t "${PREFIX}-${SVC}:latest"
+            )
+            if [[ "$EVENT" == "release" ]]; then
+              TAG_ARGS+=(-t "${PREFIX}-${SVC}:${RELEASE_TAG}")
             fi
-            echo "| ${SVC} | ${VERSION} | ${BUILD} |" >> "$GITHUB_STEP_SUMMARY"
+
+            docker buildx build \
+              --file "apps/${SVC}/Dockerfile" \
+              --platform linux/amd64 \
+              --push \
+              --cache-from "type=gha,scope=${SVC}" \
+              --cache-to "type=gha,mode=max,scope=${SVC}" \
+              "${TAG_ARGS[@]}" \
+              "$CTX"
           done
-
-  build:
-    needs: detect
-    if: needs.detect.outputs.has-builds == 'true'
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix: ${{ fromJson(needs.detect.outputs.matrix) }}
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-
-      - name: Compute image tags
-        id: tags
-        run: |
-          SHA=$(git rev-parse --short HEAD)
-          VERSION="${{ matrix.version }}"
-          PREFIX="ghcr.io/${{ github.repository }}"
-          SVC="${{ matrix.service }}"
-
-          {
-            echo "${PREFIX}-${SVC}:${VERSION}"
-            echo "${PREFIX}-${SVC}:${SHA}"
-            echo "${PREFIX}-${SVC}:latest"
-          } > tags.txt
-
-          if [[ "${{ github.event_name }}" == "release" ]]; then
-            echo "${PREFIX}-${SVC}:${{ github.event.release.tag_name }}" >> tags.txt
-          fi
-
-          {
-            echo "tags<<EOF"
-            cat tags.txt
-            echo "EOF"
-          } >> "$GITHUB_OUTPUT"
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Log in to GitHub Container Registry (GHCR)
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build and push image
-        uses: docker/build-push-action@v6
-        with:
-          context: ${{ matrix.context }}
-          file: ${{ matrix.dockerfile }}
-          platforms: linux/amd64,linux/arm64
-          push: true
-          cache-from: type=gha,scope=${{ matrix.service }}
-          cache-to: type=gha,mode=max,scope=${{ matrix.service }}
-          tags: ${{ steps.tags.outputs.tags }}

--- a/.github/workflows/sentry-sourcemaps.yml
+++ b/.github/workflows/sentry-sourcemaps.yml
@@ -4,18 +4,15 @@ on:
   workflow_run:
     workflows: ['Docker Build']
     types: [completed]
-  workflow_dispatch:
 
 permissions:
   contents: read
+  packages: read
 
 jobs:
   sentry-sourcemaps:
     runs-on: ubuntu-latest
-    if: >-
-      (github.event_name == 'workflow_dispatch') ||
-      (github.event.workflow_run.conclusion == 'success')
-    continue-on-error: true
+    if: github.event.workflow_run.conclusion == 'success'
     steps:
       - name: Check Sentry secrets
         id: secrets-check
@@ -27,79 +24,82 @@ jobs:
             echo "has_secrets=true" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Checkout code
+      - name: Log in to GHCR
         if: steps.secrets-check.outputs.has_secrets == 'true'
-        uses: actions/checkout@v6
-
-      - name: Install pnpm
-        if: steps.secrets-check.outputs.has_secrets == 'true'
-        uses: pnpm/action-setup@v4
-
-      - name: Setup Node.js
-        if: steps.secrets-check.outputs.has_secrets == 'true'
-        uses: actions/setup-node@v6
+        uses: docker/login-action@v3
         with:
-          node-version: '22'
-          cache: 'pnpm'
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Install dependencies
+      - name: Install sentry-cli
         if: steps.secrets-check.outputs.has_secrets == 'true'
-        run: pnpm install --frozen-lockfile
+        run: curl -sL https://sentry.io/get-cli/ | bash
 
-      - name: Extract frontend version
+      - name: Extract frontend dist and version from image
         if: steps.secrets-check.outputs.has_secrets == 'true'
-        id: frontend-version
-        run: echo "version=$(node -p "require('./apps/frontend/package.json').version")" >> "$GITHUB_OUTPUT"
+        id: frontend
+        run: |
+          SHA="${{ github.event.workflow_run.head_sha }}"
+          IMAGE="ghcr.io/${{ github.repository }}-frontend:${SHA:0:7}"
+          docker pull "$IMAGE"
+          CID=$(docker create "$IMAGE")
+          docker cp "$CID:/var/www" ./frontend-dist
+          docker cp "$CID:/app/apps/frontend/package.json" ./frontend-package.json
+          docker rm "$CID"
+          VERSION=$(jq -r .version ./frontend-package.json)
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
 
-      - name: Extract backend version
+      - name: Extract backend dist and version from image
         if: steps.secrets-check.outputs.has_secrets == 'true'
-        id: backend-version
-        run: echo "version=$(node -p "require('./apps/backend/package.json').version")" >> "$GITHUB_OUTPUT"
-
-      - name: Build frontend
-        if: steps.secrets-check.outputs.has_secrets == 'true'
-        run: pnpm --filter frontend build-only
-
-      - name: Build backend
-        if: steps.secrets-check.outputs.has_secrets == 'true'
-        run: pnpm --filter backend prisma:generate && pnpm --filter backend build
+        id: backend
+        run: |
+          SHA="${{ github.event.workflow_run.head_sha }}"
+          IMAGE="ghcr.io/${{ github.repository }}-backend:${SHA:0:7}"
+          docker pull "$IMAGE"
+          CID=$(docker create "$IMAGE")
+          docker cp "$CID:/app/apps/backend/dist" ./backend-dist
+          docker cp "$CID:/app/apps/backend/package.json" ./backend-package.json
+          docker rm "$CID"
+          VERSION=$(jq -r .version ./backend-package.json)
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Upload frontend sourcemaps
         if: steps.secrets-check.outputs.has_secrets == 'true'
-        run: |
-          VERSION="${{ steps.frontend-version.outputs.version }}"
-          pnpm exec sentry-cli --url $SENTRY_URL releases \
-            --org $SENTRY_ORG new --project $SENTRY_PROJECT "frontend@${VERSION}"
-          pnpm exec sentry-cli --url $SENTRY_URL releases \
-            --org $SENTRY_ORG files "frontend@${VERSION}" upload-sourcemaps \
-            --project $SENTRY_PROJECT \
-            --url-prefix '~/' \
-            --log-level=debug \
-            ./apps/frontend/dist
-          pnpm exec sentry-cli --url $SENTRY_URL releases \
-            --org $SENTRY_ORG finalize "frontend@${VERSION}"
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_URL: ${{ vars.SENTRY_URL }}
           SENTRY_ORG: ${{ vars.SENTRY_ORG }}
           SENTRY_PROJECT: ${{ vars.SENTRY_PROJECT }}
+        run: |
+          VERSION="${{ steps.frontend.outputs.version }}"
+          sentry-cli --url "$SENTRY_URL" releases \
+            --org "$SENTRY_ORG" new --project "$SENTRY_PROJECT" "frontend@${VERSION}"
+          sentry-cli --url "$SENTRY_URL" releases \
+            --org "$SENTRY_ORG" files "frontend@${VERSION}" upload-sourcemaps \
+            --project "$SENTRY_PROJECT" \
+            --url-prefix '~/' \
+            --log-level=info \
+            ./frontend-dist
+          sentry-cli --url "$SENTRY_URL" releases \
+            --org "$SENTRY_ORG" finalize "frontend@${VERSION}"
 
       - name: Upload backend sourcemaps
         if: steps.secrets-check.outputs.has_secrets == 'true'
-        run: |
-          VERSION="${{ steps.backend-version.outputs.version }}"
-          pnpm exec sentry-cli --url $SENTRY_URL releases \
-            --org $SENTRY_ORG new --project $SENTRY_PROJECT "api@${VERSION}"
-          pnpm exec sentry-cli --url $SENTRY_URL releases \
-            --org $SENTRY_ORG files "api@${VERSION}" upload-sourcemaps \
-            --project $SENTRY_PROJECT \
-            --url-prefix '~/' \
-            --log-level=debug \
-            ./apps/backend/dist
-          pnpm exec sentry-cli --url $SENTRY_URL releases \
-            --org $SENTRY_ORG finalize "api@${VERSION}"
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_URL: ${{ vars.SENTRY_URL }}
           SENTRY_ORG: ${{ vars.SENTRY_ORG }}
           SENTRY_PROJECT: ${{ vars.SENTRY_PROJECT }}
+        run: |
+          VERSION="${{ steps.backend.outputs.version }}"
+          sentry-cli --url "$SENTRY_URL" releases \
+            --org "$SENTRY_ORG" new --project "$SENTRY_PROJECT" "api@${VERSION}"
+          sentry-cli --url "$SENTRY_URL" releases \
+            --org "$SENTRY_ORG" files "api@${VERSION}" upload-sourcemaps \
+            --project "$SENTRY_PROJECT" \
+            --url-prefix '~/' \
+            --log-level=info \
+            ./backend-dist
+          sentry-cli --url "$SENTRY_URL" releases \
+            --org "$SENTRY_ORG" finalize "api@${VERSION}"

--- a/.github/workflows/sentry-sourcemaps.yml
+++ b/.github/workflows/sentry-sourcemaps.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Install sentry-cli
         if: steps.secrets-check.outputs.has_secrets == 'true'
-        run: curl -sL https://sentry.io/get-cli/ | bash
+        run: npm install --global @sentry/cli@1.77.3
 
       - name: Extract frontend dist and version from image
         if: steps.secrets-check.outputs.has_secrets == 'true'

--- a/apps/frontend/Dockerfile
+++ b/apps/frontend/Dockerfile
@@ -26,6 +26,7 @@ COPY apps/frontend/security-headers.conf.tmpl /etc/nginx/security-headers.conf.t
 COPY apps/frontend/docker-entrypoint.sh /docker-entrypoint.sh
 RUN chmod +x /docker-entrypoint.sh
 COPY --from=builder /app/apps/frontend/dist /var/www
+COPY --from=builder /app/apps/frontend/package.json /app/apps/frontend/package.json
 COPY apps/frontend/config.template.js /var/www/config.template.js
 
 EXPOSE 3001


### PR DESCRIPTION
## Summary
Two related CI changes that together restructure the build → sourcemap pipeline:

- **`docker-build.yml`** — drop ARM platform support, drop per-service `strategy.matrix`, drop QEMU. Collapses `detect` + `build` into a single sequential job that loops through services. Net `+40 / -117`. Skip-if-tag-exists, force-via-`workflow_dispatch`, GHA cache scoped per service, and the step-summary table are all preserved.
- **`sentry-sourcemaps.yml`** — replace the runner-side `pnpm install` + `pnpm build` rebuild with `docker pull` + `docker create` + `docker cp` against the image that Docker Build just pushed. Reads dist *and* the version from inside that image. The `.map` files now reference the chunk hashes that literally shipped, instead of whatever the runner's Vite happens to produce. Drops `workflow_dispatch` (re-trigger via Docker Build instead) and `continue-on-error: true` so silent failures surface.
- **`apps/frontend/Dockerfile`** — one-line `COPY --from=builder /app/apps/frontend/package.json /app/apps/frontend/package.json` so the nginx runtime image carries the version metadata. Lives outside `/var/www`, so nginx never serves it. Mirrors the layout of the backend image and lets sentry-sourcemaps use the same `docker cp` + `jq` pattern for both services.

### Why over PR #1391's strategy
The reverted PR exported the builder stage to a local artifact, hoping the GHA cache would make the second buildx invocation effectively free. The cross-platform build made that "tacked-on" second pass unbearably slow, and it was never tested end-to-end.

Pulling the *already pushed* image instead is byte-deterministic (no probabilistic cache reasoning), self-contained (sentry-sourcemaps needs only the workflow_run head_sha), and adds zero work to docker-build.

### Caveat noted (not addressed here)
The frontend ships `.map` files into `/var/www`, and nginx serves `/assets/` without filtering them. That predates this PR — sourcemaps are already publicly accessible today. Worth a follow-up `location ~ \.map$ { return 404; }` or similar, but orthogonal to the upload-pipeline alignment this PR is concerned with.

## Test plan
- [ ] Docker Build workflow runs to completion, pushes images for any services with new versions.
- [ ] Sentry Sourcemaps workflow triggers via `workflow_run` after Docker Build succeeds.
- [ ] Frontend version is correctly read via `docker cp ... /app/apps/frontend/package.json` + `jq -r .version`.
- [ ] Backend version likewise from `/app/apps/backend/package.json`.
- [ ] `frontend@<ver>` and `api@<ver>` releases appear in Sentry with sourcemaps attached and chunk hashes matching the deployed bundles.
- [ ] A frontend stack trace from production symbolicates to original source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)