### PR TITLE
chore(sentry): lower backend tracesSampleRate to 0.05

### DIFF
--- a/.changeset/six-forks-cry.md
+++ b/.changeset/six-forks-cry.md
@@ -1,0 +1,5 @@
+---
+"@opencupid/backend": patch
+---
+
+chore(sentry): lower backend tracesSampleRate to 0.05

--- a/apps/backend/src/lib/sentry.ts
+++ b/apps/backend/src/lib/sentry.ts
@@ -7,7 +7,7 @@ if (appConfig.NODE_ENV !== 'development') {
     dsn: appConfig.SENTRY_DSN,
     release: `api@${__APP_VERSION__}`,
     environment: appConfig.NODE_ENV,
-    tracesSampleRate: 1.0,
+    tracesSampleRate: 0.05,
     sendDefaultPii: true,
   })
 }


### PR DESCRIPTION
## Summary
- Drop \`tracesSampleRate\` from \`1.0\` → \`0.05\` in \`apps/backend/src/lib/sentry.ts\` (shared by both \`api\` and \`worker\` processes).
- Cuts Sentry transaction volume ~20× to reduce envelope POST noise observed against GlitchTip from \`/api\` traffic.
- Errors (\`Sentry.captureException\`) are unaffected — \`tracesSampleRate\` only governs performance transactions, not error events.

## Test plan
- [ ] Type-check: \`pnpm type-check\`
- [ ] Backend tests: \`pnpm --filter backend test\`
- [ ] After deploy, confirm GlitchTip envelope POST rate drops in Traefik logs and that error events still flow through (manual \`Sentry.captureException\` smoke test per memory recipe).

🤖 Generated with [Claude Code](https://claude.com/claude-code)