### PR TITLE
feat(backend): detect faces on uploads, mirror onto Profile

### DIFF
--- a/.changeset/silver-mirrors-detect.md
+++ b/.changeset/silver-mirrors-detect.md
@@ -1,0 +1,5 @@
+---
+'@opencupid/backend': patch
+---
+
+Detect faces on profile image uploads and mirror the primary image's face flag onto the profile.

--- a/apps/backend/prisma/migrations/20260427000000_add_has_face_to_profile_image/migration.sql
+++ b/apps/backend/prisma/migrations/20260427000000_add_has_face_to_profile_image/migration.sql
@@ -3,3 +3,6 @@ ALTER TABLE "ProfileImage" ADD COLUMN "hasFace" BOOLEAN NOT NULL DEFAULT false;
 
 -- AlterTable
 ALTER TABLE "Profile" ADD COLUMN "hasFace" BOOLEAN NOT NULL DEFAULT false;
+
+-- CreateIndex
+CREATE INDEX "ProfileImage_profileId_position_idx" ON "ProfileImage"("profileId", "position");

--- a/apps/backend/prisma/migrations/20260427000000_add_has_face_to_profile_image/migration.sql
+++ b/apps/backend/prisma/migrations/20260427000000_add_has_face_to_profile_image/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "ProfileImage" ADD COLUMN "hasFace" BOOLEAN NOT NULL DEFAULT false;
+
+-- AlterTable
+ALTER TABLE "Profile" ADD COLUMN "hasFace" BOOLEAN NOT NULL DEFAULT false;

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -270,6 +270,7 @@ model ProfileImage {
   hasFace     Boolean @default(false)
 
   @@index([userId])
+  @@index([profileId, position])
 }
 
 model Conversation {

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -92,20 +92,20 @@ enum ActivitySegment {
 }
 
 model Tag {
-  id             String              @id @default(cuid())
-  slug           String              @unique
-  name           String              @unique
+  id             String           @id @default(cuid())
+  slug           String           @unique
+  name           String           @unique
   /// Locale the tag was originally created in
-  originalLocale String              @default("en")
-  isUserCreated  Boolean             @default(false)
-  isApproved     Boolean             @default(false)
-  isHidden       Boolean             @default(false)
-  isDeleted      Boolean             @default(false)
+  originalLocale String           @default("en")
+  isUserCreated  Boolean          @default(false)
+  isApproved     Boolean          @default(false)
+  isHidden       Boolean          @default(false)
+  isDeleted      Boolean          @default(false)
   createdBy      String?
-  createdAt      DateTime            @default(now())
-  updatedAt      DateTime            @updatedAt
+  createdAt      DateTime         @default(now())
+  updatedAt      DateTime         @updatedAt
   translations   TagTranslation[]
-  profiles       Profile[]           @relation("ProfileTags")
+  profiles       Profile[]        @relation("ProfileTags")
 }
 
 model TagTranslation {
@@ -173,6 +173,7 @@ model Profile {
   isBlocked      Boolean @default(false)
   isOnboarded    Boolean @default(false)
   isCallable     Boolean @default(true)
+  hasFace        Boolean @default(false)
 
   userId String @unique
   user   User   @relation(fields: [userId], references: [id])
@@ -266,6 +267,7 @@ model ProfileImage {
   blurhash    String?
   isModerated Boolean @default(false)
   isFlagged   Boolean @default(false)
+  hasFace     Boolean @default(false)
 
   @@index([userId])
 }
@@ -440,10 +442,10 @@ model ProfileTrustFlag {
   flaggedBy String
 
   profile Profile @relation(fields: [profileId], references: [id], onDelete: Cascade)
-
-  @@index([profileId, clearedAt])
   // Partial index on active flags is defined in the migration SQL
   // (not representable in Prisma schema syntax).
+
+  @@index([profileId, clearedAt])
 }
 
 enum TrustReason {

--- a/apps/backend/scripts/reprocess-images.ts
+++ b/apps/backend/scripts/reprocess-images.ts
@@ -5,6 +5,7 @@ import { PrismaClient } from '@prisma/client'
 import { ImageService } from '../src/services/image.service'
 import { getMediaRoot, imageBasePath } from '../src/lib/media'
 import { ImageProcessor } from '../src/services/imageprocessor'
+import { syncProfileHasFace } from '../src/services/profile.service'
 
 const prisma = new PrismaClient()
 const imageService = ImageService.getInstance()
@@ -42,10 +43,13 @@ async function main() {
           blurhash: result.blurhash,
           width: result.width ?? null,
           height: result.height ?? null,
+          hasFace: result.hasFace,
         },
       })
 
-      console.log(`✔ ${img.id} → blurhash=${result.blurhash.slice(0, 12)}…`)
+      console.log(
+        `✔ ${img.id} → blurhash=${result.blurhash.slice(0, 12)}… hasFace=${result.hasFace}`
+      )
       success++
     } catch (err) {
       console.error(`❌ Failed to reprocess image ${img.id}:`, err)
@@ -53,7 +57,25 @@ async function main() {
     }
   }
 
-  console.log(`\nDone: ${success} updated, ${skipped} skipped, ${failed} failed`)
+  console.log(`\nImages: ${success} updated, ${skipped} skipped, ${failed} failed`)
+
+  // Mirror Profile.hasFace from the now-current ProfileImage.hasFace at position 0.
+  const profiles = await prisma.profile.findMany({ select: { id: true } })
+  console.log(`\nSyncing Profile.hasFace for ${profiles.length} profiles`)
+
+  let synced = 0
+  let syncFailed = 0
+  for (const p of profiles) {
+    try {
+      await prisma.$transaction((tx) => syncProfileHasFace(tx, p.id))
+      synced++
+    } catch (err) {
+      console.error(`❌ Failed to sync Profile ${p.id}:`, err)
+      syncFailed++
+    }
+  }
+
+  console.log(`Profiles: ${synced} synced, ${syncFailed} failed`)
 }
 
 main()

--- a/apps/backend/src/__tests__/services/image.service.spec.ts
+++ b/apps/backend/src/__tests__/services/image.service.spec.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { createMockPrisma } from '../../test-utils/prisma'
+
+let mockPrisma: any = {}
+vi.mock('../../lib/prisma', () => ({
+  get prisma() {
+    return mockPrisma
+  },
+}))
+
+vi.mock('@/lib/media', () => ({
+  getMediaRoot: () => '/media',
+  imageBasePath: (storagePath: string) => `images/${storagePath}`,
+  makeImageLocation: vi.fn(),
+  mediaUrl: (p: string) => `/media/${p}`,
+}))
+
+const mockUnlink = vi.fn().mockResolvedValue(undefined)
+vi.mock('fs', () => ({
+  default: { promises: { unlink: mockUnlink, mkdir: vi.fn(), readFile: vi.fn() } },
+  promises: { unlink: mockUnlink, mkdir: vi.fn(), readFile: vi.fn() },
+}))
+
+vi.mock('../../services/imageprocessor', () => ({
+  ImageProcessor: class {
+    static initialize = vi.fn()
+  },
+}))
+
+vi.mock('@/utils/hash', () => ({
+  generateContentHash: vi.fn(),
+}))
+
+vi.mock('sharp', () => {
+  const sharp: any = vi.fn()
+  sharp.fit = { cover: 'cover', contain: 'contain', inside: 'inside' }
+  return { default: sharp }
+})
+
+let service: any
+
+beforeEach(async () => {
+  Object.assign(mockPrisma, createMockPrisma())
+  mockUnlink.mockClear()
+  const mod = await import('../../services/image.service')
+  ;(mod.ImageService as any).instance = undefined
+  service = mod.ImageService.getInstance()
+})
+
+describe('ImageService.deleteImage', () => {
+  it('deletes the row, syncs Profile.hasFace, and cleans up files', async () => {
+    mockPrisma.profileImage.findUnique.mockResolvedValue({
+      id: 'img1',
+      profileId: 'p1',
+      storagePath: 'p1/abc',
+    })
+    mockPrisma.profileImage.findFirst.mockResolvedValue({ hasFace: true })
+
+    const ok = await service.deleteImage('p1', 'img1')
+
+    expect(ok).toBe(true)
+    expect(mockPrisma.profileImage.findUnique).toHaveBeenCalledWith({
+      where: { id: 'img1', profileId: 'p1' },
+    })
+    expect(mockPrisma.$transaction).toHaveBeenCalled()
+    expect(mockPrisma.profileImage.delete).toHaveBeenCalledWith({ where: { id: 'img1' } })
+    expect(mockPrisma.profileImage.findFirst).toHaveBeenCalledWith({
+      where: { profileId: 'p1', position: 0 },
+      select: { hasFace: true },
+    })
+    expect(mockPrisma.profile.update).toHaveBeenCalledWith({
+      where: { id: 'p1' },
+      data: { hasFace: true },
+    })
+    // Filesystem cleanup runs after the transaction commits.
+    expect(mockUnlink).toHaveBeenCalled()
+  })
+
+  it('returns false and skips the transaction when the image is not found', async () => {
+    mockPrisma.profileImage.findUnique.mockResolvedValue(null)
+
+    const ok = await service.deleteImage('p1', 'missing')
+
+    expect(ok).toBe(false)
+    expect(mockPrisma.$transaction).not.toHaveBeenCalled()
+    expect(mockPrisma.profileImage.delete).not.toHaveBeenCalled()
+    expect(mockUnlink).not.toHaveBeenCalled()
+  })
+
+  it('returns false and skips file cleanup when the DB delete fails', async () => {
+    mockPrisma.profileImage.findUnique.mockResolvedValue({
+      id: 'img1',
+      profileId: 'p1',
+      storagePath: 'p1/abc',
+    })
+    mockPrisma.profileImage.delete.mockRejectedValue(new Error('boom'))
+
+    const ok = await service.deleteImage('p1', 'img1')
+
+    expect(ok).toBe(false)
+    expect(mockUnlink).not.toHaveBeenCalled()
+  })
+
+  it('writes hasFace=false when no position-0 image remains after delete', async () => {
+    mockPrisma.profileImage.findUnique.mockResolvedValue({
+      id: 'img1',
+      profileId: 'p1',
+      storagePath: 'p1/abc',
+    })
+    mockPrisma.profileImage.findFirst.mockResolvedValue(null)
+
+    await service.deleteImage('p1', 'img1')
+
+    expect(mockPrisma.profile.update).toHaveBeenCalledWith({
+      where: { id: 'p1' },
+      data: { hasFace: false },
+    })
+  })
+})
+
+describe('ImageService.reorderImages', () => {
+  it('updates positions atomically, syncs Profile.hasFace, and returns sorted list', async () => {
+    const items = [
+      { id: 'img1', position: 1 },
+      { id: 'img2', position: 0 },
+    ]
+    mockPrisma.profileImage.findMany.mockResolvedValue([{ id: 'img1' }, { id: 'img2' }])
+    mockPrisma.profileImage.update
+      .mockResolvedValueOnce({ id: 'img1', position: 1 })
+      .mockResolvedValueOnce({ id: 'img2', position: 0 })
+    mockPrisma.profileImage.findFirst.mockResolvedValue({ hasFace: true })
+
+    const result = await service.reorderImages('p1', items)
+
+    expect(mockPrisma.profileImage.findMany).toHaveBeenCalledWith({
+      where: { profileId: 'p1', id: { in: ['img1', 'img2'] } },
+      select: { id: true },
+    })
+    expect(mockPrisma.$transaction).toHaveBeenCalled()
+    expect(mockPrisma.profileImage.update).toHaveBeenCalledWith({
+      where: { id: 'img1' },
+      data: { position: 1 },
+    })
+    expect(mockPrisma.profileImage.update).toHaveBeenCalledWith({
+      where: { id: 'img2' },
+      data: { position: 0 },
+    })
+    expect(mockPrisma.profileImage.findFirst).toHaveBeenCalledWith({
+      where: { profileId: 'p1', position: 0 },
+      select: { hasFace: true },
+    })
+    expect(mockPrisma.profile.update).toHaveBeenCalledWith({
+      where: { id: 'p1' },
+      data: { hasFace: true },
+    })
+    // Sorted ascending by position.
+    expect(result.map((r: any) => r.id)).toEqual(['img2', 'img1'])
+  })
+
+  it('throws when an item id does not belong to the profile', async () => {
+    const items = [
+      { id: 'img1', position: 0 },
+      { id: 'foreign', position: 1 },
+    ]
+    mockPrisma.profileImage.findMany.mockResolvedValue([{ id: 'img1' }])
+
+    await expect(service.reorderImages('p1', items)).rejects.toThrow('Invalid image ID')
+    expect(mockPrisma.$transaction).not.toHaveBeenCalled()
+    expect(mockPrisma.profileImage.update).not.toHaveBeenCalled()
+  })
+})

--- a/apps/backend/src/__tests__/services/imageprocessor.spec.ts
+++ b/apps/backend/src/__tests__/services/imageprocessor.spec.ts
@@ -50,6 +50,20 @@ describe('ImageProcessor', () => {
     expect(processor['faces'].length).toBeGreaterThanOrEqual(0)
   })
 
+  it('hasFaces() reflects detector results', async () => {
+    mockEstimateFaces.mockResolvedValueOnce([])
+    const noFaceProcessor = new ImageProcessor(buffer)
+    await noFaceProcessor.analyze()
+    expect(noFaceProcessor.hasFaces()).toBe(false)
+
+    mockEstimateFaces.mockResolvedValueOnce([
+      { box: { xMin: 0, yMin: 0, xMax: 10, yMax: 10, width: 10, height: 10 }, keypoints: [] },
+    ])
+    const faceProcessor = new ImageProcessor(buffer)
+    await faceProcessor.analyze()
+    expect(faceProcessor.hasFaces()).toBe(true)
+  })
+
   it('can extract and resize cropped image', async () => {
     const processor = new ImageProcessor(buffer)
     await processor.analyze()

--- a/apps/backend/src/__tests__/services/profile.service.spec.ts
+++ b/apps/backend/src/__tests__/services/profile.service.spec.ts
@@ -163,17 +163,46 @@ describe('ProfileService.updateProfileScalars', () => {
 })
 
 describe('ProfileService.addProfileImage', () => {
-  it('connects image to profile', async () => {
-    mockPrisma.profile.update.mockResolvedValue({
+  it('connects image, syncs Profile.hasFace from position-0 image, and returns updated images', async () => {
+    mockPrisma.profile.update.mockResolvedValue({})
+    mockPrisma.profileImage.findFirst.mockResolvedValue({ hasFace: true })
+    mockPrisma.profile.findUniqueOrThrow.mockResolvedValue({
       profileImages: [{ id: 'img1' }],
     })
+
     const result = await service.addProfileImage('p1', 'img1')
+
+    expect(mockPrisma.$transaction).toHaveBeenCalled()
     expect(mockPrisma.profile.update).toHaveBeenCalledWith({
       where: { id: 'p1' },
       data: { profileImages: { connect: { id: 'img1' } } },
+    })
+    expect(mockPrisma.profileImage.findFirst).toHaveBeenCalledWith({
+      where: { profileId: 'p1', position: 0 },
+      select: { hasFace: true },
+    })
+    expect(mockPrisma.profile.update).toHaveBeenCalledWith({
+      where: { id: 'p1' },
+      data: { hasFace: true },
+    })
+    expect(mockPrisma.profile.findUniqueOrThrow).toHaveBeenCalledWith({
+      where: { id: 'p1' },
       select: { profileImages: true },
     })
     expect(result.profileImages).toHaveLength(1)
+  })
+
+  it('writes hasFace=false when no position-0 image exists', async () => {
+    mockPrisma.profile.update.mockResolvedValue({})
+    mockPrisma.profileImage.findFirst.mockResolvedValue(null)
+    mockPrisma.profile.findUniqueOrThrow.mockResolvedValue({ profileImages: [] })
+
+    await service.addProfileImage('p1', 'img1')
+
+    expect(mockPrisma.profile.update).toHaveBeenCalledWith({
+      where: { id: 'p1' },
+      data: { hasFace: false },
+    })
   })
 })
 

--- a/apps/backend/src/api/routes/image.route.ts
+++ b/apps/backend/src/api/routes/image.route.ts
@@ -133,7 +133,7 @@ const imageRoutes: FastifyPluginAsync = async (fastify) => {
     const { id: profileImageId } = IdLookupParamsSchema.parse(req.params)
 
     try {
-      const ok = await imageService.deleteImage(req.user.userId, profileImageId)
+      const ok = await imageService.deleteImage(req.session.profileId, profileImageId)
       if (!ok) {
         return sendError(reply, 500, 'Failed to delete image')
       }
@@ -160,7 +160,7 @@ const imageRoutes: FastifyPluginAsync = async (fastify) => {
     const { images } = ReorderProfileImagesPayloadSchema.parse(req.body)
 
     try {
-      const updated = await imageService.reorderImages(req.user.userId, images)
+      const updated = await imageService.reorderImages(req.session.profileId, images)
       const ownerImages = mapProfileImagesToOwner(updated)
       const response: ImageApiResponse = { success: true, images: ownerImages }
       return reply.code(200).send(response)

--- a/apps/backend/src/services/image.service.ts
+++ b/apps/backend/src/services/image.service.ts
@@ -1,6 +1,7 @@
 import path from 'path'
 import fs from 'fs'
 
+import { Prisma } from '@prisma/client'
 import { prisma } from '../lib/prisma'
 import { getMediaRoot, imageBasePath, makeImageLocation, mediaUrl } from '@/lib/media'
 
@@ -11,6 +12,7 @@ import type { ProfileImage } from '@zod/generated'
 import sharp from 'sharp'
 
 import { ImageProcessor } from './imageprocessor'
+import { syncProfileHasFace } from './profile.service'
 
 type Variant = {
   name: string
@@ -117,6 +119,7 @@ export class ImageService {
           isModerated: false,
           contentHash: contentHash,
           blurhash: processed.blurhash,
+          hasFace: processed.hasFace,
           position: position,
         },
       })
@@ -149,6 +152,7 @@ export class ImageService {
       mime: processor.getMime(),
       variants: outputPaths,
       blurhash,
+      hasFace: processor.hasFaces(),
     }
   }
 
@@ -166,6 +170,7 @@ export class ImageService {
       ...processor.getOriginalSize(),
       variants: outputPaths,
       blurhash,
+      hasFace: processor.hasFaces(),
     }
   }
 
@@ -211,21 +216,22 @@ export class ImageService {
 
   /**
    * Delete a ProfileImage record
-   * @param userId - ID of the user who owns the image
+   * @param profileId - ID of the profile that owns the image
    * @param imageId - ID of the image to delete
    * Returns true if successful, false if not
    */
-  async deleteImage(userId: string, imageId: string): Promise<boolean> {
+  async deleteImage(profileId: string, imageId: string): Promise<boolean> {
     const image = await prisma.profileImage.findUnique({
-      where: { id: imageId, userId },
+      where: { id: imageId, profileId },
     })
     if (!image) {
-      console.warn('Image not found or does not belong to user')
+      console.warn('Image not found or does not belong to profile')
       return false
     }
     try {
-      await prisma.profileImage.delete({
-        where: { id: image.id },
+      await prisma.$transaction(async (tx) => {
+        await tx.profileImage.delete({ where: { id: image.id } })
+        await syncProfileHasFace(tx, profileId)
       })
     } catch (err) {
       console.error('Error deleting image from database:', err)
@@ -253,31 +259,32 @@ export class ImageService {
 
   /**
    * Reorder images by updating their positions
-   * @param userId - ID of the user whose images are being reordered
+   * @param profileId - ID of the profile whose images are being reordered
    * @param items - Array of image IDs and their new positions
    * Returns the updated images sorted by position
    */
-  async reorderImages(userId: string, items: ProfileImagePosition[]) {
+  async reorderImages(profileId: string, items: ProfileImagePosition[]) {
     const valid = await prisma.profileImage.findMany({
-      where: { userId, id: { in: items.map((i) => i.id) } },
+      where: { profileId, id: { in: items.map((i) => i.id) } },
       select: { id: true },
     })
 
-    const validIds = new Set(valid.map((v: any) => v.id))
+    const validIds = new Set(valid.map((v) => v.id))
     if (items.some((i) => !validIds.has(i.id))) {
       throw new Error('Invalid image ID')
     }
 
-    // Bulk‐update positions in a single transaction
-    const ops = items.map((item) =>
-      prisma.profileImage.update({
-        where: { id: item.id },
-        data: { position: item.position },
-      })
-    )
-    const updated = await prisma.$transaction(ops)
-
-    // Return them sorted by position
-    return updated.sort((a: any, b: any) => a.position - b.position)
+    return prisma.$transaction(async (tx) => {
+      const updated = await Promise.all(
+        items.map((item) =>
+          tx.profileImage.update({
+            where: { id: item.id },
+            data: { position: item.position },
+          })
+        )
+      )
+      await syncProfileHasFace(tx, profileId)
+      return updated.sort((a, b) => a.position - b.position)
+    })
   }
 }

--- a/apps/backend/src/services/image.service.ts
+++ b/apps/backend/src/services/image.service.ts
@@ -1,7 +1,6 @@
 import path from 'path'
 import fs from 'fs'
 
-import { Prisma } from '@prisma/client'
 import { prisma } from '../lib/prisma'
 import { getMediaRoot, imageBasePath, makeImageLocation, mediaUrl } from '@/lib/media'
 
@@ -275,14 +274,15 @@ export class ImageService {
     }
 
     return prisma.$transaction(async (tx) => {
-      const updated = await Promise.all(
-        items.map((item) =>
-          tx.profileImage.update({
+      const updated = []
+      for (const item of items) {
+        updated.push(
+          await tx.profileImage.update({
             where: { id: item.id },
             data: { position: item.position },
           })
         )
-      )
+      }
       await syncProfileHasFace(tx, profileId)
       return updated.sort((a, b) => a.position - b.position)
     })

--- a/apps/backend/src/services/imageprocessor.ts
+++ b/apps/backend/src/services/imageprocessor.ts
@@ -168,6 +168,10 @@ export class ImageProcessor {
     }
   }
 
+  hasFaces(): boolean {
+    return this.faces.length > 0
+  }
+
   async encodeBlurhash(componentX = 4, componentY = 3): Promise<string> {
     const { data, info } = await sharp(this.buffer, { failOn: 'error' })
       .resize(32, 32, { fit: 'inside' })

--- a/apps/backend/src/services/profile.service.ts
+++ b/apps/backend/src/services/profile.service.ts
@@ -23,6 +23,25 @@ import {
   tagsInclude,
 } from '@/db/includes/profileIncludes'
 
+/**
+ * Mirror Profile.hasFace from the position-0 ProfileImage of that profile.
+ * Falls back to false when no image occupies position 0. Caller must run
+ * this inside a transaction so the read and write stay consistent.
+ */
+export async function syncProfileHasFace(
+  tx: Prisma.TransactionClient,
+  profileId: string
+): Promise<void> {
+  const primary = await tx.profileImage.findFirst({
+    where: { profileId, position: 0 },
+    select: { hasFace: true },
+  })
+  await tx.profile.update({
+    where: { id: profileId },
+    data: { hasFace: primary?.hasFace ?? false },
+  })
+}
+
 export class ProfileService {
   private static instance: ProfileService
 
@@ -350,16 +369,16 @@ export class ProfileService {
   ): Promise<{
     profileImages: ProfileImage[]
   }> {
-    return prisma.profile.update({
-      where: {
-        id: profileId,
-      },
-      data: {
-        profileImages: { connect: { id: imageId } },
-      },
-      select: {
-        profileImages: true,
-      },
+    return prisma.$transaction(async (tx) => {
+      await tx.profile.update({
+        where: { id: profileId },
+        data: { profileImages: { connect: { id: imageId } } },
+      })
+      await syncProfileHasFace(tx, profileId)
+      return tx.profile.findUniqueOrThrow({
+        where: { id: profileId },
+        select: { profileImages: true },
+      })
     })
   }
 

--- a/apps/backend/src/services/profile.service.ts
+++ b/apps/backend/src/services/profile.service.ts
@@ -369,16 +369,16 @@ export class ProfileService {
   ): Promise<{
     profileImages: ProfileImage[]
   }> {
-    return prisma.$transaction(async (tx) => {
-      await tx.profile.update({
-        where: { id: profileId },
-        data: { profileImages: { connect: { id: imageId } } },
-      })
-      await syncProfileHasFace(tx, profileId)
-      return tx.profile.findUniqueOrThrow({
-        where: { id: profileId },
-        select: { profileImages: true },
-      })
+    return prisma.profile.update({
+      where: {
+        id: profileId,
+      },
+      data: {
+        profileImages: { connect: { id: imageId } },
+      },
+      select: {
+        profileImages: true,
+      },
     })
   }
 

--- a/apps/backend/src/services/profile.service.ts
+++ b/apps/backend/src/services/profile.service.ts
@@ -369,16 +369,16 @@ export class ProfileService {
   ): Promise<{
     profileImages: ProfileImage[]
   }> {
-    return prisma.profile.update({
-      where: {
-        id: profileId,
-      },
-      data: {
-        profileImages: { connect: { id: imageId } },
-      },
-      select: {
-        profileImages: true,
-      },
+    return prisma.$transaction(async (tx) => {
+      await tx.profile.update({
+        where: { id: profileId },
+        data: { profileImages: { connect: { id: imageId } } },
+      })
+      await syncProfileHasFace(tx, profileId)
+      return tx.profile.findUniqueOrThrow({
+        where: { id: profileId },
+        select: { profileImages: true },
+      })
     })
   }
 

--- a/apps/backend/src/test-utils/prisma.ts
+++ b/apps/backend/src/test-utils/prisma.ts
@@ -20,6 +20,7 @@ export function createMockPrisma() {
     },
     profileImage: {
       findUnique: vi.fn(),
+      findFirst: vi.fn(),
       findMany: vi.fn(),
       create: vi.fn(),
       update: vi.fn(),

--- a/packages/shared/zod/generated/index.ts
+++ b/packages/shared/zod/generated/index.ts
@@ -20,11 +20,11 @@ export const ConnectionRequestScalarFieldEnumSchema = z.enum(['id','fromUserId',
 
 export const UserScalarFieldEnumSchema = z.enum(['id','email','phonenumber','tokenVersion','loginToken','loginTokenExp','isActive','isBlocked','isRegistrationConfirmed','createdAt','updatedAt','lastLoginAt','language','originDomain','newsletterOptIn','roles','isPushNotificationEnabled']);
 
-export const ProfileScalarFieldEnumSchema = z.enum(['id','publicName','country','cityName','isSocialActive','isDatingActive','isActive','isReported','isBlocked','isOnboarded','isCallable','userId','work','languages','birthday','gender','pronouns','relationship','hasKids','prefAgeMin','prefAgeMax','prefGender','prefKids','lat','lon','createdAt','updatedAt']);
+export const ProfileScalarFieldEnumSchema = z.enum(['id','publicName','country','cityName','isSocialActive','isDatingActive','isActive','isReported','isBlocked','isOnboarded','isCallable','hasFace','userId','work','languages','birthday','gender','pronouns','relationship','hasKids','prefAgeMin','prefAgeMax','prefGender','prefKids','lat','lon','createdAt','updatedAt']);
 
 export const LocalizedProfileFieldScalarFieldEnumSchema = z.enum(['id','profileId','field','locale','value']);
 
-export const ProfileImageScalarFieldEnumSchema = z.enum(['id','userId','profileId','position','altText','storagePath','url','width','height','mimeType','createdAt','updatedAt','contentHash','blurhash','isModerated','isFlagged']);
+export const ProfileImageScalarFieldEnumSchema = z.enum(['id','userId','profileId','position','altText','storagePath','url','width','height','mimeType','createdAt','updatedAt','contentHash','blurhash','isModerated','isFlagged','hasFace']);
 
 export const ConversationScalarFieldEnumSchema = z.enum(['id','createdAt','updatedAt','profileAId','profileBId','status','initiatorProfileId','jitsiRoomId']);
 
@@ -201,6 +201,7 @@ export const ProfileSchema = z.object({
   isBlocked: z.boolean(),
   isOnboarded: z.boolean(),
   isCallable: z.boolean(),
+  hasFace: z.boolean(),
   userId: z.string(),
   work: z.string(),
   languages: z.string().array(),
@@ -250,6 +251,7 @@ export const ProfileImageSchema = z.object({
   blurhash: z.string().nullable(),
   isModerated: z.boolean(),
   isFlagged: z.boolean(),
+  hasFace: z.boolean(),
 })
 
 export type ProfileImage = z.infer<typeof ProfileImageSchema>
@@ -640,6 +642,7 @@ export const ProfileSelectSchema: z.ZodType<Prisma.ProfileSelect> = z.object({
   isBlocked: z.boolean().optional(),
   isOnboarded: z.boolean().optional(),
   isCallable: z.boolean().optional(),
+  hasFace: z.boolean().optional(),
   userId: z.boolean().optional(),
   work: z.boolean().optional(),
   languages: z.boolean().optional(),
@@ -729,6 +732,7 @@ export const ProfileImageSelectSchema: z.ZodType<Prisma.ProfileImageSelect> = z.
   blurhash: z.boolean().optional(),
   isModerated: z.boolean().optional(),
   isFlagged: z.boolean().optional(),
+  hasFace: z.boolean().optional(),
   user: z.union([z.boolean(),z.lazy(() => UserArgsSchema)]).optional(),
   profile: z.union([z.boolean(),z.lazy(() => ProfileArgsSchema)]).optional(),
 }).strict()
@@ -1486,6 +1490,7 @@ export const ProfileWhereInputSchema: z.ZodType<Prisma.ProfileWhereInput> = z.ob
   isBlocked: z.union([ z.lazy(() => BoolFilterSchema),z.boolean() ]).optional(),
   isOnboarded: z.union([ z.lazy(() => BoolFilterSchema),z.boolean() ]).optional(),
   isCallable: z.union([ z.lazy(() => BoolFilterSchema),z.boolean() ]).optional(),
+  hasFace: z.union([ z.lazy(() => BoolFilterSchema),z.boolean() ]).optional(),
   userId: z.union([ z.lazy(() => StringFilterSchema),z.string() ]).optional(),
   work: z.union([ z.lazy(() => StringFilterSchema),z.string() ]).optional(),
   languages: z.lazy(() => StringNullableListFilterSchema).optional(),
@@ -1535,6 +1540,7 @@ export const ProfileOrderByWithRelationInputSchema: z.ZodType<Prisma.ProfileOrde
   isBlocked: z.lazy(() => SortOrderSchema).optional(),
   isOnboarded: z.lazy(() => SortOrderSchema).optional(),
   isCallable: z.lazy(() => SortOrderSchema).optional(),
+  hasFace: z.lazy(() => SortOrderSchema).optional(),
   userId: z.lazy(() => SortOrderSchema).optional(),
   work: z.lazy(() => SortOrderSchema).optional(),
   languages: z.lazy(() => SortOrderSchema).optional(),
@@ -1600,6 +1606,7 @@ export const ProfileWhereUniqueInputSchema: z.ZodType<Prisma.ProfileWhereUniqueI
   isBlocked: z.union([ z.lazy(() => BoolFilterSchema),z.boolean() ]).optional(),
   isOnboarded: z.union([ z.lazy(() => BoolFilterSchema),z.boolean() ]).optional(),
   isCallable: z.union([ z.lazy(() => BoolFilterSchema),z.boolean() ]).optional(),
+  hasFace: z.union([ z.lazy(() => BoolFilterSchema),z.boolean() ]).optional(),
   work: z.union([ z.lazy(() => StringFilterSchema),z.string() ]).optional(),
   languages: z.lazy(() => StringNullableListFilterSchema).optional(),
   birthday: z.union([ z.lazy(() => DateTimeNullableFilterSchema),z.coerce.date() ]).optional().nullable(),
@@ -1648,6 +1655,7 @@ export const ProfileOrderByWithAggregationInputSchema: z.ZodType<Prisma.ProfileO
   isBlocked: z.lazy(() => SortOrderSchema).optional(),
   isOnboarded: z.lazy(() => SortOrderSchema).optional(),
   isCallable: z.lazy(() => SortOrderSchema).optional(),
+  hasFace: z.lazy(() => SortOrderSchema).optional(),
   userId: z.lazy(() => SortOrderSchema).optional(),
   work: z.lazy(() => SortOrderSchema).optional(),
   languages: z.lazy(() => SortOrderSchema).optional(),
@@ -1686,6 +1694,7 @@ export const ProfileScalarWhereWithAggregatesInputSchema: z.ZodType<Prisma.Profi
   isBlocked: z.union([ z.lazy(() => BoolWithAggregatesFilterSchema),z.boolean() ]).optional(),
   isOnboarded: z.union([ z.lazy(() => BoolWithAggregatesFilterSchema),z.boolean() ]).optional(),
   isCallable: z.union([ z.lazy(() => BoolWithAggregatesFilterSchema),z.boolean() ]).optional(),
+  hasFace: z.union([ z.lazy(() => BoolWithAggregatesFilterSchema),z.boolean() ]).optional(),
   userId: z.union([ z.lazy(() => StringWithAggregatesFilterSchema),z.string() ]).optional(),
   work: z.union([ z.lazy(() => StringWithAggregatesFilterSchema),z.string() ]).optional(),
   languages: z.lazy(() => StringNullableListFilterSchema).optional(),
@@ -1792,6 +1801,7 @@ export const ProfileImageWhereInputSchema: z.ZodType<Prisma.ProfileImageWhereInp
   blurhash: z.union([ z.lazy(() => StringNullableFilterSchema),z.string() ]).optional().nullable(),
   isModerated: z.union([ z.lazy(() => BoolFilterSchema),z.boolean() ]).optional(),
   isFlagged: z.union([ z.lazy(() => BoolFilterSchema),z.boolean() ]).optional(),
+  hasFace: z.union([ z.lazy(() => BoolFilterSchema),z.boolean() ]).optional(),
   user: z.union([ z.lazy(() => UserScalarRelationFilterSchema),z.lazy(() => UserWhereInputSchema) ]).optional(),
   profile: z.union([ z.lazy(() => ProfileNullableScalarRelationFilterSchema),z.lazy(() => ProfileWhereInputSchema) ]).optional().nullable(),
 }).strict();
@@ -1813,6 +1823,7 @@ export const ProfileImageOrderByWithRelationInputSchema: z.ZodType<Prisma.Profil
   blurhash: z.union([ z.lazy(() => SortOrderSchema),z.lazy(() => SortOrderInputSchema) ]).optional(),
   isModerated: z.lazy(() => SortOrderSchema).optional(),
   isFlagged: z.lazy(() => SortOrderSchema).optional(),
+  hasFace: z.lazy(() => SortOrderSchema).optional(),
   user: z.lazy(() => UserOrderByWithRelationInputSchema).optional(),
   profile: z.lazy(() => ProfileOrderByWithRelationInputSchema).optional()
 }).strict();
@@ -1849,6 +1860,7 @@ export const ProfileImageWhereUniqueInputSchema: z.ZodType<Prisma.ProfileImageWh
   blurhash: z.union([ z.lazy(() => StringNullableFilterSchema),z.string() ]).optional().nullable(),
   isModerated: z.union([ z.lazy(() => BoolFilterSchema),z.boolean() ]).optional(),
   isFlagged: z.union([ z.lazy(() => BoolFilterSchema),z.boolean() ]).optional(),
+  hasFace: z.union([ z.lazy(() => BoolFilterSchema),z.boolean() ]).optional(),
   user: z.union([ z.lazy(() => UserScalarRelationFilterSchema),z.lazy(() => UserWhereInputSchema) ]).optional(),
   profile: z.union([ z.lazy(() => ProfileNullableScalarRelationFilterSchema),z.lazy(() => ProfileWhereInputSchema) ]).optional().nullable(),
 }).strict());
@@ -1870,6 +1882,7 @@ export const ProfileImageOrderByWithAggregationInputSchema: z.ZodType<Prisma.Pro
   blurhash: z.union([ z.lazy(() => SortOrderSchema),z.lazy(() => SortOrderInputSchema) ]).optional(),
   isModerated: z.lazy(() => SortOrderSchema).optional(),
   isFlagged: z.lazy(() => SortOrderSchema).optional(),
+  hasFace: z.lazy(() => SortOrderSchema).optional(),
   _count: z.lazy(() => ProfileImageCountOrderByAggregateInputSchema).optional(),
   _avg: z.lazy(() => ProfileImageAvgOrderByAggregateInputSchema).optional(),
   _max: z.lazy(() => ProfileImageMaxOrderByAggregateInputSchema).optional(),
@@ -1897,6 +1910,7 @@ export const ProfileImageScalarWhereWithAggregatesInputSchema: z.ZodType<Prisma.
   blurhash: z.union([ z.lazy(() => StringNullableWithAggregatesFilterSchema),z.string() ]).optional().nullable(),
   isModerated: z.union([ z.lazy(() => BoolWithAggregatesFilterSchema),z.boolean() ]).optional(),
   isFlagged: z.union([ z.lazy(() => BoolWithAggregatesFilterSchema),z.boolean() ]).optional(),
+  hasFace: z.union([ z.lazy(() => BoolWithAggregatesFilterSchema),z.boolean() ]).optional(),
 }).strict();
 
 export const ConversationWhereInputSchema: z.ZodType<Prisma.ConversationWhereInput> = z.object({
@@ -3117,6 +3131,7 @@ export const ProfileCreateInputSchema: z.ZodType<Prisma.ProfileCreateInput> = z.
   isBlocked: z.boolean().optional(),
   isOnboarded: z.boolean().optional(),
   isCallable: z.boolean().optional(),
+  hasFace: z.boolean().optional(),
   work: z.string().optional(),
   languages: z.union([ z.lazy(() => ProfileCreatelanguagesInputSchema),z.string().array() ]).optional(),
   birthday: z.coerce.date().optional().nullable(),
@@ -3165,6 +3180,7 @@ export const ProfileUncheckedCreateInputSchema: z.ZodType<Prisma.ProfileUnchecke
   isBlocked: z.boolean().optional(),
   isOnboarded: z.boolean().optional(),
   isCallable: z.boolean().optional(),
+  hasFace: z.boolean().optional(),
   userId: z.string(),
   work: z.string().optional(),
   languages: z.union([ z.lazy(() => ProfileCreatelanguagesInputSchema),z.string().array() ]).optional(),
@@ -3213,6 +3229,7 @@ export const ProfileUpdateInputSchema: z.ZodType<Prisma.ProfileUpdateInput> = z.
   isBlocked: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   isOnboarded: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   isCallable: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
+  hasFace: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   work: z.union([ z.string(),z.lazy(() => StringFieldUpdateOperationsInputSchema) ]).optional(),
   languages: z.union([ z.lazy(() => ProfileUpdatelanguagesInputSchema),z.string().array() ]).optional(),
   birthday: z.union([ z.coerce.date(),z.lazy(() => NullableDateTimeFieldUpdateOperationsInputSchema) ]).optional().nullable(),
@@ -3261,6 +3278,7 @@ export const ProfileUncheckedUpdateInputSchema: z.ZodType<Prisma.ProfileUnchecke
   isBlocked: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   isOnboarded: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   isCallable: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
+  hasFace: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   userId: z.union([ z.string(),z.lazy(() => StringFieldUpdateOperationsInputSchema) ]).optional(),
   work: z.union([ z.string(),z.lazy(() => StringFieldUpdateOperationsInputSchema) ]).optional(),
   languages: z.union([ z.lazy(() => ProfileUpdatelanguagesInputSchema),z.string().array() ]).optional(),
@@ -3309,6 +3327,7 @@ export const ProfileCreateManyInputSchema: z.ZodType<Prisma.ProfileCreateManyInp
   isBlocked: z.boolean().optional(),
   isOnboarded: z.boolean().optional(),
   isCallable: z.boolean().optional(),
+  hasFace: z.boolean().optional(),
   userId: z.string(),
   work: z.string().optional(),
   languages: z.union([ z.lazy(() => ProfileCreatelanguagesInputSchema),z.string().array() ]).optional(),
@@ -3339,6 +3358,7 @@ export const ProfileUpdateManyMutationInputSchema: z.ZodType<Prisma.ProfileUpdat
   isBlocked: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   isOnboarded: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   isCallable: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
+  hasFace: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   work: z.union([ z.string(),z.lazy(() => StringFieldUpdateOperationsInputSchema) ]).optional(),
   languages: z.union([ z.lazy(() => ProfileUpdatelanguagesInputSchema),z.string().array() ]).optional(),
   birthday: z.union([ z.coerce.date(),z.lazy(() => NullableDateTimeFieldUpdateOperationsInputSchema) ]).optional().nullable(),
@@ -3368,6 +3388,7 @@ export const ProfileUncheckedUpdateManyInputSchema: z.ZodType<Prisma.ProfileUnch
   isBlocked: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   isOnboarded: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   isCallable: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
+  hasFace: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   userId: z.union([ z.string(),z.lazy(() => StringFieldUpdateOperationsInputSchema) ]).optional(),
   work: z.union([ z.string(),z.lazy(() => StringFieldUpdateOperationsInputSchema) ]).optional(),
   languages: z.union([ z.lazy(() => ProfileUpdatelanguagesInputSchema),z.string().array() ]).optional(),
@@ -3456,6 +3477,7 @@ export const ProfileImageCreateInputSchema: z.ZodType<Prisma.ProfileImageCreateI
   blurhash: z.string().optional().nullable(),
   isModerated: z.boolean().optional(),
   isFlagged: z.boolean().optional(),
+  hasFace: z.boolean().optional(),
   user: z.lazy(() => UserCreateNestedOneWithoutProfileImageInputSchema),
   profile: z.lazy(() => ProfileCreateNestedOneWithoutProfileImagesInputSchema).optional()
 }).strict();
@@ -3476,7 +3498,8 @@ export const ProfileImageUncheckedCreateInputSchema: z.ZodType<Prisma.ProfileIma
   contentHash: z.string().optional().nullable(),
   blurhash: z.string().optional().nullable(),
   isModerated: z.boolean().optional(),
-  isFlagged: z.boolean().optional()
+  isFlagged: z.boolean().optional(),
+  hasFace: z.boolean().optional()
 }).strict();
 
 export const ProfileImageUpdateInputSchema: z.ZodType<Prisma.ProfileImageUpdateInput> = z.object({
@@ -3494,6 +3517,7 @@ export const ProfileImageUpdateInputSchema: z.ZodType<Prisma.ProfileImageUpdateI
   blurhash: z.union([ z.string(),z.lazy(() => NullableStringFieldUpdateOperationsInputSchema) ]).optional().nullable(),
   isModerated: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   isFlagged: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
+  hasFace: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   user: z.lazy(() => UserUpdateOneRequiredWithoutProfileImageNestedInputSchema).optional(),
   profile: z.lazy(() => ProfileUpdateOneWithoutProfileImagesNestedInputSchema).optional()
 }).strict();
@@ -3515,6 +3539,7 @@ export const ProfileImageUncheckedUpdateInputSchema: z.ZodType<Prisma.ProfileIma
   blurhash: z.union([ z.string(),z.lazy(() => NullableStringFieldUpdateOperationsInputSchema) ]).optional().nullable(),
   isModerated: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   isFlagged: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
+  hasFace: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
 }).strict();
 
 export const ProfileImageCreateManyInputSchema: z.ZodType<Prisma.ProfileImageCreateManyInput> = z.object({
@@ -3533,7 +3558,8 @@ export const ProfileImageCreateManyInputSchema: z.ZodType<Prisma.ProfileImageCre
   contentHash: z.string().optional().nullable(),
   blurhash: z.string().optional().nullable(),
   isModerated: z.boolean().optional(),
-  isFlagged: z.boolean().optional()
+  isFlagged: z.boolean().optional(),
+  hasFace: z.boolean().optional()
 }).strict();
 
 export const ProfileImageUpdateManyMutationInputSchema: z.ZodType<Prisma.ProfileImageUpdateManyMutationInput> = z.object({
@@ -3551,6 +3577,7 @@ export const ProfileImageUpdateManyMutationInputSchema: z.ZodType<Prisma.Profile
   blurhash: z.union([ z.string(),z.lazy(() => NullableStringFieldUpdateOperationsInputSchema) ]).optional().nullable(),
   isModerated: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   isFlagged: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
+  hasFace: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
 }).strict();
 
 export const ProfileImageUncheckedUpdateManyInputSchema: z.ZodType<Prisma.ProfileImageUncheckedUpdateManyInput> = z.object({
@@ -3570,6 +3597,7 @@ export const ProfileImageUncheckedUpdateManyInputSchema: z.ZodType<Prisma.Profil
   blurhash: z.union([ z.string(),z.lazy(() => NullableStringFieldUpdateOperationsInputSchema) ]).optional().nullable(),
   isModerated: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   isFlagged: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
+  hasFace: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
 }).strict();
 
 export const ConversationCreateInputSchema: z.ZodType<Prisma.ConversationCreateInput> = z.object({
@@ -4978,6 +5006,7 @@ export const ProfileCountOrderByAggregateInputSchema: z.ZodType<Prisma.ProfileCo
   isBlocked: z.lazy(() => SortOrderSchema).optional(),
   isOnboarded: z.lazy(() => SortOrderSchema).optional(),
   isCallable: z.lazy(() => SortOrderSchema).optional(),
+  hasFace: z.lazy(() => SortOrderSchema).optional(),
   userId: z.lazy(() => SortOrderSchema).optional(),
   work: z.lazy(() => SortOrderSchema).optional(),
   languages: z.lazy(() => SortOrderSchema).optional(),
@@ -5015,6 +5044,7 @@ export const ProfileMaxOrderByAggregateInputSchema: z.ZodType<Prisma.ProfileMaxO
   isBlocked: z.lazy(() => SortOrderSchema).optional(),
   isOnboarded: z.lazy(() => SortOrderSchema).optional(),
   isCallable: z.lazy(() => SortOrderSchema).optional(),
+  hasFace: z.lazy(() => SortOrderSchema).optional(),
   userId: z.lazy(() => SortOrderSchema).optional(),
   work: z.lazy(() => SortOrderSchema).optional(),
   birthday: z.lazy(() => SortOrderSchema).optional(),
@@ -5042,6 +5072,7 @@ export const ProfileMinOrderByAggregateInputSchema: z.ZodType<Prisma.ProfileMinO
   isBlocked: z.lazy(() => SortOrderSchema).optional(),
   isOnboarded: z.lazy(() => SortOrderSchema).optional(),
   isCallable: z.lazy(() => SortOrderSchema).optional(),
+  hasFace: z.lazy(() => SortOrderSchema).optional(),
   userId: z.lazy(() => SortOrderSchema).optional(),
   work: z.lazy(() => SortOrderSchema).optional(),
   birthday: z.lazy(() => SortOrderSchema).optional(),
@@ -5187,7 +5218,8 @@ export const ProfileImageCountOrderByAggregateInputSchema: z.ZodType<Prisma.Prof
   contentHash: z.lazy(() => SortOrderSchema).optional(),
   blurhash: z.lazy(() => SortOrderSchema).optional(),
   isModerated: z.lazy(() => SortOrderSchema).optional(),
-  isFlagged: z.lazy(() => SortOrderSchema).optional()
+  isFlagged: z.lazy(() => SortOrderSchema).optional(),
+  hasFace: z.lazy(() => SortOrderSchema).optional()
 }).strict();
 
 export const ProfileImageAvgOrderByAggregateInputSchema: z.ZodType<Prisma.ProfileImageAvgOrderByAggregateInput> = z.object({
@@ -5212,7 +5244,8 @@ export const ProfileImageMaxOrderByAggregateInputSchema: z.ZodType<Prisma.Profil
   contentHash: z.lazy(() => SortOrderSchema).optional(),
   blurhash: z.lazy(() => SortOrderSchema).optional(),
   isModerated: z.lazy(() => SortOrderSchema).optional(),
-  isFlagged: z.lazy(() => SortOrderSchema).optional()
+  isFlagged: z.lazy(() => SortOrderSchema).optional(),
+  hasFace: z.lazy(() => SortOrderSchema).optional()
 }).strict();
 
 export const ProfileImageMinOrderByAggregateInputSchema: z.ZodType<Prisma.ProfileImageMinOrderByAggregateInput> = z.object({
@@ -5231,7 +5264,8 @@ export const ProfileImageMinOrderByAggregateInputSchema: z.ZodType<Prisma.Profil
   contentHash: z.lazy(() => SortOrderSchema).optional(),
   blurhash: z.lazy(() => SortOrderSchema).optional(),
   isModerated: z.lazy(() => SortOrderSchema).optional(),
-  isFlagged: z.lazy(() => SortOrderSchema).optional()
+  isFlagged: z.lazy(() => SortOrderSchema).optional(),
+  hasFace: z.lazy(() => SortOrderSchema).optional()
 }).strict();
 
 export const ProfileImageSumOrderByAggregateInputSchema: z.ZodType<Prisma.ProfileImageSumOrderByAggregateInput> = z.object({
@@ -7711,6 +7745,7 @@ export const ProfileCreateWithoutTagsInputSchema: z.ZodType<Prisma.ProfileCreate
   isBlocked: z.boolean().optional(),
   isOnboarded: z.boolean().optional(),
   isCallable: z.boolean().optional(),
+  hasFace: z.boolean().optional(),
   work: z.string().optional(),
   languages: z.union([ z.lazy(() => ProfileCreatelanguagesInputSchema),z.string().array() ]).optional(),
   birthday: z.coerce.date().optional().nullable(),
@@ -7758,6 +7793,7 @@ export const ProfileUncheckedCreateWithoutTagsInputSchema: z.ZodType<Prisma.Prof
   isBlocked: z.boolean().optional(),
   isOnboarded: z.boolean().optional(),
   isCallable: z.boolean().optional(),
+  hasFace: z.boolean().optional(),
   userId: z.string(),
   work: z.string().optional(),
   languages: z.union([ z.lazy(() => ProfileCreatelanguagesInputSchema),z.string().array() ]).optional(),
@@ -7855,6 +7891,7 @@ export const ProfileScalarWhereInputSchema: z.ZodType<Prisma.ProfileScalarWhereI
   isBlocked: z.union([ z.lazy(() => BoolFilterSchema),z.boolean() ]).optional(),
   isOnboarded: z.union([ z.lazy(() => BoolFilterSchema),z.boolean() ]).optional(),
   isCallable: z.union([ z.lazy(() => BoolFilterSchema),z.boolean() ]).optional(),
+  hasFace: z.union([ z.lazy(() => BoolFilterSchema),z.boolean() ]).optional(),
   userId: z.union([ z.lazy(() => StringFilterSchema),z.string() ]).optional(),
   work: z.union([ z.lazy(() => StringFilterSchema),z.string() ]).optional(),
   languages: z.lazy(() => StringNullableListFilterSchema).optional(),
@@ -8185,6 +8222,7 @@ export const ProfileCreateWithoutUserInputSchema: z.ZodType<Prisma.ProfileCreate
   isBlocked: z.boolean().optional(),
   isOnboarded: z.boolean().optional(),
   isCallable: z.boolean().optional(),
+  hasFace: z.boolean().optional(),
   work: z.string().optional(),
   languages: z.union([ z.lazy(() => ProfileCreatelanguagesInputSchema),z.string().array() ]).optional(),
   birthday: z.coerce.date().optional().nullable(),
@@ -8232,6 +8270,7 @@ export const ProfileUncheckedCreateWithoutUserInputSchema: z.ZodType<Prisma.Prof
   isBlocked: z.boolean().optional(),
   isOnboarded: z.boolean().optional(),
   isCallable: z.boolean().optional(),
+  hasFace: z.boolean().optional(),
   work: z.string().optional(),
   languages: z.union([ z.lazy(() => ProfileCreatelanguagesInputSchema),z.string().array() ]).optional(),
   birthday: z.coerce.date().optional().nullable(),
@@ -8287,6 +8326,7 @@ export const ProfileImageCreateWithoutUserInputSchema: z.ZodType<Prisma.ProfileI
   blurhash: z.string().optional().nullable(),
   isModerated: z.boolean().optional(),
   isFlagged: z.boolean().optional(),
+  hasFace: z.boolean().optional(),
   profile: z.lazy(() => ProfileCreateNestedOneWithoutProfileImagesInputSchema).optional()
 }).strict();
 
@@ -8305,7 +8345,8 @@ export const ProfileImageUncheckedCreateWithoutUserInputSchema: z.ZodType<Prisma
   contentHash: z.string().optional().nullable(),
   blurhash: z.string().optional().nullable(),
   isModerated: z.boolean().optional(),
-  isFlagged: z.boolean().optional()
+  isFlagged: z.boolean().optional(),
+  hasFace: z.boolean().optional()
 }).strict();
 
 export const ProfileImageCreateOrConnectWithoutUserInputSchema: z.ZodType<Prisma.ProfileImageCreateOrConnectWithoutUserInput> = z.object({
@@ -8425,6 +8466,7 @@ export const ProfileUpdateWithoutUserInputSchema: z.ZodType<Prisma.ProfileUpdate
   isBlocked: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   isOnboarded: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   isCallable: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
+  hasFace: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   work: z.union([ z.string(),z.lazy(() => StringFieldUpdateOperationsInputSchema) ]).optional(),
   languages: z.union([ z.lazy(() => ProfileUpdatelanguagesInputSchema),z.string().array() ]).optional(),
   birthday: z.union([ z.coerce.date(),z.lazy(() => NullableDateTimeFieldUpdateOperationsInputSchema) ]).optional().nullable(),
@@ -8472,6 +8514,7 @@ export const ProfileUncheckedUpdateWithoutUserInputSchema: z.ZodType<Prisma.Prof
   isBlocked: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   isOnboarded: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   isCallable: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
+  hasFace: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   work: z.union([ z.string(),z.lazy(() => StringFieldUpdateOperationsInputSchema) ]).optional(),
   languages: z.union([ z.lazy(() => ProfileUpdatelanguagesInputSchema),z.string().array() ]).optional(),
   birthday: z.union([ z.coerce.date(),z.lazy(() => NullableDateTimeFieldUpdateOperationsInputSchema) ]).optional().nullable(),
@@ -8543,6 +8586,7 @@ export const ProfileImageScalarWhereInputSchema: z.ZodType<Prisma.ProfileImageSc
   blurhash: z.union([ z.lazy(() => StringNullableFilterSchema),z.string() ]).optional().nullable(),
   isModerated: z.union([ z.lazy(() => BoolFilterSchema),z.boolean() ]).optional(),
   isFlagged: z.union([ z.lazy(() => BoolFilterSchema),z.boolean() ]).optional(),
+  hasFace: z.union([ z.lazy(() => BoolFilterSchema),z.boolean() ]).optional(),
 }).strict();
 
 export const ConnectionRequestUpsertWithWhereUniqueWithoutFromUserInputSchema: z.ZodType<Prisma.ConnectionRequestUpsertWithWhereUniqueWithoutFromUserInput> = z.object({
@@ -8723,6 +8767,7 @@ export const ProfileImageCreateWithoutProfileInputSchema: z.ZodType<Prisma.Profi
   blurhash: z.string().optional().nullable(),
   isModerated: z.boolean().optional(),
   isFlagged: z.boolean().optional(),
+  hasFace: z.boolean().optional(),
   user: z.lazy(() => UserCreateNestedOneWithoutProfileImageInputSchema)
 }).strict();
 
@@ -8741,7 +8786,8 @@ export const ProfileImageUncheckedCreateWithoutProfileInputSchema: z.ZodType<Pri
   contentHash: z.string().optional().nullable(),
   blurhash: z.string().optional().nullable(),
   isModerated: z.boolean().optional(),
-  isFlagged: z.boolean().optional()
+  isFlagged: z.boolean().optional(),
+  hasFace: z.boolean().optional()
 }).strict();
 
 export const ProfileImageCreateOrConnectWithoutProfileInputSchema: z.ZodType<Prisma.ProfileImageCreateOrConnectWithoutProfileInput> = z.object({
@@ -8948,6 +8994,7 @@ export const ProfileCreateWithoutBlockedByProfilesInputSchema: z.ZodType<Prisma.
   isBlocked: z.boolean().optional(),
   isOnboarded: z.boolean().optional(),
   isCallable: z.boolean().optional(),
+  hasFace: z.boolean().optional(),
   work: z.string().optional(),
   languages: z.union([ z.lazy(() => ProfileCreatelanguagesInputSchema),z.string().array() ]).optional(),
   birthday: z.coerce.date().optional().nullable(),
@@ -8995,6 +9042,7 @@ export const ProfileUncheckedCreateWithoutBlockedByProfilesInputSchema: z.ZodTyp
   isBlocked: z.boolean().optional(),
   isOnboarded: z.boolean().optional(),
   isCallable: z.boolean().optional(),
+  hasFace: z.boolean().optional(),
   userId: z.string(),
   work: z.string().optional(),
   languages: z.union([ z.lazy(() => ProfileCreatelanguagesInputSchema),z.string().array() ]).optional(),
@@ -9047,6 +9095,7 @@ export const ProfileCreateWithoutBlockedProfilesInputSchema: z.ZodType<Prisma.Pr
   isBlocked: z.boolean().optional(),
   isOnboarded: z.boolean().optional(),
   isCallable: z.boolean().optional(),
+  hasFace: z.boolean().optional(),
   work: z.string().optional(),
   languages: z.union([ z.lazy(() => ProfileCreatelanguagesInputSchema),z.string().array() ]).optional(),
   birthday: z.coerce.date().optional().nullable(),
@@ -9094,6 +9143,7 @@ export const ProfileUncheckedCreateWithoutBlockedProfilesInputSchema: z.ZodType<
   isBlocked: z.boolean().optional(),
   isOnboarded: z.boolean().optional(),
   isCallable: z.boolean().optional(),
+  hasFace: z.boolean().optional(),
   userId: z.string(),
   work: z.string().optional(),
   languages: z.union([ z.lazy(() => ProfileCreatelanguagesInputSchema),z.string().array() ]).optional(),
@@ -9847,6 +9897,7 @@ export const ProfileCreateWithoutLocalizedInputSchema: z.ZodType<Prisma.ProfileC
   isBlocked: z.boolean().optional(),
   isOnboarded: z.boolean().optional(),
   isCallable: z.boolean().optional(),
+  hasFace: z.boolean().optional(),
   work: z.string().optional(),
   languages: z.union([ z.lazy(() => ProfileCreatelanguagesInputSchema),z.string().array() ]).optional(),
   birthday: z.coerce.date().optional().nullable(),
@@ -9894,6 +9945,7 @@ export const ProfileUncheckedCreateWithoutLocalizedInputSchema: z.ZodType<Prisma
   isBlocked: z.boolean().optional(),
   isOnboarded: z.boolean().optional(),
   isCallable: z.boolean().optional(),
+  hasFace: z.boolean().optional(),
   userId: z.string(),
   work: z.string().optional(),
   languages: z.union([ z.lazy(() => ProfileCreatelanguagesInputSchema),z.string().array() ]).optional(),
@@ -9957,6 +10009,7 @@ export const ProfileUpdateWithoutLocalizedInputSchema: z.ZodType<Prisma.ProfileU
   isBlocked: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   isOnboarded: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   isCallable: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
+  hasFace: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   work: z.union([ z.string(),z.lazy(() => StringFieldUpdateOperationsInputSchema) ]).optional(),
   languages: z.union([ z.lazy(() => ProfileUpdatelanguagesInputSchema),z.string().array() ]).optional(),
   birthday: z.union([ z.coerce.date(),z.lazy(() => NullableDateTimeFieldUpdateOperationsInputSchema) ]).optional().nullable(),
@@ -10004,6 +10057,7 @@ export const ProfileUncheckedUpdateWithoutLocalizedInputSchema: z.ZodType<Prisma
   isBlocked: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   isOnboarded: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   isCallable: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
+  hasFace: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   userId: z.union([ z.string(),z.lazy(() => StringFieldUpdateOperationsInputSchema) ]).optional(),
   work: z.union([ z.string(),z.lazy(() => StringFieldUpdateOperationsInputSchema) ]).optional(),
   languages: z.union([ z.lazy(() => ProfileUpdatelanguagesInputSchema),z.string().array() ]).optional(),
@@ -10104,6 +10158,7 @@ export const ProfileCreateWithoutProfileImagesInputSchema: z.ZodType<Prisma.Prof
   isBlocked: z.boolean().optional(),
   isOnboarded: z.boolean().optional(),
   isCallable: z.boolean().optional(),
+  hasFace: z.boolean().optional(),
   work: z.string().optional(),
   languages: z.union([ z.lazy(() => ProfileCreatelanguagesInputSchema),z.string().array() ]).optional(),
   birthday: z.coerce.date().optional().nullable(),
@@ -10151,6 +10206,7 @@ export const ProfileUncheckedCreateWithoutProfileImagesInputSchema: z.ZodType<Pr
   isBlocked: z.boolean().optional(),
   isOnboarded: z.boolean().optional(),
   isCallable: z.boolean().optional(),
+  hasFace: z.boolean().optional(),
   userId: z.string(),
   work: z.string().optional(),
   languages: z.union([ z.lazy(() => ProfileCreatelanguagesInputSchema),z.string().array() ]).optional(),
@@ -10273,6 +10329,7 @@ export const ProfileUpdateWithoutProfileImagesInputSchema: z.ZodType<Prisma.Prof
   isBlocked: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   isOnboarded: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   isCallable: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
+  hasFace: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   work: z.union([ z.string(),z.lazy(() => StringFieldUpdateOperationsInputSchema) ]).optional(),
   languages: z.union([ z.lazy(() => ProfileUpdatelanguagesInputSchema),z.string().array() ]).optional(),
   birthday: z.union([ z.coerce.date(),z.lazy(() => NullableDateTimeFieldUpdateOperationsInputSchema) ]).optional().nullable(),
@@ -10320,6 +10377,7 @@ export const ProfileUncheckedUpdateWithoutProfileImagesInputSchema: z.ZodType<Pr
   isBlocked: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   isOnboarded: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   isCallable: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
+  hasFace: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   userId: z.union([ z.string(),z.lazy(() => StringFieldUpdateOperationsInputSchema) ]).optional(),
   work: z.union([ z.string(),z.lazy(() => StringFieldUpdateOperationsInputSchema) ]).optional(),
   languages: z.union([ z.lazy(() => ProfileUpdatelanguagesInputSchema),z.string().array() ]).optional(),
@@ -10367,6 +10425,7 @@ export const ProfileCreateWithoutConversationAsAInputSchema: z.ZodType<Prisma.Pr
   isBlocked: z.boolean().optional(),
   isOnboarded: z.boolean().optional(),
   isCallable: z.boolean().optional(),
+  hasFace: z.boolean().optional(),
   work: z.string().optional(),
   languages: z.union([ z.lazy(() => ProfileCreatelanguagesInputSchema),z.string().array() ]).optional(),
   birthday: z.coerce.date().optional().nullable(),
@@ -10414,6 +10473,7 @@ export const ProfileUncheckedCreateWithoutConversationAsAInputSchema: z.ZodType<
   isBlocked: z.boolean().optional(),
   isOnboarded: z.boolean().optional(),
   isCallable: z.boolean().optional(),
+  hasFace: z.boolean().optional(),
   userId: z.string(),
   work: z.string().optional(),
   languages: z.union([ z.lazy(() => ProfileCreatelanguagesInputSchema),z.string().array() ]).optional(),
@@ -10466,6 +10526,7 @@ export const ProfileCreateWithoutConversationAsBInputSchema: z.ZodType<Prisma.Pr
   isBlocked: z.boolean().optional(),
   isOnboarded: z.boolean().optional(),
   isCallable: z.boolean().optional(),
+  hasFace: z.boolean().optional(),
   work: z.string().optional(),
   languages: z.union([ z.lazy(() => ProfileCreatelanguagesInputSchema),z.string().array() ]).optional(),
   birthday: z.coerce.date().optional().nullable(),
@@ -10513,6 +10574,7 @@ export const ProfileUncheckedCreateWithoutConversationAsBInputSchema: z.ZodType<
   isBlocked: z.boolean().optional(),
   isOnboarded: z.boolean().optional(),
   isCallable: z.boolean().optional(),
+  hasFace: z.boolean().optional(),
   userId: z.string(),
   work: z.string().optional(),
   languages: z.union([ z.lazy(() => ProfileCreatelanguagesInputSchema),z.string().array() ]).optional(),
@@ -10621,6 +10683,7 @@ export const ProfileCreateWithoutConversationInputSchema: z.ZodType<Prisma.Profi
   isBlocked: z.boolean().optional(),
   isOnboarded: z.boolean().optional(),
   isCallable: z.boolean().optional(),
+  hasFace: z.boolean().optional(),
   work: z.string().optional(),
   languages: z.union([ z.lazy(() => ProfileCreatelanguagesInputSchema),z.string().array() ]).optional(),
   birthday: z.coerce.date().optional().nullable(),
@@ -10668,6 +10731,7 @@ export const ProfileUncheckedCreateWithoutConversationInputSchema: z.ZodType<Pri
   isBlocked: z.boolean().optional(),
   isOnboarded: z.boolean().optional(),
   isCallable: z.boolean().optional(),
+  hasFace: z.boolean().optional(),
   userId: z.string(),
   work: z.string().optional(),
   languages: z.union([ z.lazy(() => ProfileCreatelanguagesInputSchema),z.string().array() ]).optional(),
@@ -10731,6 +10795,7 @@ export const ProfileUpdateWithoutConversationAsAInputSchema: z.ZodType<Prisma.Pr
   isBlocked: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   isOnboarded: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   isCallable: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
+  hasFace: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   work: z.union([ z.string(),z.lazy(() => StringFieldUpdateOperationsInputSchema) ]).optional(),
   languages: z.union([ z.lazy(() => ProfileUpdatelanguagesInputSchema),z.string().array() ]).optional(),
   birthday: z.union([ z.coerce.date(),z.lazy(() => NullableDateTimeFieldUpdateOperationsInputSchema) ]).optional().nullable(),
@@ -10778,6 +10843,7 @@ export const ProfileUncheckedUpdateWithoutConversationAsAInputSchema: z.ZodType<
   isBlocked: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   isOnboarded: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   isCallable: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
+  hasFace: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   userId: z.union([ z.string(),z.lazy(() => StringFieldUpdateOperationsInputSchema) ]).optional(),
   work: z.union([ z.string(),z.lazy(() => StringFieldUpdateOperationsInputSchema) ]).optional(),
   languages: z.union([ z.lazy(() => ProfileUpdatelanguagesInputSchema),z.string().array() ]).optional(),
@@ -10836,6 +10902,7 @@ export const ProfileUpdateWithoutConversationAsBInputSchema: z.ZodType<Prisma.Pr
   isBlocked: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   isOnboarded: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   isCallable: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
+  hasFace: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   work: z.union([ z.string(),z.lazy(() => StringFieldUpdateOperationsInputSchema) ]).optional(),
   languages: z.union([ z.lazy(() => ProfileUpdatelanguagesInputSchema),z.string().array() ]).optional(),
   birthday: z.union([ z.coerce.date(),z.lazy(() => NullableDateTimeFieldUpdateOperationsInputSchema) ]).optional().nullable(),
@@ -10883,6 +10950,7 @@ export const ProfileUncheckedUpdateWithoutConversationAsBInputSchema: z.ZodType<
   isBlocked: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   isOnboarded: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   isCallable: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
+  hasFace: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   userId: z.union([ z.string(),z.lazy(() => StringFieldUpdateOperationsInputSchema) ]).optional(),
   work: z.union([ z.string(),z.lazy(() => StringFieldUpdateOperationsInputSchema) ]).optional(),
   languages: z.union([ z.lazy(() => ProfileUpdatelanguagesInputSchema),z.string().array() ]).optional(),
@@ -10973,6 +11041,7 @@ export const ProfileUpdateWithoutConversationInputSchema: z.ZodType<Prisma.Profi
   isBlocked: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   isOnboarded: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   isCallable: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
+  hasFace: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   work: z.union([ z.string(),z.lazy(() => StringFieldUpdateOperationsInputSchema) ]).optional(),
   languages: z.union([ z.lazy(() => ProfileUpdatelanguagesInputSchema),z.string().array() ]).optional(),
   birthday: z.union([ z.coerce.date(),z.lazy(() => NullableDateTimeFieldUpdateOperationsInputSchema) ]).optional().nullable(),
@@ -11020,6 +11089,7 @@ export const ProfileUncheckedUpdateWithoutConversationInputSchema: z.ZodType<Pri
   isBlocked: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   isOnboarded: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   isCallable: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
+  hasFace: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   userId: z.union([ z.string(),z.lazy(() => StringFieldUpdateOperationsInputSchema) ]).optional(),
   work: z.union([ z.string(),z.lazy(() => StringFieldUpdateOperationsInputSchema) ]).optional(),
   languages: z.union([ z.lazy(() => ProfileUpdatelanguagesInputSchema),z.string().array() ]).optional(),
@@ -11067,6 +11137,7 @@ export const ProfileCreateWithoutConversationParticipantsInputSchema: z.ZodType<
   isBlocked: z.boolean().optional(),
   isOnboarded: z.boolean().optional(),
   isCallable: z.boolean().optional(),
+  hasFace: z.boolean().optional(),
   work: z.string().optional(),
   languages: z.union([ z.lazy(() => ProfileCreatelanguagesInputSchema),z.string().array() ]).optional(),
   birthday: z.coerce.date().optional().nullable(),
@@ -11114,6 +11185,7 @@ export const ProfileUncheckedCreateWithoutConversationParticipantsInputSchema: z
   isBlocked: z.boolean().optional(),
   isOnboarded: z.boolean().optional(),
   isCallable: z.boolean().optional(),
+  hasFace: z.boolean().optional(),
   userId: z.string(),
   work: z.string().optional(),
   languages: z.union([ z.lazy(() => ProfileCreatelanguagesInputSchema),z.string().array() ]).optional(),
@@ -11206,6 +11278,7 @@ export const ProfileUpdateWithoutConversationParticipantsInputSchema: z.ZodType<
   isBlocked: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   isOnboarded: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   isCallable: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
+  hasFace: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   work: z.union([ z.string(),z.lazy(() => StringFieldUpdateOperationsInputSchema) ]).optional(),
   languages: z.union([ z.lazy(() => ProfileUpdatelanguagesInputSchema),z.string().array() ]).optional(),
   birthday: z.union([ z.coerce.date(),z.lazy(() => NullableDateTimeFieldUpdateOperationsInputSchema) ]).optional().nullable(),
@@ -11253,6 +11326,7 @@ export const ProfileUncheckedUpdateWithoutConversationParticipantsInputSchema: z
   isBlocked: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   isOnboarded: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   isCallable: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
+  hasFace: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   userId: z.union([ z.string(),z.lazy(() => StringFieldUpdateOperationsInputSchema) ]).optional(),
   work: z.union([ z.string(),z.lazy(() => StringFieldUpdateOperationsInputSchema) ]).optional(),
   languages: z.union([ z.lazy(() => ProfileUpdatelanguagesInputSchema),z.string().array() ]).optional(),
@@ -11335,6 +11409,7 @@ export const ProfileCreateWithoutLikesSentInputSchema: z.ZodType<Prisma.ProfileC
   isBlocked: z.boolean().optional(),
   isOnboarded: z.boolean().optional(),
   isCallable: z.boolean().optional(),
+  hasFace: z.boolean().optional(),
   work: z.string().optional(),
   languages: z.union([ z.lazy(() => ProfileCreatelanguagesInputSchema),z.string().array() ]).optional(),
   birthday: z.coerce.date().optional().nullable(),
@@ -11382,6 +11457,7 @@ export const ProfileUncheckedCreateWithoutLikesSentInputSchema: z.ZodType<Prisma
   isBlocked: z.boolean().optional(),
   isOnboarded: z.boolean().optional(),
   isCallable: z.boolean().optional(),
+  hasFace: z.boolean().optional(),
   userId: z.string(),
   work: z.string().optional(),
   languages: z.union([ z.lazy(() => ProfileCreatelanguagesInputSchema),z.string().array() ]).optional(),
@@ -11434,6 +11510,7 @@ export const ProfileCreateWithoutLikesReceivedInputSchema: z.ZodType<Prisma.Prof
   isBlocked: z.boolean().optional(),
   isOnboarded: z.boolean().optional(),
   isCallable: z.boolean().optional(),
+  hasFace: z.boolean().optional(),
   work: z.string().optional(),
   languages: z.union([ z.lazy(() => ProfileCreatelanguagesInputSchema),z.string().array() ]).optional(),
   birthday: z.coerce.date().optional().nullable(),
@@ -11481,6 +11558,7 @@ export const ProfileUncheckedCreateWithoutLikesReceivedInputSchema: z.ZodType<Pr
   isBlocked: z.boolean().optional(),
   isOnboarded: z.boolean().optional(),
   isCallable: z.boolean().optional(),
+  hasFace: z.boolean().optional(),
   userId: z.string(),
   work: z.string().optional(),
   languages: z.union([ z.lazy(() => ProfileCreatelanguagesInputSchema),z.string().array() ]).optional(),
@@ -11544,6 +11622,7 @@ export const ProfileUpdateWithoutLikesSentInputSchema: z.ZodType<Prisma.ProfileU
   isBlocked: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   isOnboarded: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   isCallable: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
+  hasFace: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   work: z.union([ z.string(),z.lazy(() => StringFieldUpdateOperationsInputSchema) ]).optional(),
   languages: z.union([ z.lazy(() => ProfileUpdatelanguagesInputSchema),z.string().array() ]).optional(),
   birthday: z.union([ z.coerce.date(),z.lazy(() => NullableDateTimeFieldUpdateOperationsInputSchema) ]).optional().nullable(),
@@ -11591,6 +11670,7 @@ export const ProfileUncheckedUpdateWithoutLikesSentInputSchema: z.ZodType<Prisma
   isBlocked: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   isOnboarded: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   isCallable: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
+  hasFace: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   userId: z.union([ z.string(),z.lazy(() => StringFieldUpdateOperationsInputSchema) ]).optional(),
   work: z.union([ z.string(),z.lazy(() => StringFieldUpdateOperationsInputSchema) ]).optional(),
   languages: z.union([ z.lazy(() => ProfileUpdatelanguagesInputSchema),z.string().array() ]).optional(),
@@ -11649,6 +11729,7 @@ export const ProfileUpdateWithoutLikesReceivedInputSchema: z.ZodType<Prisma.Prof
   isBlocked: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   isOnboarded: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   isCallable: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
+  hasFace: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   work: z.union([ z.string(),z.lazy(() => StringFieldUpdateOperationsInputSchema) ]).optional(),
   languages: z.union([ z.lazy(() => ProfileUpdatelanguagesInputSchema),z.string().array() ]).optional(),
   birthday: z.union([ z.coerce.date(),z.lazy(() => NullableDateTimeFieldUpdateOperationsInputSchema) ]).optional().nullable(),
@@ -11696,6 +11777,7 @@ export const ProfileUncheckedUpdateWithoutLikesReceivedInputSchema: z.ZodType<Pr
   isBlocked: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   isOnboarded: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   isCallable: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
+  hasFace: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   userId: z.union([ z.string(),z.lazy(() => StringFieldUpdateOperationsInputSchema) ]).optional(),
   work: z.union([ z.string(),z.lazy(() => StringFieldUpdateOperationsInputSchema) ]).optional(),
   languages: z.union([ z.lazy(() => ProfileUpdatelanguagesInputSchema),z.string().array() ]).optional(),
@@ -11743,6 +11825,7 @@ export const ProfileCreateWithoutHiddenProfilesInputSchema: z.ZodType<Prisma.Pro
   isBlocked: z.boolean().optional(),
   isOnboarded: z.boolean().optional(),
   isCallable: z.boolean().optional(),
+  hasFace: z.boolean().optional(),
   work: z.string().optional(),
   languages: z.union([ z.lazy(() => ProfileCreatelanguagesInputSchema),z.string().array() ]).optional(),
   birthday: z.coerce.date().optional().nullable(),
@@ -11790,6 +11873,7 @@ export const ProfileUncheckedCreateWithoutHiddenProfilesInputSchema: z.ZodType<P
   isBlocked: z.boolean().optional(),
   isOnboarded: z.boolean().optional(),
   isCallable: z.boolean().optional(),
+  hasFace: z.boolean().optional(),
   userId: z.string(),
   work: z.string().optional(),
   languages: z.union([ z.lazy(() => ProfileCreatelanguagesInputSchema),z.string().array() ]).optional(),
@@ -11842,6 +11926,7 @@ export const ProfileCreateWithoutHiddenByInputSchema: z.ZodType<Prisma.ProfileCr
   isBlocked: z.boolean().optional(),
   isOnboarded: z.boolean().optional(),
   isCallable: z.boolean().optional(),
+  hasFace: z.boolean().optional(),
   work: z.string().optional(),
   languages: z.union([ z.lazy(() => ProfileCreatelanguagesInputSchema),z.string().array() ]).optional(),
   birthday: z.coerce.date().optional().nullable(),
@@ -11889,6 +11974,7 @@ export const ProfileUncheckedCreateWithoutHiddenByInputSchema: z.ZodType<Prisma.
   isBlocked: z.boolean().optional(),
   isOnboarded: z.boolean().optional(),
   isCallable: z.boolean().optional(),
+  hasFace: z.boolean().optional(),
   userId: z.string(),
   work: z.string().optional(),
   languages: z.union([ z.lazy(() => ProfileCreatelanguagesInputSchema),z.string().array() ]).optional(),
@@ -11952,6 +12038,7 @@ export const ProfileUpdateWithoutHiddenProfilesInputSchema: z.ZodType<Prisma.Pro
   isBlocked: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   isOnboarded: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   isCallable: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
+  hasFace: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   work: z.union([ z.string(),z.lazy(() => StringFieldUpdateOperationsInputSchema) ]).optional(),
   languages: z.union([ z.lazy(() => ProfileUpdatelanguagesInputSchema),z.string().array() ]).optional(),
   birthday: z.union([ z.coerce.date(),z.lazy(() => NullableDateTimeFieldUpdateOperationsInputSchema) ]).optional().nullable(),
@@ -11999,6 +12086,7 @@ export const ProfileUncheckedUpdateWithoutHiddenProfilesInputSchema: z.ZodType<P
   isBlocked: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   isOnboarded: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   isCallable: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
+  hasFace: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   userId: z.union([ z.string(),z.lazy(() => StringFieldUpdateOperationsInputSchema) ]).optional(),
   work: z.union([ z.string(),z.lazy(() => StringFieldUpdateOperationsInputSchema) ]).optional(),
   languages: z.union([ z.lazy(() => ProfileUpdatelanguagesInputSchema),z.string().array() ]).optional(),
@@ -12057,6 +12145,7 @@ export const ProfileUpdateWithoutHiddenByInputSchema: z.ZodType<Prisma.ProfileUp
   isBlocked: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   isOnboarded: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   isCallable: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
+  hasFace: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   work: z.union([ z.string(),z.lazy(() => StringFieldUpdateOperationsInputSchema) ]).optional(),
   languages: z.union([ z.lazy(() => ProfileUpdatelanguagesInputSchema),z.string().array() ]).optional(),
   birthday: z.union([ z.coerce.date(),z.lazy(() => NullableDateTimeFieldUpdateOperationsInputSchema) ]).optional().nullable(),
@@ -12104,6 +12193,7 @@ export const ProfileUncheckedUpdateWithoutHiddenByInputSchema: z.ZodType<Prisma.
   isBlocked: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   isOnboarded: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   isCallable: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
+  hasFace: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   userId: z.union([ z.string(),z.lazy(() => StringFieldUpdateOperationsInputSchema) ]).optional(),
   work: z.union([ z.string(),z.lazy(() => StringFieldUpdateOperationsInputSchema) ]).optional(),
   languages: z.union([ z.lazy(() => ProfileUpdatelanguagesInputSchema),z.string().array() ]).optional(),
@@ -12180,6 +12270,7 @@ export const ProfileCreateWithoutMessageInputSchema: z.ZodType<Prisma.ProfileCre
   isBlocked: z.boolean().optional(),
   isOnboarded: z.boolean().optional(),
   isCallable: z.boolean().optional(),
+  hasFace: z.boolean().optional(),
   work: z.string().optional(),
   languages: z.union([ z.lazy(() => ProfileCreatelanguagesInputSchema),z.string().array() ]).optional(),
   birthday: z.coerce.date().optional().nullable(),
@@ -12227,6 +12318,7 @@ export const ProfileUncheckedCreateWithoutMessageInputSchema: z.ZodType<Prisma.P
   isBlocked: z.boolean().optional(),
   isOnboarded: z.boolean().optional(),
   isCallable: z.boolean().optional(),
+  hasFace: z.boolean().optional(),
   userId: z.string(),
   work: z.string().optional(),
   languages: z.union([ z.lazy(() => ProfileCreatelanguagesInputSchema),z.string().array() ]).optional(),
@@ -12348,6 +12440,7 @@ export const ProfileUpdateWithoutMessageInputSchema: z.ZodType<Prisma.ProfileUpd
   isBlocked: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   isOnboarded: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   isCallable: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
+  hasFace: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   work: z.union([ z.string(),z.lazy(() => StringFieldUpdateOperationsInputSchema) ]).optional(),
   languages: z.union([ z.lazy(() => ProfileUpdatelanguagesInputSchema),z.string().array() ]).optional(),
   birthday: z.union([ z.coerce.date(),z.lazy(() => NullableDateTimeFieldUpdateOperationsInputSchema) ]).optional().nullable(),
@@ -12395,6 +12488,7 @@ export const ProfileUncheckedUpdateWithoutMessageInputSchema: z.ZodType<Prisma.P
   isBlocked: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   isOnboarded: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   isCallable: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
+  hasFace: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   userId: z.union([ z.string(),z.lazy(() => StringFieldUpdateOperationsInputSchema) ]).optional(),
   work: z.union([ z.string(),z.lazy(() => StringFieldUpdateOperationsInputSchema) ]).optional(),
   languages: z.union([ z.lazy(() => ProfileUpdatelanguagesInputSchema),z.string().array() ]).optional(),
@@ -12635,6 +12729,7 @@ export const ProfileCreateWithoutPostsInputSchema: z.ZodType<Prisma.ProfileCreat
   isBlocked: z.boolean().optional(),
   isOnboarded: z.boolean().optional(),
   isCallable: z.boolean().optional(),
+  hasFace: z.boolean().optional(),
   work: z.string().optional(),
   languages: z.union([ z.lazy(() => ProfileCreatelanguagesInputSchema),z.string().array() ]).optional(),
   birthday: z.coerce.date().optional().nullable(),
@@ -12682,6 +12777,7 @@ export const ProfileUncheckedCreateWithoutPostsInputSchema: z.ZodType<Prisma.Pro
   isBlocked: z.boolean().optional(),
   isOnboarded: z.boolean().optional(),
   isCallable: z.boolean().optional(),
+  hasFace: z.boolean().optional(),
   userId: z.string(),
   work: z.string().optional(),
   languages: z.union([ z.lazy(() => ProfileCreatelanguagesInputSchema),z.string().array() ]).optional(),
@@ -12745,6 +12841,7 @@ export const ProfileUpdateWithoutPostsInputSchema: z.ZodType<Prisma.ProfileUpdat
   isBlocked: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   isOnboarded: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   isCallable: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
+  hasFace: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   work: z.union([ z.string(),z.lazy(() => StringFieldUpdateOperationsInputSchema) ]).optional(),
   languages: z.union([ z.lazy(() => ProfileUpdatelanguagesInputSchema),z.string().array() ]).optional(),
   birthday: z.union([ z.coerce.date(),z.lazy(() => NullableDateTimeFieldUpdateOperationsInputSchema) ]).optional().nullable(),
@@ -12792,6 +12889,7 @@ export const ProfileUncheckedUpdateWithoutPostsInputSchema: z.ZodType<Prisma.Pro
   isBlocked: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   isOnboarded: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   isCallable: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
+  hasFace: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   userId: z.union([ z.string(),z.lazy(() => StringFieldUpdateOperationsInputSchema) ]).optional(),
   work: z.union([ z.string(),z.lazy(() => StringFieldUpdateOperationsInputSchema) ]).optional(),
   languages: z.union([ z.lazy(() => ProfileUpdatelanguagesInputSchema),z.string().array() ]).optional(),
@@ -12839,6 +12937,7 @@ export const ProfileCreateWithoutSessionLogsInputSchema: z.ZodType<Prisma.Profil
   isBlocked: z.boolean().optional(),
   isOnboarded: z.boolean().optional(),
   isCallable: z.boolean().optional(),
+  hasFace: z.boolean().optional(),
   work: z.string().optional(),
   languages: z.union([ z.lazy(() => ProfileCreatelanguagesInputSchema),z.string().array() ]).optional(),
   birthday: z.coerce.date().optional().nullable(),
@@ -12886,6 +12985,7 @@ export const ProfileUncheckedCreateWithoutSessionLogsInputSchema: z.ZodType<Pris
   isBlocked: z.boolean().optional(),
   isOnboarded: z.boolean().optional(),
   isCallable: z.boolean().optional(),
+  hasFace: z.boolean().optional(),
   userId: z.string(),
   work: z.string().optional(),
   languages: z.union([ z.lazy(() => ProfileCreatelanguagesInputSchema),z.string().array() ]).optional(),
@@ -12949,6 +13049,7 @@ export const ProfileUpdateWithoutSessionLogsInputSchema: z.ZodType<Prisma.Profil
   isBlocked: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   isOnboarded: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   isCallable: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
+  hasFace: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   work: z.union([ z.string(),z.lazy(() => StringFieldUpdateOperationsInputSchema) ]).optional(),
   languages: z.union([ z.lazy(() => ProfileUpdatelanguagesInputSchema),z.string().array() ]).optional(),
   birthday: z.union([ z.coerce.date(),z.lazy(() => NullableDateTimeFieldUpdateOperationsInputSchema) ]).optional().nullable(),
@@ -12996,6 +13097,7 @@ export const ProfileUncheckedUpdateWithoutSessionLogsInputSchema: z.ZodType<Pris
   isBlocked: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   isOnboarded: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   isCallable: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
+  hasFace: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   userId: z.union([ z.string(),z.lazy(() => StringFieldUpdateOperationsInputSchema) ]).optional(),
   work: z.union([ z.string(),z.lazy(() => StringFieldUpdateOperationsInputSchema) ]).optional(),
   languages: z.union([ z.lazy(() => ProfileUpdatelanguagesInputSchema),z.string().array() ]).optional(),
@@ -13043,6 +13145,7 @@ export const ProfileCreateWithoutActivitySummaryInputSchema: z.ZodType<Prisma.Pr
   isBlocked: z.boolean().optional(),
   isOnboarded: z.boolean().optional(),
   isCallable: z.boolean().optional(),
+  hasFace: z.boolean().optional(),
   work: z.string().optional(),
   languages: z.union([ z.lazy(() => ProfileCreatelanguagesInputSchema),z.string().array() ]).optional(),
   birthday: z.coerce.date().optional().nullable(),
@@ -13090,6 +13193,7 @@ export const ProfileUncheckedCreateWithoutActivitySummaryInputSchema: z.ZodType<
   isBlocked: z.boolean().optional(),
   isOnboarded: z.boolean().optional(),
   isCallable: z.boolean().optional(),
+  hasFace: z.boolean().optional(),
   userId: z.string(),
   work: z.string().optional(),
   languages: z.union([ z.lazy(() => ProfileCreatelanguagesInputSchema),z.string().array() ]).optional(),
@@ -13153,6 +13257,7 @@ export const ProfileUpdateWithoutActivitySummaryInputSchema: z.ZodType<Prisma.Pr
   isBlocked: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   isOnboarded: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   isCallable: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
+  hasFace: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   work: z.union([ z.string(),z.lazy(() => StringFieldUpdateOperationsInputSchema) ]).optional(),
   languages: z.union([ z.lazy(() => ProfileUpdatelanguagesInputSchema),z.string().array() ]).optional(),
   birthday: z.union([ z.coerce.date(),z.lazy(() => NullableDateTimeFieldUpdateOperationsInputSchema) ]).optional().nullable(),
@@ -13200,6 +13305,7 @@ export const ProfileUncheckedUpdateWithoutActivitySummaryInputSchema: z.ZodType<
   isBlocked: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   isOnboarded: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   isCallable: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
+  hasFace: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   userId: z.union([ z.string(),z.lazy(() => StringFieldUpdateOperationsInputSchema) ]).optional(),
   work: z.union([ z.string(),z.lazy(() => StringFieldUpdateOperationsInputSchema) ]).optional(),
   languages: z.union([ z.lazy(() => ProfileUpdatelanguagesInputSchema),z.string().array() ]).optional(),
@@ -13247,6 +13353,7 @@ export const ProfileCreateWithoutTrustFlagsInputSchema: z.ZodType<Prisma.Profile
   isBlocked: z.boolean().optional(),
   isOnboarded: z.boolean().optional(),
   isCallable: z.boolean().optional(),
+  hasFace: z.boolean().optional(),
   work: z.string().optional(),
   languages: z.union([ z.lazy(() => ProfileCreatelanguagesInputSchema),z.string().array() ]).optional(),
   birthday: z.coerce.date().optional().nullable(),
@@ -13294,6 +13401,7 @@ export const ProfileUncheckedCreateWithoutTrustFlagsInputSchema: z.ZodType<Prism
   isBlocked: z.boolean().optional(),
   isOnboarded: z.boolean().optional(),
   isCallable: z.boolean().optional(),
+  hasFace: z.boolean().optional(),
   userId: z.string(),
   work: z.string().optional(),
   languages: z.union([ z.lazy(() => ProfileCreatelanguagesInputSchema),z.string().array() ]).optional(),
@@ -13357,6 +13465,7 @@ export const ProfileUpdateWithoutTrustFlagsInputSchema: z.ZodType<Prisma.Profile
   isBlocked: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   isOnboarded: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   isCallable: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
+  hasFace: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   work: z.union([ z.string(),z.lazy(() => StringFieldUpdateOperationsInputSchema) ]).optional(),
   languages: z.union([ z.lazy(() => ProfileUpdatelanguagesInputSchema),z.string().array() ]).optional(),
   birthday: z.union([ z.coerce.date(),z.lazy(() => NullableDateTimeFieldUpdateOperationsInputSchema) ]).optional().nullable(),
@@ -13404,6 +13513,7 @@ export const ProfileUncheckedUpdateWithoutTrustFlagsInputSchema: z.ZodType<Prism
   isBlocked: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   isOnboarded: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   isCallable: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
+  hasFace: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   userId: z.union([ z.string(),z.lazy(() => StringFieldUpdateOperationsInputSchema) ]).optional(),
   work: z.union([ z.string(),z.lazy(() => StringFieldUpdateOperationsInputSchema) ]).optional(),
   languages: z.union([ z.lazy(() => ProfileUpdatelanguagesInputSchema),z.string().array() ]).optional(),
@@ -13474,6 +13584,7 @@ export const ProfileUpdateWithoutTagsInputSchema: z.ZodType<Prisma.ProfileUpdate
   isBlocked: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   isOnboarded: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   isCallable: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
+  hasFace: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   work: z.union([ z.string(),z.lazy(() => StringFieldUpdateOperationsInputSchema) ]).optional(),
   languages: z.union([ z.lazy(() => ProfileUpdatelanguagesInputSchema),z.string().array() ]).optional(),
   birthday: z.union([ z.coerce.date(),z.lazy(() => NullableDateTimeFieldUpdateOperationsInputSchema) ]).optional().nullable(),
@@ -13521,6 +13632,7 @@ export const ProfileUncheckedUpdateWithoutTagsInputSchema: z.ZodType<Prisma.Prof
   isBlocked: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   isOnboarded: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   isCallable: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
+  hasFace: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   userId: z.union([ z.string(),z.lazy(() => StringFieldUpdateOperationsInputSchema) ]).optional(),
   work: z.union([ z.string(),z.lazy(() => StringFieldUpdateOperationsInputSchema) ]).optional(),
   languages: z.union([ z.lazy(() => ProfileUpdatelanguagesInputSchema),z.string().array() ]).optional(),
@@ -13568,6 +13680,7 @@ export const ProfileUncheckedUpdateManyWithoutTagsInputSchema: z.ZodType<Prisma.
   isBlocked: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   isOnboarded: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   isCallable: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
+  hasFace: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   userId: z.union([ z.string(),z.lazy(() => StringFieldUpdateOperationsInputSchema) ]).optional(),
   work: z.union([ z.string(),z.lazy(() => StringFieldUpdateOperationsInputSchema) ]).optional(),
   languages: z.union([ z.lazy(() => ProfileUpdatelanguagesInputSchema),z.string().array() ]).optional(),
@@ -13601,7 +13714,8 @@ export const ProfileImageCreateManyUserInputSchema: z.ZodType<Prisma.ProfileImag
   contentHash: z.string().optional().nullable(),
   blurhash: z.string().optional().nullable(),
   isModerated: z.boolean().optional(),
-  isFlagged: z.boolean().optional()
+  isFlagged: z.boolean().optional(),
+  hasFace: z.boolean().optional()
 }).strict();
 
 export const ConnectionRequestCreateManyFromUserInputSchema: z.ZodType<Prisma.ConnectionRequestCreateManyFromUserInput> = z.object({
@@ -13646,6 +13760,7 @@ export const ProfileImageUpdateWithoutUserInputSchema: z.ZodType<Prisma.ProfileI
   blurhash: z.union([ z.string(),z.lazy(() => NullableStringFieldUpdateOperationsInputSchema) ]).optional().nullable(),
   isModerated: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   isFlagged: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
+  hasFace: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   profile: z.lazy(() => ProfileUpdateOneWithoutProfileImagesNestedInputSchema).optional()
 }).strict();
 
@@ -13665,6 +13780,7 @@ export const ProfileImageUncheckedUpdateWithoutUserInputSchema: z.ZodType<Prisma
   blurhash: z.union([ z.string(),z.lazy(() => NullableStringFieldUpdateOperationsInputSchema) ]).optional().nullable(),
   isModerated: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   isFlagged: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
+  hasFace: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
 }).strict();
 
 export const ProfileImageUncheckedUpdateManyWithoutUserInputSchema: z.ZodType<Prisma.ProfileImageUncheckedUpdateManyWithoutUserInput> = z.object({
@@ -13683,6 +13799,7 @@ export const ProfileImageUncheckedUpdateManyWithoutUserInputSchema: z.ZodType<Pr
   blurhash: z.union([ z.string(),z.lazy(() => NullableStringFieldUpdateOperationsInputSchema) ]).optional().nullable(),
   isModerated: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   isFlagged: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
+  hasFace: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
 }).strict();
 
 export const ConnectionRequestUpdateWithoutFromUserInputSchema: z.ZodType<Prisma.ConnectionRequestUpdateWithoutFromUserInput> = z.object({
@@ -13781,7 +13898,8 @@ export const ProfileImageCreateManyProfileInputSchema: z.ZodType<Prisma.ProfileI
   contentHash: z.string().optional().nullable(),
   blurhash: z.string().optional().nullable(),
   isModerated: z.boolean().optional(),
-  isFlagged: z.boolean().optional()
+  isFlagged: z.boolean().optional(),
+  hasFace: z.boolean().optional()
 }).strict();
 
 export const ConversationParticipantCreateManyProfileInputSchema: z.ZodType<Prisma.ConversationParticipantCreateManyProfileInput> = z.object({
@@ -13954,6 +14072,7 @@ export const ProfileImageUpdateWithoutProfileInputSchema: z.ZodType<Prisma.Profi
   blurhash: z.union([ z.string(),z.lazy(() => NullableStringFieldUpdateOperationsInputSchema) ]).optional().nullable(),
   isModerated: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   isFlagged: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
+  hasFace: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   user: z.lazy(() => UserUpdateOneRequiredWithoutProfileImageNestedInputSchema).optional()
 }).strict();
 
@@ -13973,6 +14092,7 @@ export const ProfileImageUncheckedUpdateWithoutProfileInputSchema: z.ZodType<Pri
   blurhash: z.union([ z.string(),z.lazy(() => NullableStringFieldUpdateOperationsInputSchema) ]).optional().nullable(),
   isModerated: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   isFlagged: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
+  hasFace: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
 }).strict();
 
 export const ProfileImageUncheckedUpdateManyWithoutProfileInputSchema: z.ZodType<Prisma.ProfileImageUncheckedUpdateManyWithoutProfileInput> = z.object({
@@ -13991,6 +14111,7 @@ export const ProfileImageUncheckedUpdateManyWithoutProfileInputSchema: z.ZodType
   blurhash: z.union([ z.string(),z.lazy(() => NullableStringFieldUpdateOperationsInputSchema) ]).optional().nullable(),
   isModerated: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   isFlagged: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
+  hasFace: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
 }).strict();
 
 export const ConversationParticipantUpdateWithoutProfileInputSchema: z.ZodType<Prisma.ConversationParticipantUpdateWithoutProfileInput> = z.object({
@@ -14181,6 +14302,7 @@ export const ProfileUpdateWithoutBlockedByProfilesInputSchema: z.ZodType<Prisma.
   isBlocked: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   isOnboarded: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   isCallable: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
+  hasFace: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   work: z.union([ z.string(),z.lazy(() => StringFieldUpdateOperationsInputSchema) ]).optional(),
   languages: z.union([ z.lazy(() => ProfileUpdatelanguagesInputSchema),z.string().array() ]).optional(),
   birthday: z.union([ z.coerce.date(),z.lazy(() => NullableDateTimeFieldUpdateOperationsInputSchema) ]).optional().nullable(),
@@ -14228,6 +14350,7 @@ export const ProfileUncheckedUpdateWithoutBlockedByProfilesInputSchema: z.ZodTyp
   isBlocked: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   isOnboarded: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   isCallable: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
+  hasFace: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   userId: z.union([ z.string(),z.lazy(() => StringFieldUpdateOperationsInputSchema) ]).optional(),
   work: z.union([ z.string(),z.lazy(() => StringFieldUpdateOperationsInputSchema) ]).optional(),
   languages: z.union([ z.lazy(() => ProfileUpdatelanguagesInputSchema),z.string().array() ]).optional(),
@@ -14275,6 +14398,7 @@ export const ProfileUncheckedUpdateManyWithoutBlockedByProfilesInputSchema: z.Zo
   isBlocked: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   isOnboarded: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   isCallable: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
+  hasFace: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   userId: z.union([ z.string(),z.lazy(() => StringFieldUpdateOperationsInputSchema) ]).optional(),
   work: z.union([ z.string(),z.lazy(() => StringFieldUpdateOperationsInputSchema) ]).optional(),
   languages: z.union([ z.lazy(() => ProfileUpdatelanguagesInputSchema),z.string().array() ]).optional(),
@@ -14305,6 +14429,7 @@ export const ProfileUpdateWithoutBlockedProfilesInputSchema: z.ZodType<Prisma.Pr
   isBlocked: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   isOnboarded: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   isCallable: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
+  hasFace: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   work: z.union([ z.string(),z.lazy(() => StringFieldUpdateOperationsInputSchema) ]).optional(),
   languages: z.union([ z.lazy(() => ProfileUpdatelanguagesInputSchema),z.string().array() ]).optional(),
   birthday: z.union([ z.coerce.date(),z.lazy(() => NullableDateTimeFieldUpdateOperationsInputSchema) ]).optional().nullable(),
@@ -14352,6 +14477,7 @@ export const ProfileUncheckedUpdateWithoutBlockedProfilesInputSchema: z.ZodType<
   isBlocked: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   isOnboarded: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   isCallable: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
+  hasFace: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   userId: z.union([ z.string(),z.lazy(() => StringFieldUpdateOperationsInputSchema) ]).optional(),
   work: z.union([ z.string(),z.lazy(() => StringFieldUpdateOperationsInputSchema) ]).optional(),
   languages: z.union([ z.lazy(() => ProfileUpdatelanguagesInputSchema),z.string().array() ]).optional(),
@@ -14399,6 +14525,7 @@ export const ProfileUncheckedUpdateManyWithoutBlockedProfilesInputSchema: z.ZodT
   isBlocked: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   isOnboarded: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   isCallable: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
+  hasFace: z.union([ z.boolean(),z.lazy(() => BoolFieldUpdateOperationsInputSchema) ]).optional(),
   userId: z.union([ z.string(),z.lazy(() => StringFieldUpdateOperationsInputSchema) ]).optional(),
   work: z.union([ z.string(),z.lazy(() => StringFieldUpdateOperationsInputSchema) ]).optional(),
   languages: z.union([ z.lazy(() => ProfileUpdatelanguagesInputSchema),z.string().array() ]).optional(),


### PR DESCRIPTION
## Summary

- Adds `ProfileImage.hasFace` populated by MediaPipe face detection during image processing, and `Profile.hasFace` mirroring the position-0 image's flag.
- `syncProfileHasFace(tx, profileId)` runs inside the `addProfileImage`, `deleteImage`, and `reorderImages` transactions so the derived flag stays consistent with the primary image.
- `deleteImage` and `reorderImages` now take `profileId` instead of `userId`.
- Backfill: `scripts/reprocess-images.ts` now persists `hasFace` per image and runs a second pass to populate `Profile.hasFace`.

## Design notes

- **Strict `position = 0` semantic** for "primary": `syncProfileHasFace` reads `WHERE profileId AND position = 0`. If position 0 is missing (e.g. after deleting the primary without reorder), `Profile.hasFace` falls back to `false`. Frontend reorder typically renumbers contiguously so this is a transient state in practice.
- **Service-level hook (no DB trigger)** chosen over a Postgres trigger to keep logic in TS / log-visible. All five hot paths (`storeImage`, `addProfileImage`, `deleteImage`, `reorderImages`, backfill) are wrapped in transactions to guarantee read-after-write consistency.
- Field is **not yet exposed in the UI** — bumped as `patch` per the project's "non-visible improvements" guideline.

## Test plan

- [x] Unit tests added for `ImageProcessor.hasFaces()`, `syncProfileHasFace`, `addProfileImage`, `deleteImage`, `reorderImages` — 643 backend tests passing.
- [x] UAT walkthrough on dev DB: first-upload-with-face, non-primary upload doesn't override, reorder face↔no-face primary, delete primary, delete non-primary — all flags propagated correctly.
- [x] Backfill script verified end-to-end with clean-slate reset: image-loop output count exactly matches `Profile.hasFace=true` count after run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)