### PR TITLE
feat(messaging): hide turn badges for admin-initiated conversations

### DIFF
--- a/.changeset/admin-initiator-turn-badges.md
+++ b/.changeset/admin-initiator-turn-badges.md
@@ -1,0 +1,7 @@
+---
+'@opencupid/backend': minor
+'@opencupid/frontend': minor
+'@opencupid/shared': patch
+---
+
+Hide "My turn / Their turn" badges on admin-initiated conversations.

--- a/apps/backend/src/__tests__/api/messaging.mappers.spec.ts
+++ b/apps/backend/src/__tests__/api/messaging.mappers.spec.ts
@@ -5,9 +5,13 @@ import {
   mapAttachmentDTO,
 } from '../../api/mappers/messaging.mappers'
 vi.mock('@prisma/client', () => ({ Prisma: {}, PrismaClient: class {} }))
+const mockAppConfig: { MEDIA_URL_BASE: string; ADMIN_PROFILE_ID?: string } = {
+  MEDIA_URL_BASE: '/user-content',
+  ADMIN_PROFILE_ID: 'admin-profile',
+}
 vi.mock('@/lib/appconfig', () => ({
-  appConfig: {
-    MEDIA_URL_BASE: '/user-content',
+  get appConfig() {
+    return mockAppConfig
   },
 }))
 
@@ -39,6 +43,7 @@ const participant: any = {
     createdAt: new Date(),
     profileAId: 'p1',
     profileBId: 'p2',
+    initiatorProfileId: 'p1',
     profileA: profileMe,
     profileB: profileThem,
     participants: [
@@ -164,6 +169,38 @@ describe('messaging mappers', () => {
       }
       const summary = mapConversationParticipantToSummary(p, 'p1')
       expect(summary.myIsCallable).toBe(false)
+    })
+  })
+
+  describe('isAdminInitiator mapping', () => {
+    it('returns false when initiator is a regular user', () => {
+      const summary = mapConversationParticipantToSummary(participant, 'p1')
+      expect(summary.isAdminInitiator).toBe(false)
+    })
+
+    it('returns true when initiator equals appConfig.ADMIN_PROFILE_ID', () => {
+      const p: any = {
+        ...participant,
+        conversation: { ...participant.conversation, initiatorProfileId: 'admin-profile' },
+      }
+      const summary = mapConversationParticipantToSummary(p, 'p1')
+      expect(summary.isAdminInitiator).toBe(true)
+    })
+
+    it('returns false when ADMIN_PROFILE_ID is unset, even if initiator is also undefined', () => {
+      // Guards against undefined === undefined falsely matching every conversation.
+      const previous = mockAppConfig.ADMIN_PROFILE_ID
+      mockAppConfig.ADMIN_PROFILE_ID = undefined
+      try {
+        const p: any = {
+          ...participant,
+          conversation: { ...participant.conversation, initiatorProfileId: undefined },
+        }
+        const summary = mapConversationParticipantToSummary(p, 'p1')
+        expect(summary.isAdminInitiator).toBe(false)
+      } finally {
+        mockAppConfig.ADMIN_PROFILE_ID = previous
+      }
     })
   })
 

--- a/apps/backend/src/api/mappers/messaging.mappers.ts
+++ b/apps/backend/src/api/mappers/messaging.mappers.ts
@@ -10,6 +10,7 @@ import {
   type MessageWithSender,
 } from '../../services/messaging.service'
 import { mediaUrl } from '../../lib/media'
+import { appConfig } from '../../lib/appconfig'
 
 function mapConversationMeta(c: { id: string; updatedAt: Date; createdAt: Date }) {
   return {
@@ -34,6 +35,12 @@ export function mapConversationParticipantToSummary(
 
   const lastMessage = conversation.messages[0] ?? null
   const canReply = canSendMessageInConversation(conversation, currentProfileId)
+  // Truthiness guard: if ADMIN_PROFILE_ID is unset, undefined === undefined would
+  // mark every conversation as admin-initiated. Comparing only when the id is
+  // configured matches the rest of the codebase's "no admin id, no admin behavior"
+  // contract (see messaging.service.sendWelcomeMessage).
+  const adminId = appConfig.ADMIN_PROFILE_ID
+  const isAdminInitiator = !!adminId && conversation.initiatorProfileId === adminId
 
   return {
     id: p.id,
@@ -43,6 +50,7 @@ export function mapConversationParticipantToSummary(
     isMuted: p.isMuted,
     isArchived: p.isArchived,
     canReply,
+    isAdminInitiator,
     isCallable: partnerState?.isCallable !== false && partner.isCallable !== false,
     myIsCallable: myState?.isCallable !== false,
     lastMessage: lastMessage

--- a/apps/frontend/src/features/messaging/components/ConversationSummaries.vue
+++ b/apps/frontend/src/features/messaging/components/ConversationSummaries.vue
@@ -45,7 +45,10 @@ const haveConversations = computed(() => props.conversations.length > 0)
             }}</small
           >
         </div>
-        <div class="flex-shrink-0 me-2">
+        <div
+          v-if="!convo.isAdminInitiator"
+          class="flex-shrink-0 me-2"
+        >
           <small
             v-if="!convo.lastMessage?.isMine"
             class="badge bg-danger"

--- a/apps/frontend/src/features/messaging/components/ConversationSummaries.vue
+++ b/apps/frontend/src/features/messaging/components/ConversationSummaries.vue
@@ -24,7 +24,7 @@ const haveConversations = computed(() => props.conversations.length > 0)
         v-for="convo in conversations"
         :key="convo.conversationId"
         :active="activeConversation?.conversationId === convo.conversationId"
-        :class="{ disabled: !convo.canReply }"
+        :class="{ disabled: !convo.canReply, admin: convo.isAdminInitiator }"
         variant="light"
         class="d-flex justify-content-start align-items-center mb-3 p-2 border-0 rounded-3 shadow cursor-pointer user-select-none"
         @click="$emit('convo:select', convo)"
@@ -67,12 +67,20 @@ const haveConversations = computed(() => props.conversations.length > 0)
   </div>
 </template>
 
-<style scoped>
+<style scoped lang="scss">
+@import '@bootstrap/scss/functions';
+@import '@bootstrap/scss/variables';
+@import '@bootstrap/scss/mixins';
+@import '@/css/theme';
+
 .last-message {
   text-overflow: ellipsis;
 }
 .disabled {
   opacity: 0.5;
   pointer-events: none;
+}
+.admin {
+  background-color: transparentize($color: $info, $amount: 0.9);
 }
 </style>

--- a/apps/frontend/src/features/messaging/components/__tests__/ConversationSummaries.spec.ts
+++ b/apps/frontend/src/features/messaging/components/__tests__/ConversationSummaries.spec.ts
@@ -66,6 +66,34 @@ describe('ConversationSummaries', () => {
     expect(wrapper.find('.last-message').text()).toBe('messaging.voice.voice_message_preview')
   })
 
+  it('shows the "my turn" badge by default for non-admin-initiated conversations', () => {
+    const wrapper = mount(ConversationSummaries, {
+      props: {
+        conversations: [makeConvo({ isAdminInitiator: false })],
+        activeConversation: null,
+        loading: false,
+      },
+      ...globalMocks,
+    })
+
+    expect(wrapper.html()).toContain('messaging.my_turn')
+  })
+
+  it('hides the turn badges for admin-initiated conversations', () => {
+    const wrapper = mount(ConversationSummaries, {
+      props: {
+        conversations: [makeConvo({ isAdminInitiator: true })],
+        activeConversation: null,
+        loading: false,
+      },
+      ...globalMocks,
+    })
+
+    const html = wrapper.html()
+    expect(html).not.toContain('messaging.my_turn')
+    expect(html).not.toContain('messaging.their_turn')
+  })
+
   it('strips HTML tags from text message preview', () => {
     const wrapper = mount(ConversationSummaries, {
       props: {

--- a/apps/frontend/src/features/messaging/stores/__tests__/messageStore.spec.ts
+++ b/apps/frontend/src/features/messaging/stores/__tests__/messageStore.spec.ts
@@ -35,6 +35,7 @@ function makeConvo(conversationId: string, partnerName: string): ConversationSum
     canReply: false,
     isCallable: true,
     myIsCallable: true,
+    isAdminInitiator: false,
     conversation: {
       id: conversationId,
       updatedAt: new Date('2024-01-01'),
@@ -71,6 +72,7 @@ describe('messageStore', () => {
         canReply: false, // User initiated, waiting for reply
         isCallable: true,
         myIsCallable: true,
+        isAdminInitiator: false,
         conversation: {
           id: 'convo-1',
           updatedAt: new Date('2024-01-01'),
@@ -130,6 +132,7 @@ describe('messageStore', () => {
         canReply: true,
         isCallable: true,
         myIsCallable: true,
+        isAdminInitiator: false,
         conversation: {
           id: 'convo-1',
           updatedAt: new Date('2024-01-01'),
@@ -154,6 +157,7 @@ describe('messageStore', () => {
         canReply: true,
         isCallable: true,
         myIsCallable: true,
+        isAdminInitiator: false,
         conversation: {
           id: 'convo-2',
           updatedAt: new Date('2024-01-02'),
@@ -207,6 +211,7 @@ describe('messageStore', () => {
         canReply: true,
         isCallable: true,
         myIsCallable: true,
+        isAdminInitiator: false,
         conversation: {
           id: 'convo-1',
           updatedAt: new Date('2024-01-01'),
@@ -231,7 +236,12 @@ describe('messageStore', () => {
         messageType: 'text/html',
         createdAt: new Date('2024-01-02'),
         isMine: false,
-        sender: { id: 'partner-1', publicName: 'Partner', profileImages: [], location: { country: '' } },
+        sender: {
+          id: 'partner-1',
+          publicName: 'Partner',
+          profileImages: [],
+          location: { country: '' },
+        },
       }
 
       await store.handleIncomingMessage(incomingMessage)
@@ -253,6 +263,7 @@ describe('messageStore', () => {
         canReply: true,
         isCallable: true,
         myIsCallable: true,
+        isAdminInitiator: false,
         conversation: {
           id: 'convo-1',
           updatedAt: new Date('2024-01-01'),
@@ -277,7 +288,12 @@ describe('messageStore', () => {
         messageType: 'text/html',
         createdAt: new Date('2024-01-02'),
         isMine: false,
-        sender: { id: 'partner-1', publicName: 'Partner', profileImages: [], location: { country: '' } },
+        sender: {
+          id: 'partner-1',
+          publicName: 'Partner',
+          profileImages: [],
+          location: { country: '' },
+        },
       }
 
       await store.handleIncomingMessage(incomingMessage)

--- a/packages/shared/zod/messaging/messaging.dto.ts
+++ b/packages/shared/zod/messaging/messaging.dto.ts
@@ -100,6 +100,7 @@ const ConversationSummarySchema = ConversationParticipantSchema.pick({
     createdAt: true,
   }),
   canReply: z.boolean().default(false),
+  isAdminInitiator: z.boolean().default(false),
   isCallable: z.boolean().default(true),
   myIsCallable: z.boolean().default(true),
   partnerProfile: ProfileSummarySchema,


### PR DESCRIPTION
## Summary
- Adds an \`isAdminInitiator\` flag to \`ConversationSummary\` so the inbox UI can suppress the "My turn / Their turn" badges when the conversation was started by the system/admin sender (e.g. the welcome bot, admin broadcasts).
- Computed at mapping time by comparing \`Conversation.initiatorProfileId\` against \`appConfig.ADMIN_PROFILE_ID\`. No new column, no migration.
- The admin profile id never flows to the frontend — only the boolean does.

## Why
A turn-tracker on a system-initiated conversation is meaningless: the recipient cannot meaningfully take a turn against the welcome bot, and the badges create false urgency on the inbox.

## Notes for review
- **Stacked on #1399.** Base is \`claude/welcome-message-db-templates-Dpjvj\` because that PR introduces \`appConfig.ADMIN_PROFILE_ID\` (renamed from \`WELCOME_MESSAGE_SENDER_PROFILE_ID\`). This PR will rebase onto \`main\` once #1399 merges.
- **Truthiness guard:** if \`ADMIN_PROFILE_ID\` is unset, \`undefined === undefined\` would falsely flag every conversation as admin-initiated. The mapper short-circuits when the id isn't configured (matches the pattern in \`messaging.service.sendWelcomeMessage\`).
- **First commit on this branch** (\`4cdb4278\`) is a small follow-up to the rename in #1399: two test files still mocked the old \`WELCOME_MESSAGE_SENDER_PROFILE_ID\`, which broke the welcome-message and admin-broadcast specs once the source-side rename landed. The same fix has been cherry-picked onto #1399 as \`d1c7c2a7\` so its CI also goes green.

## Test plan
- [x] \`pnpm test\` (3/3 packages, all 1247 tests green)
- [x] \`pnpm type-check\` (3/3 packages green)
- [ ] Manual: log in as a profile that has a welcome message in their inbox; verify neither "My turn" nor "Their turn" badge renders on that row, while non-system conversations still show the badges as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)