### PR TITLE
chore(nginx): block public access to *.map files

### DIFF
--- a/.changeset/quiet-maps-hidden.md
+++ b/.changeset/quiet-maps-hidden.md
@@ -1,0 +1,6 @@
+---
+'@opencupid/frontend': patch
+'@opencupid/admin': patch
+---
+
+Block public access to *.map files via nginx; sourcemaps remain in image for Sentry upload only.

--- a/apps/admin/nginx.conf
+++ b/apps/admin/nginx.conf
@@ -16,6 +16,10 @@ server {
     add_header Cache-Control "no-cache";
   }
 
+  location ~* \.map$ {
+    return 404;
+  }
+
   location /assets/ {
     add_header Cache-Control "public, max-age=43200";
     try_files $uri =404;

--- a/apps/frontend/nginx.conf
+++ b/apps/frontend/nginx.conf
@@ -26,6 +26,10 @@ server {
     types { application/manifest+json webmanifest; }
   }
 
+  location ~* \.map$ {
+    return 404;
+  }
+
   location /assets/ {
     add_header Cache-Control "public, max-age=43200";
     try_files $uri =404;


### PR DESCRIPTION
## Summary
- Add `location ~* \.map$ { return 404; }` to both [apps/frontend/nginx.conf](apps/frontend/nginx.conf) and [apps/admin/nginx.conf](apps/admin/nginx.conf) so sourcemaps shipped in the image are not served over HTTP.
- Sentry/GlitchTip uploads are unaffected: the sourcemap upload step reads `*.map` files directly out of the pushed image via `docker cp`, never via HTTP.

## Why
After v0.55.3, `*.js.map` files are visible in the released frontend image and would be reachable at `https://<host>/assets/<chunk>.js.map`. This exposes prod source code to anyone hitting the URL. A regex location placed before the `/assets/` prefix wins nginx's location-matching order and short-circuits with a clean 404 (no filesystem access, no error log noise).

## Test plan
- [ ] `docker compose up -d --build frontend admin`
- [ ] `curl -i https://localhost:5173/assets/index-FAKEHASH.js.map` → expect `404`
- [ ] `curl -i https://localhost:5173/assets/<real-chunk>.js` → expect `200`
- [ ] After release, hit a real prod `*.js.map` URL → expect `404`
- [ ] Verify Sentry release `frontend@<version>` still has uploaded sourcemaps after next release

🤖 Generated with [Claude Code](https://claude.com/claude-code)