### PR TITLE
feat(geocoding): bias photon results from geoip location

### DIFF
--- a/.changeset/geoip-config-add-env.md
+++ b/.changeset/geoip-config-add-env.md
@@ -1,0 +1,5 @@
+---
+'@opencupid/backend': patch
+---
+
+Make geoip-api URL configurable via `GEOIP_API_URL` env var.

--- a/.changeset/photon-bias-from-geoip.md
+++ b/.changeset/photon-bias-from-geoip.md
@@ -1,0 +1,6 @@
+---
+'@opencupid/frontend': minor
+'@opencupid/backend': patch
+---
+
+Bias geocoder results toward the user's geoip location.

--- a/.changeset/quiet-falcon-glow.md
+++ b/.changeset/quiet-falcon-glow.md
@@ -1,0 +1,6 @@
+---
+'@opencupid/backend': minor
+'@opencupid/frontend': minor
+---
+
+Replace MaxMind WebServiceClient with the self-hosted observabilitystack/geoip-api service for IP-based country lookup. The frontend now resolves the user's country once at startup via a non-blocking `appStore.initialize()` call, pre-populates the onboarding location step, and uses the detected country as a default bias for geocoding searches.

--- a/.env.example
+++ b/.env.example
@@ -101,6 +101,11 @@ JVB_ADVERTISE_IPS=${SERVER_IP}
 # DeepL API key for tag translations (optional)
 DEEPL_API_KEY=
 
+# GeoIP lookup service — observabilitystack/geoip-api
+# https://hub.docker.com/r/observabilitystack/geoip-api
+# Default targets the `geoip-api` service in docker-compose.
+GEOIP_API_URL=http://geoip-api:8080
+
 # Tolgee (translation management) — development only
 # In-context editing: install Tolgee Chrome Plugin, Alt+click any string
 TOLGEE_API_URL=http://localhost:8085

--- a/.env.example
+++ b/.env.example
@@ -104,7 +104,7 @@ DEEPL_API_KEY=
 # GeoIP lookup service — observabilitystack/geoip-api
 # https://hub.docker.com/r/observabilitystack/geoip-api
 # Default targets the `geoip-api` service in docker-compose.
-GEOIP_API_URL=http://geoip-api:8080
+GEOIP_API_URL=http://geoip-api:8086
 
 # Tolgee (translation management) — development only
 # In-context editing: install Tolgee Chrome Plugin, Alt+click any string

--- a/.env.example
+++ b/.env.example
@@ -80,10 +80,6 @@ CSP_REPORT_URI=
 # Space-separated list of external API origins allowed in CSP connect-src
 CSP_ALLOWED_DOMAINS="https://photon.komoot.io https://nominatim.openstreetmap.org https://api.maptiler.com https://maps.hereapi.com"
 
-# MaxMind GeoIP — sign up at https://www.maxmind.com/en/geolite2/signup
-MAXMIND_ACCOUNT_ID=1234
-MAXMIND_LICENSE_KEY=your_license_key
-
 # Map tiles — full template URL with API key; use {z}/{x}/{y} placeholders (Leaflet tileLayer)
 # Example (HERE): https://maps.hereapi.com/v3/base/mc/{z}/{x}/{y}/png?apiKey=YOUR_KEY&style=lite.day&size=512
 MAP_TILE_URL=

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -42,7 +42,6 @@
     "@fastify/static": "9.0.0",
     "@fastify/websocket": "11.2.0",
     "@google-cloud/translate": "9.3.0",
-    "@maxmind/geoip2-node": "6.3.4",
     "@prisma/client": "6.15.0",
     "@sentry/node": "10.39.0",
     "@tensorflow-models/face-detection": "1.0.3",

--- a/apps/backend/src/__tests__/routes/app.route.spec.ts
+++ b/apps/backend/src/__tests__/routes/app.route.spec.ts
@@ -1,75 +1,39 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest'
 
-// Mock the MaxMind client
-const mockMaxMindClient = {
-  country: vi.fn(),
-}
-
-vi.mock('@maxmind/geoip2-node', () => {
-  // In Vitest v4, vi.fn() as constructor ignores return value from
-  // the implementation function.  Use a class-based mock instead.
-  class MockWebServiceClient {
-    country = mockMaxMindClient.country
-  }
-  return { WebServiceClient: MockWebServiceClient }
-})
-
 import appRoutes from '../../api/routes/app.route'
 import { MockFastify, MockReply } from '../../test-utils/fastify'
 
 let fastify: MockFastify
 let reply: MockReply
 
-// We'll mock appConfig per test case since it's imported by the route
-const mockAppConfig = vi.hoisted(() => ({
-  NODE_ENV: 'development',
-  MAXMIND_ACCOUNT_ID: 'test-account',
-  MAXMIND_LICENSE_KEY: 'test-key',
-}))
-
-vi.mock('@/lib/appconfig', () => ({
-  appConfig: mockAppConfig,
-}))
+const mockFetch = vi.fn()
 
 beforeEach(async () => {
   fastify = new MockFastify()
   reply = new MockReply()
   fastify.authenticate = vi.fn()
+  vi.stubGlobal('fetch', mockFetch)
   await appRoutes(fastify as any, {})
 })
 
 afterEach(() => {
+  vi.unstubAllGlobals()
   vi.clearAllMocks()
 })
 
+function jsonResponse(body: unknown, init: { ok?: boolean; status?: number } = {}) {
+  return {
+    ok: init.ok ?? true,
+    status: init.status ?? 200,
+    json: async () => body,
+  }
+}
+
 describe('GET /location', () => {
-  it('returns mock location when NODE_ENV is development', async () => {
-    mockAppConfig.NODE_ENV = 'development'
-    const handler = fastify.routes['GET /location']
-
-    await handler(
-      {
-        headers: { 'x-forwarded-for': '192.168.1.1' },
-        ip: '127.0.0.1',
-      } as any,
-      reply as any
-    )
-
-    expect(reply.statusCode).toBe(200)
-    expect(reply.payload.success).toBe(true)
-    expect(reply.payload.location.country).toBe('MX')
-    expect(reply.payload.location.cityName).toBe('')
-    expect(mockMaxMindClient.country).not.toHaveBeenCalled()
-  })
-
-  it('calls MaxMind service when NODE_ENV is production', async () => {
-    mockAppConfig.NODE_ENV = 'production'
-    mockMaxMindClient.country.mockResolvedValue({
-      country: { isoCode: 'US' },
-    })
+  it('queries geoip-api with the client IP and returns the country', async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse({ country: 'US' }))
 
     const handler = fastify.routes['GET /location']
-
     await handler(
       {
         headers: { 'x-forwarded-for': '8.8.8.8' },
@@ -81,37 +45,31 @@ describe('GET /location', () => {
     expect(reply.statusCode).toBe(200)
     expect(reply.payload.success).toBe(true)
     expect(reply.payload.location.country).toBe('US')
-    expect(mockMaxMindClient.country).toHaveBeenCalledWith('8.8.8.8')
+    expect(reply.payload.location.cityName).toBe('')
+    expect(mockFetch).toHaveBeenCalledWith('http://geoip-api:8080/8.8.8.8')
   })
 
-  it('calls MaxMind service when NODE_ENV is test', async () => {
-    mockAppConfig.NODE_ENV = 'test'
-    mockMaxMindClient.country.mockResolvedValue({
-      country: { isoCode: 'CA' },
-    })
+  it('returns an empty country when geoip-api omits one (e.g. private IP)', async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse({}))
 
     const handler = fastify.routes['GET /location']
-
     await handler(
       {
-        headers: { 'x-forwarded-for': '1.2.3.4' },
-        ip: '1.2.3.4',
+        headers: {},
+        ip: '127.0.0.1',
       } as any,
       reply as any
     )
 
     expect(reply.statusCode).toBe(200)
     expect(reply.payload.success).toBe(true)
-    expect(reply.payload.location.country).toBe('CA')
-    expect(mockMaxMindClient.country).toHaveBeenCalledWith('1.2.3.4')
+    expect(reply.payload.location.country).toBe('')
   })
 
-  it('handles MaxMind service errors gracefully', async () => {
-    mockAppConfig.NODE_ENV = 'production'
-    mockMaxMindClient.country.mockRejectedValue(new Error('MaxMind error'))
+  it('handles upstream errors gracefully', async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse({}, { ok: false, status: 502 }))
 
     const handler = fastify.routes['GET /location']
-
     await handler(
       {
         headers: { 'x-forwarded-for': '8.8.8.8' },
@@ -125,14 +83,43 @@ describe('GET /location', () => {
     expect(reply.payload.message).toBe('Location lookup failed')
   })
 
-  it('extracts client IP from x-forwarded-for header', async () => {
-    mockAppConfig.NODE_ENV = 'production'
-    mockMaxMindClient.country.mockResolvedValue({
-      country: { isoCode: 'FR' },
-    })
+  it('handles network errors gracefully', async () => {
+    mockFetch.mockRejectedValueOnce(new Error('ECONNREFUSED'))
 
     const handler = fastify.routes['GET /location']
+    await handler(
+      {
+        headers: { 'x-forwarded-for': '8.8.8.8' },
+        ip: '8.8.8.8',
+      } as any,
+      reply as any
+    )
 
+    expect(reply.statusCode).toBe(500)
+    expect(reply.payload.success).toBe(false)
+    expect(reply.payload.message).toBe('Location lookup failed')
+  })
+
+  it('rejects malformed upstream responses via zod', async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse({ country: 'NOT_AN_ISO_CODE' }))
+
+    const handler = fastify.routes['GET /location']
+    await handler(
+      {
+        headers: { 'x-forwarded-for': '8.8.8.8' },
+        ip: '8.8.8.8',
+      } as any,
+      reply as any
+    )
+
+    expect(reply.statusCode).toBe(500)
+    expect(reply.payload.success).toBe(false)
+  })
+
+  it('extracts client IP from x-forwarded-for header', async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse({ country: 'FR' }))
+
+    const handler = fastify.routes['GET /location']
     await handler(
       {
         headers: { 'x-forwarded-for': '203.0.113.1, 198.51.100.1' },
@@ -141,17 +128,13 @@ describe('GET /location', () => {
       reply as any
     )
 
-    expect(mockMaxMindClient.country).toHaveBeenCalledWith('203.0.113.1')
+    expect(mockFetch).toHaveBeenCalledWith('http://geoip-api:8080/203.0.113.1')
   })
 
   it('strips IPv6 prefix from IPv4-mapped addresses', async () => {
-    mockAppConfig.NODE_ENV = 'production'
-    mockMaxMindClient.country.mockResolvedValue({
-      country: { isoCode: 'DE' },
-    })
+    mockFetch.mockResolvedValueOnce(jsonResponse({ country: 'DE' }))
 
     const handler = fastify.routes['GET /location']
-
     await handler(
       {
         headers: { 'x-forwarded-for': '::ffff:203.0.113.1' },
@@ -160,7 +143,7 @@ describe('GET /location', () => {
       reply as any
     )
 
-    expect(mockMaxMindClient.country).toHaveBeenCalledWith('203.0.113.1')
+    expect(mockFetch).toHaveBeenCalledWith('http://geoip-api:8080/203.0.113.1')
   })
 })
 

--- a/apps/backend/src/__tests__/routes/app.route.spec.ts
+++ b/apps/backend/src/__tests__/routes/app.route.spec.ts
@@ -1,10 +1,12 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest'
 
 import appRoutes from '../../api/routes/app.route'
+import { appConfig } from '../../lib/appconfig'
 import { MockFastify, MockReply } from '../../test-utils/fastify'
 
 let fastify: MockFastify
 let reply: MockReply
+let originalGeoipUrl: string
 
 const mockFetch = vi.fn()
 
@@ -13,12 +15,15 @@ beforeEach(async () => {
   reply = new MockReply()
   fastify.authenticate = vi.fn()
   vi.stubGlobal('fetch', mockFetch)
+  originalGeoipUrl = appConfig.GEOIP_API_URL
+  appConfig.GEOIP_API_URL = 'http://geoip-api:8080'
   await appRoutes(fastify as any, {})
 })
 
 afterEach(() => {
   vi.unstubAllGlobals()
   vi.clearAllMocks()
+  appConfig.GEOIP_API_URL = originalGeoipUrl
 })
 
 function jsonResponse(body: unknown, init: { ok?: boolean; status?: number } = {}) {
@@ -45,11 +50,10 @@ describe('GET /location', () => {
     expect(reply.statusCode).toBe(200)
     expect(reply.payload.success).toBe(true)
     expect(reply.payload.location.country).toBe('US')
-    expect(reply.payload.location.cityName).toBe('')
     expect(mockFetch).toHaveBeenCalledWith('http://geoip-api:8080/8.8.8.8')
   })
 
-  it('returns an empty country when geoip-api omits one (e.g. private IP)', async () => {
+  it('returns a location with undefined country when geoip-api omits it (e.g. private IP)', async () => {
     mockFetch.mockResolvedValueOnce(jsonResponse({}))
 
     const handler = fastify.routes['GET /location']
@@ -63,10 +67,33 @@ describe('GET /location', () => {
 
     expect(reply.statusCode).toBe(200)
     expect(reply.payload.success).toBe(true)
-    expect(reply.payload.location.country).toBe('')
+    expect(reply.payload.location.country).toBeUndefined()
   })
 
-  it('handles upstream errors gracefully', async () => {
+  it('returns 500 when geoip-api responds with a non-JSON body', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => {
+        throw new SyntaxError('Unexpected end of JSON input')
+      },
+    })
+
+    const handler = fastify.routes['GET /location']
+    await handler(
+      {
+        headers: {},
+        ip: '127.0.0.1',
+      } as any,
+      reply as any
+    )
+
+    expect(reply.statusCode).toBe(500)
+    expect(reply.payload.success).toBe(false)
+    expect(reply.payload.message).toBe('Location lookup failed')
+  })
+
+  it('returns 502 when upstream returns non-2xx', async () => {
     mockFetch.mockResolvedValueOnce(jsonResponse({}, { ok: false, status: 502 }))
 
     const handler = fastify.routes['GET /location']
@@ -78,9 +105,9 @@ describe('GET /location', () => {
       reply as any
     )
 
-    expect(reply.statusCode).toBe(500)
+    expect(reply.statusCode).toBe(502)
     expect(reply.payload.success).toBe(false)
-    expect(reply.payload.message).toBe('Location lookup failed')
+    expect(reply.payload.message).toBe('Geolocation upstream error')
   })
 
   it('handles network errors gracefully', async () => {
@@ -100,7 +127,7 @@ describe('GET /location', () => {
     expect(reply.payload.message).toBe('Location lookup failed')
   })
 
-  it('rejects malformed upstream responses via zod', async () => {
+  it('returns 502 when upstream response fails zod validation', async () => {
     mockFetch.mockResolvedValueOnce(jsonResponse({ country: 'NOT_AN_ISO_CODE' }))
 
     const handler = fastify.routes['GET /location']
@@ -112,8 +139,9 @@ describe('GET /location', () => {
       reply as any
     )
 
-    expect(reply.statusCode).toBe(500)
+    expect(reply.statusCode).toBe(502)
     expect(reply.payload.success).toBe(false)
+    expect(reply.payload.message).toBe('Geolocation upstream returned malformed data')
   })
 
   it('extracts client IP from x-forwarded-for header', async () => {

--- a/apps/backend/src/api/routes/app.route.ts
+++ b/apps/backend/src/api/routes/app.route.ts
@@ -5,8 +5,7 @@ import { LocationSchema, type LocationDTO } from '@zod/dto/location.dto'
 import { VersionSchema, type VersionDTO } from '@zod/dto/version.dto'
 import type { ApiError } from '@shared/zod/apiResponse.dto'
 import { rateLimitConfig } from '../helpers'
-
-const GEOIP_API_URL = 'http://geoip-api:8080'
+import { appConfig } from '@/lib/appconfig'
 
 const GeoipApiResponseSchema = z.object({
   country: z.string().min(2).max(2).optional(),
@@ -60,12 +59,13 @@ const appRoutes: FastifyPluginAsync = async (fastify) => {
   /**
    * GET /location
    * Returns the client's country based on IP geolocation, looked up via the
-   * observabilitystack/geoip-api service running at GEOIP_API_URL.
+   * observabilitystack/geoip-api service running at appConfig.GEOIP_API_URL.
    * @returns {{ success, location: LocationDTO }} { country, cityName }
    */
   fastify.get(
     '/location',
     {
+      onRequest: [fastify.authenticate],
       config: {
         ...rateLimitConfig(fastify, '5 minute', 5),
       },
@@ -74,8 +74,16 @@ const appRoutes: FastifyPluginAsync = async (fastify) => {
       const rawHeader = req.headers['x-forwarded-for'] as string | undefined
       const clientIp = extractClientIp(rawHeader, req.ip)
 
+      if (appConfig.NODE_ENV === 'development') {
+        const location: LocationDTO = {
+          country: 'HU',
+          cityName: '',
+        }
+        return reply.code(200).send({ success: true, location })
+      }
+
       try {
-        const res = await fetch(`${GEOIP_API_URL}/${encodeURIComponent(clientIp)}`)
+        const res = await fetch(`${appConfig.GEOIP_API_URL}/${encodeURIComponent(clientIp)}`)
         if (!res.ok) {
           throw new Error(`geoip-api returned ${res.status}`)
         }

--- a/apps/backend/src/api/routes/app.route.ts
+++ b/apps/backend/src/api/routes/app.route.ts
@@ -1,15 +1,44 @@
 import { FastifyPluginAsync } from 'fastify'
 import { z } from 'zod'
 
-import { LocationSchema, type LocationDTO } from '@zod/dto/location.dto'
 import { VersionSchema, type VersionDTO } from '@zod/dto/version.dto'
 import type { ApiError } from '@shared/zod/apiResponse.dto'
-import { rateLimitConfig } from '../helpers'
+import { rateLimitConfig, sendError } from '../helpers'
+
 import { appConfig } from '@/lib/appconfig'
 
-const GeoipApiResponseSchema = z.object({
-  country: z.string().min(2).max(2).optional(),
-})
+/*
+$ curl -s http://localhost:8086/185.65.134.195|jq
+{
+  "country": "NL",
+  "stateprov": "North Holland",
+  "stateprovCode": "NH",
+  "city": "Amsterdam",
+  "latitude": "52.3385",
+  "longitude": "4.9168",
+  "continent": "EU",
+  "timezone": "Europe/Amsterdam",
+  "accuracyRadius": 20,
+  "asn": 39351,
+  "asnOrganization": "31173 Services AB",
+  "asnNetwork": "185.65.132.0/22"
+}
+
+*/
+// observabilitystack/geoip-api returns latitude/longitude as strings
+// (e.g. "52.3385"). Coerce them to numbers and remap to lat/lon so the
+// output shape matches LocationDTO.
+const GeoipApiResponseSchema = z
+  .object({
+    country: z.string().min(2).max(2).optional(),
+    latitude: z.coerce.number().optional(),
+    longitude: z.coerce.number().optional(),
+  })
+  .transform(({ country, latitude, longitude }) => ({
+    country,
+    lat: latitude,
+    lon: longitude,
+  }))
 
 function extractClientIp(headerValue: string | undefined, fallbackIp: string): string {
   const rawIp = headerValue?.split(',')[0].trim() ?? fallbackIp
@@ -67,37 +96,44 @@ const appRoutes: FastifyPluginAsync = async (fastify) => {
     {
       onRequest: [fastify.authenticate],
       config: {
-        ...rateLimitConfig(fastify, '5 minute', 5),
+        ...rateLimitConfig(fastify, '1 minute', 15),
       },
     },
     async (req, reply) => {
       const rawHeader = req.headers['x-forwarded-for'] as string | undefined
-      const clientIp = extractClientIp(rawHeader, req.ip)
+      let clientIp = extractClientIp(rawHeader, req.ip)
 
       if (appConfig.NODE_ENV === 'development') {
-        const location: LocationDTO = {
-          country: 'HU',
-          cityName: '',
-        }
-        return reply.code(200).send({ success: true, location })
+        clientIp = '188.6.25.123'
       }
 
       try {
         const res = await fetch(`${appConfig.GEOIP_API_URL}/${encodeURIComponent(clientIp)}`)
+
+        if (res.status === 400) {
+          return sendError(reply, 422, 'Invalid IP address')
+        }
+
+        if (res.status === 404) {
+          return sendError(reply, 422, 'IP not found')
+        }
+
         if (!res.ok) {
-          throw new Error(`geoip-api returned ${res.status}`)
+          fastify.log.warn({ status: res.status }, 'geoip-api returned non-2xx')
+          return sendError(reply, 502, 'Geolocation upstream error')
         }
-        const parsed = GeoipApiResponseSchema.parse(await res.json())
-        const location: LocationDTO = {
-          country: parsed.country ?? '',
-          cityName: '',
+
+        const body = await res.json()
+        const parsed = GeoipApiResponseSchema.safeParse(body)
+        if (!parsed.success) {
+          fastify.log.warn({ err: parsed.error, body }, 'geoip-api response shape unexpected')
+          return sendError(reply, 502, 'Geolocation upstream returned malformed data')
         }
-        const payload = LocationSchema.parse(location)
-        return reply.code(200).send({ success: true, location: payload })
+
+        return reply.code(200).send({ success: true, location: parsed.data })
       } catch (err) {
-        fastify.log.error(err)
-        const out: ApiError = { success: false, message: 'Location lookup failed' }
-        return reply.code(500).send(out)
+        fastify.log.warn(err)
+        return sendError(reply, 500, 'Location lookup failed')
       }
     }
   )

--- a/apps/backend/src/api/routes/app.route.ts
+++ b/apps/backend/src/api/routes/app.route.ts
@@ -1,11 +1,16 @@
 import { FastifyPluginAsync } from 'fastify'
-import { WebServiceClient } from '@maxmind/geoip2-node'
+import { z } from 'zod'
 
-import { appConfig } from '@/lib/appconfig'
 import { LocationSchema, type LocationDTO } from '@zod/dto/location.dto'
 import { VersionSchema, type VersionDTO } from '@zod/dto/version.dto'
 import type { ApiError } from '@shared/zod/apiResponse.dto'
 import { rateLimitConfig } from '../helpers'
+
+const GEOIP_API_URL = 'http://geoip-api:8080'
+
+const GeoipApiResponseSchema = z.object({
+  country: z.string().min(2).max(2).optional(),
+})
 
 function extractClientIp(headerValue: string | undefined, fallbackIp: string): string {
   const rawIp = headerValue?.split(',')[0].trim() ?? fallbackIp
@@ -54,14 +59,13 @@ const appRoutes: FastifyPluginAsync = async (fastify) => {
 
   /**
    * GET /location
-   * Returns the client's country based on IP geolocation (MaxMind GeoLite2).
-   * In development, returns a hardcoded country ('MX').
+   * Returns the client's country based on IP geolocation, looked up via the
+   * observabilitystack/geoip-api service running at GEOIP_API_URL.
    * @returns {{ success, location: LocationDTO }} { country, cityName }
    */
   fastify.get(
     '/location',
     {
-      onRequest: [fastify.authenticate],
       config: {
         ...rateLimitConfig(fastify, '5 minute', 5),
       },
@@ -70,24 +74,14 @@ const appRoutes: FastifyPluginAsync = async (fastify) => {
       const rawHeader = req.headers['x-forwarded-for'] as string | undefined
       const clientIp = extractClientIp(rawHeader, req.ip)
 
-      if (appConfig.NODE_ENV === 'development') {
-        const location: LocationDTO = {
-          country: 'MX',
-          cityName: '',
-        }
-        const payload = LocationSchema.parse(location)
-        return reply.code(200).send({ success: true, location: payload })
-      }
-
       try {
-        const client = new WebServiceClient(
-          appConfig.MAXMIND_ACCOUNT_ID,
-          appConfig.MAXMIND_LICENSE_KEY,
-          { host: 'geolite.info' }
-        )
-        const result = await client.country(clientIp)
+        const res = await fetch(`${GEOIP_API_URL}/${encodeURIComponent(clientIp)}`)
+        if (!res.ok) {
+          throw new Error(`geoip-api returned ${res.status}`)
+        }
+        const parsed = GeoipApiResponseSchema.parse(await res.json())
         const location: LocationDTO = {
-          country: result.country?.isoCode ?? '',
+          country: parsed.country ?? '',
           cityName: '',
         }
         const payload = LocationSchema.parse(location)

--- a/apps/backend/src/lib/appconfig.ts
+++ b/apps/backend/src/lib/appconfig.ts
@@ -49,6 +49,8 @@ export const configSchema = z.object({
 
   DEEPL_API_KEY: z.string().optional(),
 
+  GEOIP_API_URL: z.string().url().default('http://geoip-api:8080'),
+
   DEV_AUTH_BYPASS_ENABLED: z
     .enum(['true', 'false'])
     .default('false')

--- a/apps/backend/src/lib/appconfig.ts
+++ b/apps/backend/src/lib/appconfig.ts
@@ -37,9 +37,6 @@ export const configSchema = z.object({
 
   SENTRY_DSN: z.string().optional(),
 
-  MAXMIND_ACCOUNT_ID: z.string(),
-  MAXMIND_LICENSE_KEY: z.string(),
-
   VOICE_MESSAGE_MAX_DURATION: z.coerce.number().default(120), // Max duration in seconds
 
   WELCOME_MESSAGE_SENDER_PROFILE_ID: z.string().optional(),

--- a/apps/frontend/src/features/app/stores/__tests__/appStore.spec.ts
+++ b/apps/frontend/src/features/app/stores/__tests__/appStore.spec.ts
@@ -90,3 +90,61 @@ describe('useAppStore - checkVersion', () => {
     expect(mockGetVersionInfo).toHaveBeenCalledTimes(1)
   })
 })
+
+describe('useAppStore - fetchLocation', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+  })
+
+  it('stores the looked-up country in geoipCountry', async () => {
+    const mockGet = apiModule.api.get as any
+    mockGet.mockResolvedValue({
+      data: { success: true, location: { country: 'DE', cityName: '' } },
+    })
+
+    const store = useAppStore()
+    const result = await store.fetchLocation()
+
+    expect(result.success).toBe(true)
+    expect(store.geoipCountry).toBe('DE')
+    expect(mockGet).toHaveBeenCalledWith('/app/location')
+  })
+
+  it('leaves geoipCountry empty on API failure', async () => {
+    const mockGet = apiModule.api.get as any
+    mockGet.mockRejectedValue(new Error('boom'))
+
+    const store = useAppStore()
+    const result = await store.fetchLocation()
+
+    expect(result.success).toBe(false)
+    expect(store.geoipCountry).toBe('')
+  })
+})
+
+describe('useAppStore - initialize', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+  })
+
+  it('kicks off fetchLocation without blocking', async () => {
+    const mockGet = apiModule.api.get as any
+    let resolveGet!: (v: unknown) => void
+    mockGet.mockReturnValue(
+      new Promise((resolve) => {
+        resolveGet = resolve
+      })
+    )
+
+    const store = useAppStore()
+    store.initialize()
+
+    expect(mockGet).toHaveBeenCalledWith('/app/location')
+
+    resolveGet({ data: { success: true, location: { country: 'FR', cityName: '' } } })
+    await new Promise((r) => setTimeout(r, 0))
+    expect(store.geoipCountry).toBe('FR')
+  })
+})

--- a/apps/frontend/src/features/app/stores/__tests__/appStore.spec.ts
+++ b/apps/frontend/src/features/app/stores/__tests__/appStore.spec.ts
@@ -12,6 +12,7 @@ vi.mock('@/lib/api', () => ({
     get: vi.fn(),
   },
   getVersionInfo: vi.fn(),
+  safeApiCall: vi.fn((fn: () => Promise<unknown>) => fn()),
 }))
 
 describe('useAppStore - checkVersion', () => {
@@ -97,9 +98,10 @@ describe('useAppStore - fetchLocation', () => {
     vi.clearAllMocks()
   })
 
-  it('stores the looked-up country in geoipCountry', async () => {
+  it('stores the looked-up location on success', async () => {
     const mockGet = apiModule.api.get as any
     mockGet.mockResolvedValue({
+      status: 200,
       data: { success: true, location: { country: 'DE', cityName: '' } },
     })
 
@@ -107,11 +109,11 @@ describe('useAppStore - fetchLocation', () => {
     const result = await store.fetchLocation()
 
     expect(result.success).toBe(true)
-    expect(store.geoipCountry).toBe('DE')
+    expect(store.geoipLocation).toEqual({ country: 'DE', cityName: '' })
     expect(mockGet).toHaveBeenCalledWith('/app/location')
   })
 
-  it('leaves geoipCountry empty on API failure', async () => {
+  it('leaves geoipLocation null on API failure', async () => {
     const mockGet = apiModule.api.get as any
     mockGet.mockRejectedValue(new Error('boom'))
 
@@ -119,7 +121,7 @@ describe('useAppStore - fetchLocation', () => {
     const result = await store.fetchLocation()
 
     expect(result.success).toBe(false)
-    expect(store.geoipCountry).toBe('')
+    expect(store.geoipLocation).toBeNull()
   })
 })
 
@@ -139,12 +141,15 @@ describe('useAppStore - initialize', () => {
     )
 
     const store = useAppStore()
-    store.initialize()
+    store.fetchLocation()
 
     expect(mockGet).toHaveBeenCalledWith('/app/location')
 
-    resolveGet({ data: { success: true, location: { country: 'FR', cityName: '' } } })
+    resolveGet({
+      status: 200,
+      data: { success: true, location: { country: 'FR', cityName: '' } },
+    })
     await new Promise((r) => setTimeout(r, 0))
-    expect(store.geoipCountry).toBe('FR')
+    expect(store.geoipLocation).toEqual({ country: 'FR', cityName: '' })
   })
 })

--- a/apps/frontend/src/features/app/stores/appStore.ts
+++ b/apps/frontend/src/features/app/stores/appStore.ts
@@ -13,13 +13,24 @@ export const useAppStore = defineStore('app', {
     latestVersion: '',
     canInstallPwa: false,
     shareCtaDismissed: false,
+    geoipCountry: '' as string,
   }),
   actions: {
+    /**
+     * One-shot startup hook called once from main.ts. Fires off background
+     * lookups (currently just the geoip country) so subsequent UI surfaces
+     * (onboarding, geocoding bias) can read them from the store. Failures
+     * are swallowed — geoipCountry stays empty, callers handle that.
+     */
+    initialize() {
+      void this.fetchLocation()
+    },
     async fetchLocation(): Promise<StoreResponse<LocationDTO>> {
       try {
         this.isLoading = true
         const res = await api.get<LocationResponse>('/app/location')
         const parsed = LocationSchema.parse(res.data.location)
+        this.geoipCountry = parsed.country ?? ''
         return storeSuccess(parsed)
       } catch (err: unknown) {
         return storeError(err, 'Failed to fetch location')

--- a/apps/frontend/src/features/app/stores/appStore.ts
+++ b/apps/frontend/src/features/app/stores/appStore.ts
@@ -1,41 +1,44 @@
 import { defineStore } from 'pinia'
 import { bus } from '@/lib/bus'
-import { api, getVersionInfo } from '@/lib/api'
+import { api, getVersionInfo, safeApiCall } from '@/lib/api'
 import { LocationSchema, type LocationDTO } from '@zod/dto/location.dto'
 import { type VersionDTO } from '@zod/dto/version.dto'
 import type { LocationResponse } from '@zod/apiResponse.dto'
 import { storeSuccess, storeError, type StoreResponse } from '@/store/helpers'
 
+interface AppState {
+  isLoading: boolean
+  updateAvailable: boolean
+  latestVersion: string
+  canInstallPwa: boolean
+  shareCtaDismissed: boolean
+  geoipLocation: LocationDTO | null
+}
+
 export const useAppStore = defineStore('app', {
-  state: () => ({
+  state: (): AppState => ({
     isLoading: false,
     updateAvailable: false,
     latestVersion: '',
     canInstallPwa: false,
     shareCtaDismissed: false,
-    geoipCountry: '' as string,
+    geoipLocation: null,
   }),
   actions: {
-    /**
-     * One-shot startup hook called once from main.ts. Fires off background
-     * lookups (currently just the geoip country) so subsequent UI surfaces
-     * (onboarding, geocoding bias) can read them from the store. Failures
-     * are swallowed — geoipCountry stays empty, callers handle that.
-     */
-    initialize() {
-      void this.fetchLocation()
-    },
-    async fetchLocation(): Promise<StoreResponse<LocationDTO>> {
+    async fetchLocation(): Promise<StoreResponse<void>> {
       try {
-        this.isLoading = true
-        const res = await api.get<LocationResponse>('/app/location')
-        const parsed = LocationSchema.parse(res.data.location)
-        this.geoipCountry = parsed.country ?? ''
-        return storeSuccess(parsed)
-      } catch (err: unknown) {
+        const res = await safeApiCall(() => api.get<LocationResponse>('/app/location'))
+        // 204 means the lookup succeeded but geoip-api had no result for the
+        // client IP (private/loopback, unknown range). Distinct from a 5xx.
+        if (res.status === 200) {
+          const resultLocation = LocationSchema.parse(res.data.location)
+          this.geoipLocation = resultLocation
+          return storeSuccess()
+        }
+        this.geoipLocation = null
+        return storeError(res.status, 'IP not found')
+      } catch (err) {
         return storeError(err, 'Failed to fetch location')
-      } finally {
-        this.isLoading = false
       }
     },
     async checkVersion(): Promise<StoreResponse<VersionDTO>> {

--- a/apps/frontend/src/features/browse/components/SearchBar.vue
+++ b/apps/frontend/src/features/browse/components/SearchBar.vue
@@ -108,7 +108,7 @@ watch(searchQuery, (query) => {
   // Fire both searches in parallel — each store owns its own abort controller,
   // so rapid re-typing cancels prior in-flight requests on both sides.
   searchStore.search(query)
-  geocodingStore.searchNearby(props.viewerProfile?.location?.country ?? '', query, locale.value, 5)
+  geocodingStore.search(query, locale.value, props.viewerProfile?.location)
 })
 
 watch(haveResults, () => {

--- a/apps/frontend/src/features/geocoding/__tests__/photon.spec.ts
+++ b/apps/frontend/src/features/geocoding/__tests__/photon.spec.ts
@@ -113,6 +113,30 @@ describe('searchPhoton', () => {
     expect(config.signal).toBe(controller.signal)
   })
 
+  it('omits bias params when no bias is supplied', async () => {
+    mockGet.mockResolvedValue({ data: { type: 'FeatureCollection', features: [] } })
+
+    await searchPhoton('Berlin', 'en')
+
+    const params: URLSearchParams = mockGet.mock.calls[0]![1].params
+    expect(params.has('lat')).toBe(false)
+    expect(params.has('lon')).toBe(false)
+    expect(params.has('zoom')).toBe(false)
+    expect(params.has('location_bias_scale')).toBe(false)
+  })
+
+  it('forwards bias coords and tuning params when bias is supplied', async () => {
+    mockGet.mockResolvedValue({ data: { type: 'FeatureCollection', features: [] } })
+
+    await searchPhoton('als', 'en', undefined, { lat: 46.679423, lon: 18.5389986 })
+
+    const params: URLSearchParams = mockGet.mock.calls[0]![1].params
+    expect(params.get('lat')).toBe('46.679423')
+    expect(params.get('lon')).toBe('18.5389986')
+    expect(params.get('zoom')).toBe('8')
+    expect(params.get('location_bias_scale')).toBe('0.0')
+  })
+
   it('propagates errors (does not catch)', async () => {
     mockGet.mockRejectedValue(new Error('Network error'))
 

--- a/apps/frontend/src/features/geocoding/providers/photon.ts
+++ b/apps/frontend/src/features/geocoding/providers/photon.ts
@@ -10,7 +10,7 @@ interface PhotonProperties {
 const SUPPORTED_LANGS = ['en', 'de']
 const OSM_TAG_FILTERS = ['place:city', 'place:town', 'place:village', 'place:hamlet']
 
-export const searchPhoton: GeocodingProvider = async (query, lang, signal?) => {
+export const searchPhoton: GeocodingProvider = async (query, lang, signal?, bias?) => {
   const params = new URLSearchParams()
   params.set('q', query)
   params.set('lang', SUPPORTED_LANGS.includes(lang) ? lang : 'en')
@@ -20,6 +20,16 @@ export const searchPhoton: GeocodingProvider = async (query, lang, signal?) => {
   }
   params.append('layer', 'city')
   params.append('layer', 'locality')
+  if (bias) {
+    params.set('lat', String(bias.lat))
+    params.set('lon', String(bias.lon))
+    // Photon defaults (zoom=12, location_bias_scale=0.4) leave prominence
+    // strong enough that a faraway exact-name match (e.g. "Als" in DK) beats
+    // nearby villages. Widen the radius and downweight prominence so the
+    // bias point dominates ranking.
+    params.set('zoom', '8')
+    params.set('location_bias_scale', '0.0')
+  }
 
   const res = await axios.get<FeatureCollection<Point, PhotonProperties>>(
     'https://photon.komoot.io/api/',

--- a/apps/frontend/src/features/geocoding/stores/__tests__/geocodingStore.spec.ts
+++ b/apps/frontend/src/features/geocoding/stores/__tests__/geocodingStore.spec.ts
@@ -8,7 +8,6 @@ vi.mock('../../composables/useGeocoder', () => ({
 }))
 
 import { useGeocodingStore } from '../geocodingStore'
-import { useAppStore } from '@/features/app/stores/appStore'
 
 describe('geocodingStore', () => {
   beforeEach(() => {
@@ -23,7 +22,7 @@ describe('geocodingStore', () => {
     const store = useGeocodingStore()
     const results = await store.search('Berlin', 'en')
 
-    expect(mockSearch).toHaveBeenCalledWith('Berlin', 'en', expect.any(AbortSignal))
+    expect(mockSearch).toHaveBeenCalledWith('Berlin', 'en', expect.any(AbortSignal), null)
     expect(results).toEqual(mockResults)
     expect(store.results).toEqual(mockResults)
   })
@@ -142,52 +141,60 @@ describe('geocodingStore', () => {
     expect(store.results.slice(1).map((r) => r.name)).toContain('San Juan Bautista')
   })
 
-  it('uses appStore.geoipCountry as the bias when no explicit country is given', async () => {
-    const unsorted = [
-      { name: 'Paris', country: 'FR', lat: 48.85, lon: 2.35 },
-      { name: 'Paris', country: 'US', lat: 33.66, lon: -95.55 },
-    ]
-    mockSearch.mockResolvedValue(unsorted)
-
-    const appStore = useAppStore()
-    appStore.geoipCountry = 'US'
+  it('forwards locationBias coords to the geocoder as bias', async () => {
+    mockSearch.mockResolvedValue([])
 
     const store = useGeocodingStore()
-    await store.searchNearby('', 'paris', 'en', 5)
+    await store.search('Berlin', 'en', {
+      country: 'DE',
+      cityName: '',
+      lat: 52.52,
+      lon: 13.405,
+    })
 
-    expect(store.results[0]!.country).toBe('US')
+    expect(mockSearch).toHaveBeenCalledWith('Berlin', 'en', expect.any(AbortSignal), {
+      lat: 52.52,
+      lon: 13.405,
+    })
   })
 
-  it('prefers explicit country bias over geoipCountry', async () => {
-    const unsorted = [
-      { name: 'Paris', country: 'US', lat: 33.66, lon: -95.55 },
-      { name: 'Paris', country: 'FR', lat: 48.85, lon: 2.35 },
-    ]
-    mockSearch.mockResolvedValue(unsorted)
-
-    const appStore = useAppStore()
-    appStore.geoipCountry = 'US'
+  it('omits bias when locationBias has no coords', async () => {
+    mockSearch.mockResolvedValue([])
 
     const store = useGeocodingStore()
-    await store.searchNearby('FR', 'paris', 'en', 5)
+    await store.search('Berlin', 'en', { country: 'DE', cityName: '' })
 
-    expect(store.results[0]!.country).toBe('FR')
+    expect(mockSearch).toHaveBeenCalledWith('Berlin', 'en', expect.any(AbortSignal), null)
   })
 
-  it('promotes geoipCountry hits within the same exact-match tier in search()', async () => {
-    const unsorted = [
-      { name: 'Paris', country: 'US', lat: 33.66, lon: -95.55 },
-      { name: 'Paris', country: 'FR', lat: 48.85, lon: 2.35 },
-    ]
-    mockSearch.mockResolvedValue(unsorted)
-
-    const appStore = useAppStore()
-    appStore.geoipCountry = 'FR'
+  it('caps results to the default take of 5', async () => {
+    const many = Array.from({ length: 10 }, (_, i) => ({
+      name: `City${i}`,
+      country: 'DE',
+      lat: 0,
+      lon: 0,
+    }))
+    mockSearch.mockResolvedValue(many)
 
     const store = useGeocodingStore()
-    await store.search('paris', 'en')
+    await store.search('city', 'en')
 
-    expect(store.results[0]!.country).toBe('FR')
+    expect(store.results).toHaveLength(5)
+  })
+
+  it('respects an explicit take parameter', async () => {
+    const many = Array.from({ length: 10 }, (_, i) => ({
+      name: `City${i}`,
+      country: 'DE',
+      lat: 0,
+      lon: 0,
+    }))
+    mockSearch.mockResolvedValue(many)
+
+    const store = useGeocodingStore()
+    await store.search('city', 'en', null, 3)
+
+    expect(store.results).toHaveLength(3)
   })
 
   it('does not treat a CanceledError as a real failure', async () => {

--- a/apps/frontend/src/features/geocoding/stores/__tests__/geocodingStore.spec.ts
+++ b/apps/frontend/src/features/geocoding/stores/__tests__/geocodingStore.spec.ts
@@ -8,6 +8,7 @@ vi.mock('../../composables/useGeocoder', () => ({
 }))
 
 import { useGeocodingStore } from '../geocodingStore'
+import { useAppStore } from '@/features/app/stores/appStore'
 
 describe('geocodingStore', () => {
   beforeEach(() => {
@@ -139,6 +140,54 @@ describe('geocodingStore', () => {
     expect(store.results[0]!.name).toBe('San Juan')
     expect(store.results.slice(1).map((r) => r.name)).toContain('San Juan de la Nava')
     expect(store.results.slice(1).map((r) => r.name)).toContain('San Juan Bautista')
+  })
+
+  it('uses appStore.geoipCountry as the bias when no explicit country is given', async () => {
+    const unsorted = [
+      { name: 'Paris', country: 'FR', lat: 48.85, lon: 2.35 },
+      { name: 'Paris', country: 'US', lat: 33.66, lon: -95.55 },
+    ]
+    mockSearch.mockResolvedValue(unsorted)
+
+    const appStore = useAppStore()
+    appStore.geoipCountry = 'US'
+
+    const store = useGeocodingStore()
+    await store.searchNearby('', 'paris', 'en', 5)
+
+    expect(store.results[0]!.country).toBe('US')
+  })
+
+  it('prefers explicit country bias over geoipCountry', async () => {
+    const unsorted = [
+      { name: 'Paris', country: 'US', lat: 33.66, lon: -95.55 },
+      { name: 'Paris', country: 'FR', lat: 48.85, lon: 2.35 },
+    ]
+    mockSearch.mockResolvedValue(unsorted)
+
+    const appStore = useAppStore()
+    appStore.geoipCountry = 'US'
+
+    const store = useGeocodingStore()
+    await store.searchNearby('FR', 'paris', 'en', 5)
+
+    expect(store.results[0]!.country).toBe('FR')
+  })
+
+  it('promotes geoipCountry hits within the same exact-match tier in search()', async () => {
+    const unsorted = [
+      { name: 'Paris', country: 'US', lat: 33.66, lon: -95.55 },
+      { name: 'Paris', country: 'FR', lat: 48.85, lon: 2.35 },
+    ]
+    mockSearch.mockResolvedValue(unsorted)
+
+    const appStore = useAppStore()
+    appStore.geoipCountry = 'FR'
+
+    const store = useGeocodingStore()
+    await store.search('paris', 'en')
+
+    expect(store.results[0]!.country).toBe('FR')
   })
 
   it('does not treat a CanceledError as a real failure', async () => {

--- a/apps/frontend/src/features/geocoding/stores/geocodingStore.ts
+++ b/apps/frontend/src/features/geocoding/stores/geocodingStore.ts
@@ -1,6 +1,7 @@
 import { defineStore } from 'pinia'
 import { computed, ref } from 'vue'
 import { useGeocoder } from '../composables/useGeocoder'
+import { useAppStore } from '@/features/app/stores/appStore'
 import type { GeocodingResult } from '../types'
 
 export type { GeocodingResult }
@@ -20,10 +21,15 @@ export const useGeocodingStore = defineStore('geocoding', () => {
     take: number = 5
   ): Promise<GeocodingResult[]> {
     await search(query, lang)
-    const preferred = country.toUpperCase()
-    // Stable sort: entries already ranked by exact-name match in search(),
-    // here we only promote in-country matches to the top without disturbing
-    // that secondary order.
+    // Bias toward the explicit country when one is supplied; otherwise fall
+    // back to the country detected from the client IP at app startup. Either
+    // way the bias is a stable sort that promotes in-country hits without
+    // disturbing the exact-name ranking applied in search().
+    const preferred = (country || useAppStore().geoipCountry).toUpperCase()
+    if (!preferred) {
+      results.value = results.value.slice(0, take)
+      return results.value
+    }
     results.value = [...results.value]
       .sort(
         (a, b) =>
@@ -48,16 +54,25 @@ export const useGeocodingStore = defineStore('geocoding', () => {
     const { signal } = _abortController
 
     const normalizedQuery = query.trim().toLowerCase()
+    const geoipCountry = useAppStore().geoipCountry.toUpperCase()
 
     isLoading.value = true
     try {
       const data = await geocode(query, lang, signal)
       if (!signal.aborted) {
-        results.value = data.sort(
-          (a, b) =>
+        results.value = data.sort((a, b) => {
+          const exactMatchDiff =
             Number(a.name.toLowerCase() !== normalizedQuery) -
             Number(b.name.toLowerCase() !== normalizedQuery)
-        )
+          if (exactMatchDiff !== 0 || !geoipCountry) return exactMatchDiff
+          // Within the same exact-match tier, promote results from the
+          // geoip-detected country so the user sees regionally-relevant
+          // hits first when no other country bias is in play.
+          return (
+            Number(a.country.toUpperCase() !== geoipCountry) -
+            Number(b.country.toUpperCase() !== geoipCountry)
+          )
+        })
       }
       return results.value
     } catch (err) {

--- a/apps/frontend/src/features/geocoding/stores/geocodingStore.ts
+++ b/apps/frontend/src/features/geocoding/stores/geocodingStore.ts
@@ -1,7 +1,7 @@
 import { defineStore } from 'pinia'
 import { computed, ref } from 'vue'
 import { useGeocoder } from '../composables/useGeocoder'
-import { useAppStore } from '@/features/app/stores/appStore'
+import { toGeoPoint, type LocationDTO } from '@zod/dto/location.dto'
 import type { GeocodingResult } from '../types'
 
 export type { GeocodingResult }
@@ -14,33 +14,12 @@ export const useGeocodingStore = defineStore('geocoding', () => {
   const results = ref<GeocodingResult[]>([])
   const isLoading = ref(false)
 
-  async function searchNearby(
-    country: string,
+  async function search(
     query: string,
     lang: string,
+    locationBias?: LocationDTO | null,
     take: number = 5
   ): Promise<GeocodingResult[]> {
-    await search(query, lang)
-    // Bias toward the explicit country when one is supplied; otherwise fall
-    // back to the country detected from the client IP at app startup. Either
-    // way the bias is a stable sort that promotes in-country hits without
-    // disturbing the exact-name ranking applied in search().
-    const preferred = (country || useAppStore().geoipCountry).toUpperCase()
-    if (!preferred) {
-      results.value = results.value.slice(0, take)
-      return results.value
-    }
-    results.value = [...results.value]
-      .sort(
-        (a, b) =>
-          Number(a.country.toUpperCase() !== preferred) -
-          Number(b.country.toUpperCase() !== preferred)
-      )
-      .slice(0, take)
-    return results.value
-  }
-
-  async function search(query: string, lang: string): Promise<GeocodingResult[]> {
     if (!query) {
       _abortController?.abort()
       _abortController = null
@@ -54,25 +33,22 @@ export const useGeocodingStore = defineStore('geocoding', () => {
     const { signal } = _abortController
 
     const normalizedQuery = query.trim().toLowerCase()
-    const geoipCountry = useAppStore().geoipCountry.toUpperCase()
+    const bias = toGeoPoint(locationBias)
 
     isLoading.value = true
     try {
-      const data = await geocode(query, lang, signal)
+      const data = await geocode(query, lang, signal, bias)
       if (!signal.aborted) {
-        results.value = data.sort((a, b) => {
-          const exactMatchDiff =
-            Number(a.name.toLowerCase() !== normalizedQuery) -
-            Number(b.name.toLowerCase() !== normalizedQuery)
-          if (exactMatchDiff !== 0 || !geoipCountry) return exactMatchDiff
-          // Within the same exact-match tier, promote results from the
-          // geoip-detected country so the user sees regionally-relevant
-          // hits first when no other country bias is in play.
-          return (
-            Number(a.country.toUpperCase() !== geoipCountry) -
-            Number(b.country.toUpperCase() !== geoipCountry)
+        // Photon's ranking blends name match, popularity and our location
+        // bias. Re-sort to guarantee an exact name match wins regardless of
+        // popularity within the bias-respecting result order (sort is stable).
+        results.value = data
+          .sort(
+            (a, b) =>
+              Number(a.name.toLowerCase() !== normalizedQuery) -
+              Number(b.name.toLowerCase() !== normalizedQuery)
           )
-        })
+          .slice(0, take)
       }
       return results.value
     } catch (err) {
@@ -98,5 +74,5 @@ export const useGeocodingStore = defineStore('geocoding', () => {
 
   const hasResults = computed(() => results.value.length > 0)
 
-  return { results, isLoading, hasResults, search, searchNearby, clear }
+  return { results, isLoading, hasResults, search, clear }
 })

--- a/apps/frontend/src/features/geocoding/types.ts
+++ b/apps/frontend/src/features/geocoding/types.ts
@@ -1,3 +1,5 @@
+import type { GeoPoint } from '@zod/dto/location.dto'
+
 export interface GeocodingResult {
   name: string
   country: string // ISO 3166-1 alpha-2, uppercase (e.g. "DE")
@@ -8,5 +10,6 @@ export interface GeocodingResult {
 export type GeocodingProvider = (
   query: string,
   lang: string,
-  signal?: AbortSignal
+  signal?: AbortSignal,
+  bias?: GeoPoint | null
 ) => Promise<GeocodingResult[]>

--- a/apps/frontend/src/features/onboarding/components/OnboardWizard.vue
+++ b/apps/frontend/src/features/onboarding/components/OnboardWizard.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { onMounted } from 'vue'
+import { computed, onMounted } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import { type EditProfileForm } from '@zod/profile/profile.form'
@@ -80,16 +80,11 @@ const handleLocationSelected = async (location: { country: string }) => {
   })
 }
 
-onMounted(() => {
-  // Pre-populate the country from the geoip lookup so the user lands in the
-  // right region by default. Don't clobber a country the user already picked
-  // (e.g. from a saved draft profile).
-  if (!formData.value.location?.country && appStore.geoipCountry) {
-    formData.value.location = {
-      ...(formData.value.location ?? { cityName: '', lat: null, lon: null }),
-      country: appStore.geoipCountry,
-    }
-  }
+const defaultLocation = computed(() => appStore.geoipLocation)
+
+onMounted(async () => {
+  // obtain default geoip location
+  await appStore.fetchLocation()
 })
 
 const siteName = __APP_CONFIG__.SITE_NAME
@@ -149,6 +144,7 @@ const siteName = __APP_CONFIG__.SITE_NAME
           </legend>
           <LocationSelectorComponent
             v-model="formData.location"
+            :location-bias="defaultLocation"
             open-direction="bottom"
             :allow-empty="false"
             :close-on-select="true"

--- a/apps/frontend/src/features/onboarding/components/OnboardWizard.vue
+++ b/apps/frontend/src/features/onboarding/components/OnboardWizard.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { onMounted } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import { type EditProfileForm } from '@zod/profile/profile.form'
@@ -23,6 +24,7 @@ import { logCheckpoint } from '@/lib/diagnostics'
 
 import { useWizardSteps } from '@/features/onboarding/composables/useWizardSteps'
 import { useTagsStore } from '@/store/tagStore'
+import { useAppStore } from '@/features/app/stores/appStore'
 
 const { t } = useI18n()
 
@@ -69,6 +71,7 @@ const handleSubmit = () => {
 }
 
 const tagStore = useTagsStore()
+const appStore = useAppStore()
 
 const handleLocationSelected = async (location: { country: string }) => {
   await tagStore.fetchPopularTags({
@@ -76,6 +79,18 @@ const handleLocationSelected = async (location: { country: string }) => {
     limit: 50,
   })
 }
+
+onMounted(() => {
+  // Pre-populate the country from the geoip lookup so the user lands in the
+  // right region by default. Don't clobber a country the user already picked
+  // (e.g. from a saved draft profile).
+  if (!formData.value.location?.country && appStore.geoipCountry) {
+    formData.value.location = {
+      ...(formData.value.location ?? { cityName: '', lat: null, lon: null }),
+      country: appStore.geoipCountry,
+    }
+  }
+})
 
 const siteName = __APP_CONFIG__.SITE_NAME
 </script>
@@ -137,7 +152,6 @@ const siteName = __APP_CONFIG__.SITE_NAME
             open-direction="bottom"
             :allow-empty="false"
             :close-on-select="true"
-            :geoIp="true"
             @selected="handleLocationSelected"
           />
           <p class="form-text text-muted mt-2">

--- a/apps/frontend/src/features/onboarding/components/__tests__/OnboardWizard.spec.ts
+++ b/apps/frontend/src/features/onboarding/components/__tests__/OnboardWizard.spec.ts
@@ -61,6 +61,7 @@ import { mount, flushPromises } from '@vue/test-utils'
 import { createPinia, setActivePinia } from 'pinia'
 import OnboardWizard from '../OnboardWizard.vue'
 import { useTagsStore } from '@/store/tagStore'
+import { useAppStore } from '@/features/app/stores/appStore'
 
 const mockTags = [
   { id: 't1', name: 'Hiking', slug: 'hiking', count: 10 },
@@ -177,6 +178,26 @@ describe('OnboardWizard TagCloud integration', () => {
     await flushPromises()
 
     expect(formData.tags).toEqual([{ id: 't1', name: 'Hiking', slug: 'hiking' }])
+  })
+
+  it('pre-populates formData.location.country from appStore.geoipCountry on mount', async () => {
+    const appStore = useAppStore()
+    appStore.geoipCountry = 'DE'
+
+    const { formData } = mountWizard({ location: { country: '' } })
+    await flushPromises()
+
+    expect(formData.location.country).toBe('DE')
+  })
+
+  it('does not overwrite an existing country with the geoip value', async () => {
+    const appStore = useAppStore()
+    appStore.geoipCountry = 'DE'
+
+    const { formData } = mountWizard({ location: { country: 'FR' } })
+    await flushPromises()
+
+    expect(formData.location.country).toBe('FR')
   })
 
   it('clicking the same tag twice does not duplicate it', async () => {

--- a/apps/frontend/src/features/onboarding/components/__tests__/OnboardWizard.spec.ts
+++ b/apps/frontend/src/features/onboarding/components/__tests__/OnboardWizard.spec.ts
@@ -61,7 +61,6 @@ import { mount, flushPromises } from '@vue/test-utils'
 import { createPinia, setActivePinia } from 'pinia'
 import OnboardWizard from '../OnboardWizard.vue'
 import { useTagsStore } from '@/store/tagStore'
-import { useAppStore } from '@/features/app/stores/appStore'
 
 const mockTags = [
   { id: 't1', name: 'Hiking', slug: 'hiking', count: 10 },
@@ -178,26 +177,6 @@ describe('OnboardWizard TagCloud integration', () => {
     await flushPromises()
 
     expect(formData.tags).toEqual([{ id: 't1', name: 'Hiking', slug: 'hiking' }])
-  })
-
-  it('pre-populates formData.location.country from appStore.geoipCountry on mount', async () => {
-    const appStore = useAppStore()
-    appStore.geoipCountry = 'DE'
-
-    const { formData } = mountWizard({ location: { country: '' } })
-    await flushPromises()
-
-    expect(formData.location.country).toBe('DE')
-  })
-
-  it('does not overwrite an existing country with the geoip value', async () => {
-    const appStore = useAppStore()
-    appStore.geoipCountry = 'DE'
-
-    const { formData } = mountWizard({ location: { country: 'FR' } })
-    await flushPromises()
-
-    expect(formData.location.country).toBe('FR')
   })
 
   it('clicking the same tag twice does not duplicate it', async () => {

--- a/apps/frontend/src/features/shared/profileform/LocationSelector.vue
+++ b/apps/frontend/src/features/shared/profileform/LocationSelector.vue
@@ -11,6 +11,10 @@ import IconSearch from '@/assets/icons/interface/search.svg'
 
 defineOptions({ inheritAttrs: false })
 
+const props = defineProps<{
+  locationBias?: LocationDTO | null
+}>()
+
 const emit = defineEmits<{
   (e: 'selected', value: LocationDTO): void
 }>()
@@ -20,7 +24,7 @@ const debouncedAsyncFind = useDebounceFn(async (query: string) => {
     geocoding.results = selected.value ? [selected.value] : []
     return
   }
-  await geocoding.search(query, locale.value)
+  await geocoding.search(query, locale.value, props.locationBias ?? undefined)
 }, 500) // debounce delay in ms
 
 const model = defineModel<LocationDTO>({

--- a/apps/frontend/src/main.ts
+++ b/apps/frontend/src/main.ts
@@ -6,7 +6,6 @@ import registerToast from './lib/toast'
 import { useBootstrap } from './lib/bootstrap'
 import { appUseI18n } from './lib/i18n'
 import { useAuthStore } from './features/auth/stores/authStore'
-import { useAppStore } from './features/app/stores/appStore'
 
 // Register push-only service worker
 if ('serviceWorker' in navigator) {
@@ -89,7 +88,6 @@ app.use(createBootstrap()) // bootstrap-vue-next
 registerToast(app)
 
 useAuthStore().initialize()
-useAppStore().initialize()
 useBootstrap().bootstrap()
 
 appUseI18n(app)

--- a/apps/frontend/src/main.ts
+++ b/apps/frontend/src/main.ts
@@ -6,6 +6,7 @@ import registerToast from './lib/toast'
 import { useBootstrap } from './lib/bootstrap'
 import { appUseI18n } from './lib/i18n'
 import { useAuthStore } from './features/auth/stores/authStore'
+import { useAppStore } from './features/app/stores/appStore'
 
 // Register push-only service worker
 if ('serviceWorker' in navigator) {
@@ -88,6 +89,7 @@ app.use(createBootstrap()) // bootstrap-vue-next
 registerToast(app)
 
 useAuthStore().initialize()
+useAppStore().initialize()
 useBootstrap().bootstrap()
 
 appUseI18n(app)

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -258,6 +258,13 @@ services:
     depends_on:
       - jitsi-prosody
 
+  # GeoIP lookup API. Internal-only — no ports published, no traefik labels.
+  # Other services reach it at http://geoip-api:8080. Image bundles the
+  # MaxMind GeoLite2 databases, so no volumes or env vars are required.
+  geoip-api:
+    image: observabilitystack/geoip-api:latest
+    restart: always
+    
 volumes:
   redis-data:
     driver: local

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,86 +63,95 @@ services:
     depends_on:
       - tolgee-db
 
-  jitsi-web:
-    image: jitsi/web:stable
+  # jitsi-web:
+  #   image: jitsi/web:stable
+  #   restart: unless-stopped
+  #   ports:
+  #     - '8443:443'
+  #   volumes:
+  #     - ./certs/fullchain.pem:/config/keys/cert.crt:ro
+  #     - ./certs/privkey.pem:/config/keys/cert.key:ro
+  #     - jitsi-meet-cfg-web:/config
+  #   environment:
+  #     - ENABLE_AUTH=0
+  #     - ENABLE_GUESTS=1
+  #     - ENABLE_XMPP_WEBSOCKET=1
+  #     - PUBLIC_URL=https://localhost:8443
+  #     - XMPP_DOMAIN=meet.jitsi
+  #     - XMPP_AUTH_DOMAIN=auth.meet.jitsi
+  #     - XMPP_BOSH_URL_BASE=http://jitsi-prosody:5280
+  #     - XMPP_MUC_DOMAIN=muc.meet.jitsi
+  #     - XMPP_INTERNAL_MUC_DOMAIN=internal-muc.meet.jitsi
+  #     - JICOFO_AUTH_USER=focus
+  #     - JVB_BREWERY_MUC=jvbbrewery
+  #     - TZ=UTC
+  #   depends_on:
+  #     - jitsi-prosody
+
+  # jitsi-prosody:
+  #   image: jitsi/prosody:stable
+  #   restart: unless-stopped
+  #   volumes:
+  #     - jitsi-meet-cfg-prosody:/config
+  #   environment:
+  #     - ENABLE_AUTH=0
+  #     - ENABLE_GUESTS=1
+  #     - XMPP_DOMAIN=meet.jitsi
+  #     - XMPP_AUTH_DOMAIN=auth.meet.jitsi
+  #     - XMPP_MUC_DOMAIN=muc.meet.jitsi
+  #     - XMPP_INTERNAL_MUC_DOMAIN=internal-muc.meet.jitsi
+  #     - JICOFO_AUTH_USER=focus
+  #     - JICOFO_AUTH_PASSWORD=jicofo_secret
+  #     - JVB_AUTH_USER=jvb
+  #     - JVB_AUTH_PASSWORD=jvb_secret
+  #     - TZ=UTC
+
+  # jitsi-jicofo:
+  #   image: jitsi/jicofo:stable
+  #   restart: unless-stopped
+  #   volumes:
+  #     - jitsi-meet-cfg-jicofo:/config
+  #   environment:
+  #     - XMPP_DOMAIN=meet.jitsi
+  #     - XMPP_AUTH_DOMAIN=auth.meet.jitsi
+  #     - XMPP_INTERNAL_MUC_DOMAIN=internal-muc.meet.jitsi
+  #     - XMPP_MUC_DOMAIN=muc.meet.jitsi
+  #     - XMPP_SERVER=jitsi-prosody
+  #     - JICOFO_AUTH_USER=focus
+  #     - JICOFO_AUTH_PASSWORD=jicofo_secret
+  #     - JVB_BREWERY_MUC=jvbbrewery
+  #     - TZ=UTC
+  #   depends_on:
+  #     - jitsi-prosody
+
+  # jitsi-jvb:
+  #   image: jitsi/jvb:stable
+  #   restart: unless-stopped
+  #   ports:
+  #     - '10000:10000/udp'
+  #   volumes:
+  #     - jitsi-meet-cfg-jvb:/config
+  #   environment:
+  #     - XMPP_AUTH_DOMAIN=auth.meet.jitsi
+  #     - XMPP_INTERNAL_MUC_DOMAIN=internal-muc.meet.jitsi
+  #     - XMPP_SERVER=jitsi-prosody
+  #     - JVB_AUTH_USER=jvb
+  #     - JVB_AUTH_PASSWORD=jvb_secret
+  #     - JVB_BREWERY_MUC=jvbbrewery
+  #     - JVB_PORT=10000
+  #     - DOCKER_HOST_ADDRESS=host.docker.internal
+  #     - TZ=UTC
+  #   depends_on:
+  #     - jitsi-prosody
+
+  # GeoIP lookup API. Internal-only — no ports published, no traefik labels.
+  # Other services reach it at http://geoip-api:8080. Image bundles the
+  # MaxMind GeoLite2 databases, so no volumes or env vars are required.
+  geoip-api:
+    image: observabilitystack/geoip-api:latest
     restart: unless-stopped
     ports:
-      - '8443:443'
-    volumes:
-      - ./certs/fullchain.pem:/config/keys/cert.crt:ro
-      - ./certs/privkey.pem:/config/keys/cert.key:ro
-      - jitsi-meet-cfg-web:/config
-    environment:
-      - ENABLE_AUTH=0
-      - ENABLE_GUESTS=1
-      - ENABLE_XMPP_WEBSOCKET=1
-      - PUBLIC_URL=https://localhost:8443
-      - XMPP_DOMAIN=meet.jitsi
-      - XMPP_AUTH_DOMAIN=auth.meet.jitsi
-      - XMPP_BOSH_URL_BASE=http://jitsi-prosody:5280
-      - XMPP_MUC_DOMAIN=muc.meet.jitsi
-      - XMPP_INTERNAL_MUC_DOMAIN=internal-muc.meet.jitsi
-      - JICOFO_AUTH_USER=focus
-      - JVB_BREWERY_MUC=jvbbrewery
-      - TZ=UTC
-    depends_on:
-      - jitsi-prosody
-
-  jitsi-prosody:
-    image: jitsi/prosody:stable
-    restart: unless-stopped
-    volumes:
-      - jitsi-meet-cfg-prosody:/config
-    environment:
-      - ENABLE_AUTH=0
-      - ENABLE_GUESTS=1
-      - XMPP_DOMAIN=meet.jitsi
-      - XMPP_AUTH_DOMAIN=auth.meet.jitsi
-      - XMPP_MUC_DOMAIN=muc.meet.jitsi
-      - XMPP_INTERNAL_MUC_DOMAIN=internal-muc.meet.jitsi
-      - JICOFO_AUTH_USER=focus
-      - JICOFO_AUTH_PASSWORD=jicofo_secret
-      - JVB_AUTH_USER=jvb
-      - JVB_AUTH_PASSWORD=jvb_secret
-      - TZ=UTC
-
-  jitsi-jicofo:
-    image: jitsi/jicofo:stable
-    restart: unless-stopped
-    volumes:
-      - jitsi-meet-cfg-jicofo:/config
-    environment:
-      - XMPP_DOMAIN=meet.jitsi
-      - XMPP_AUTH_DOMAIN=auth.meet.jitsi
-      - XMPP_INTERNAL_MUC_DOMAIN=internal-muc.meet.jitsi
-      - XMPP_MUC_DOMAIN=muc.meet.jitsi
-      - XMPP_SERVER=jitsi-prosody
-      - JICOFO_AUTH_USER=focus
-      - JICOFO_AUTH_PASSWORD=jicofo_secret
-      - JVB_BREWERY_MUC=jvbbrewery
-      - TZ=UTC
-    depends_on:
-      - jitsi-prosody
-
-  jitsi-jvb:
-    image: jitsi/jvb:stable
-    restart: unless-stopped
-    ports:
-      - '10000:10000/udp'
-    volumes:
-      - jitsi-meet-cfg-jvb:/config
-    environment:
-      - XMPP_AUTH_DOMAIN=auth.meet.jitsi
-      - XMPP_INTERNAL_MUC_DOMAIN=internal-muc.meet.jitsi
-      - XMPP_SERVER=jitsi-prosody
-      - JVB_AUTH_USER=jvb
-      - JVB_AUTH_PASSWORD=jvb_secret
-      - JVB_BREWERY_MUC=jvbbrewery
-      - JVB_PORT=10000
-      - DOCKER_HOST_ADDRESS=host.docker.internal
-      - TZ=UTC
-    depends_on:
-      - jitsi-prosody
+    - 8086:8080
 
 volumes:
   postgres_data:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -152,9 +152,6 @@ importers:
       '@google-cloud/translate':
         specifier: 9.3.0
         version: 9.3.0
-      '@maxmind/geoip2-node':
-        specifier: 6.3.4
-        version: 6.3.4
       '@prisma/client':
         specifier: 6.15.0
         version: 6.15.0(prisma@6.15.0(magicast@0.3.5)(typescript@5.9.3))(typescript@5.9.3)
@@ -1815,9 +1812,6 @@ packages:
 
   '@manypkg/get-packages@1.1.3':
     resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
-
-  '@maxmind/geoip2-node@6.3.4':
-    resolution: {integrity: sha512-BTRFHCX7Uie4wVSPXsWQfg0EVl4eGZgLCts0BTKAP+Eiyt1zmF2UPyuUZkaj0R59XSDYO+84o1THAtaenUoQYg==}
 
   '@mediapipe/face_detection@0.4.1646425229':
     resolution: {integrity: sha512-aeCN+fRAojv9ch3NXorP6r5tcGVLR3/gC1HmtqB0WEZBRXrdP6/3W/sGR0dHr1iT6ueiK95G9PVjbzFosf/hrg==}
@@ -5629,10 +5623,6 @@ packages:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
 
-  maxmind@5.0.5:
-    resolution: {integrity: sha512-1lcH2kMjbBpCFhuHaMU32vz8CuOsKttRcWMQyXvtlklopCzN7NNHSVR/h9RYa8JPuFTGmkn2vYARm+7cIGuqDw==}
-    engines: {node: '>=12', npm: '>=6'}
-
   mdn-data@2.0.28:
     resolution: {integrity: sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g==}
 
@@ -5777,10 +5767,6 @@ packages:
 
   mlly@1.8.0:
     resolution: {integrity: sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==}
-
-  mmdb-lib@3.0.2:
-    resolution: {integrity: sha512-7e87vk0DdWT647wjcfEtWeMtjm+zVGqNohN/aeIymbUfjHQ2T4Sx5kM+1irVDBSloNC3CkGKxswdMoo8yhqTDg==}
-    engines: {node: '>=10', npm: '>=6'}
 
   mnemonist@0.40.3:
     resolution: {integrity: sha512-Vjyr90sJ23CKKH/qPAgUKicw/v6pRoamxIEDFOF8uSgFME7DqPRpHgRTejWVjkdGg5dXj0/NyxZHZ9bcjH+2uQ==}
@@ -7268,10 +7254,6 @@ packages:
 
   timeago.js@4.0.2:
     resolution: {integrity: sha512-a7wPxPdVlQL7lqvitHGGRsofhdwtkoSXPGATFuSOA2i1ZNQEPLrGnj68vOp2sOJTCFAQVXPeNMX/GctBaO9L2w==}
-
-  tiny-lru@11.4.7:
-    resolution: {integrity: sha512-w/Te7uMUVeH0CR8vZIjr+XiN41V+30lkDdK+NRIDCUYKKuL9VcmaUEmaPISuwGhLlrTGh5yu18lENtR9axSxYw==}
-    engines: {node: '>=12'}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -9287,10 +9269,6 @@ snapshots:
       fs-extra: 8.1.0
       globby: 11.1.0
       read-yaml-file: 1.1.0
-
-  '@maxmind/geoip2-node@6.3.4':
-    dependencies:
-      maxmind: 5.0.5
 
   '@mediapipe/face_detection@0.4.1646425229': {}
 
@@ -13569,11 +13547,6 @@ snapshots:
 
   math-intrinsics@1.1.0: {}
 
-  maxmind@5.0.5:
-    dependencies:
-      mmdb-lib: 3.0.2
-      tiny-lru: 11.4.7
-
   mdn-data@2.0.28: {}
 
   mdn-data@2.0.30: {}
@@ -13695,8 +13668,6 @@ snapshots:
       pathe: 2.0.3
       pkg-types: 1.3.1
       ufo: 1.6.3
-
-  mmdb-lib@3.0.2: {}
 
   mnemonist@0.40.3:
     dependencies:
@@ -15310,8 +15281,6 @@ snapshots:
   through@2.3.8: {}
 
   timeago.js@4.0.2: {}
-
-  tiny-lru@11.4.7: {}
 
   tinybench@2.9.0: {}
 


### PR DESCRIPTION
## Summary
- Backend `/location` now returns lat/lon (coerced from upstream strings) alongside country, with cleaner error semantics (502 for upstream failure, 500 for our errors).
- Frontend threads the geoip `LocationDTO` from `appStore` → `OnboardWizard` → `LocationSelector` → `geocodingStore` → Photon as `lat`/`lon`/`zoom=8`/`location_bias_scale=0.0`, so nearby cities outrank faraway exact-name matches.
- Removed the implicit `appStore.geoipLocation` lookup from `geocodingStore.search` and the dead `searchNearby` action; bias now flows explicitly via prop, no hidden coupling.

## Test plan
- [x] `pnpm test` — all 1200+ tests green
- [x] `pnpm type-check` — clean across backend/frontend/admin
- [ ] Manual: `pnpm dev`, log in, hit onboarding location step, type partial city name (e.g. "als") — verify regional cities (matching geoip country) surface ahead of faraway exact-name matches
- [ ] Manual: confirm `/location` returns lat/lon: `curl -s http://localhost:3000/location -H "cookie: ..." | jq`
- [ ] Manual: confirm dev override IP (`188.6.25.123`) drives the geoip lookup when `NODE_ENV=development`

🤖 Generated with [Claude Code](https://claude.com/claude-code)