### PR TITLE
fix(frontend,admin): disable browser auto-translation

### DIFF
--- a/.changeset/silver-translator-mute.md
+++ b/.changeset/silver-translator-mute.md
@@ -1,0 +1,6 @@
+---
+'@opencupid/frontend': patch
+'@opencupid/admin': patch
+---
+
+Disable browser auto-translation to prevent crash on Chrome iOS when a Hungarian user landed on the app and Chrome's translator wrapped Vue-rendered text nodes in `<font>` tags, causing Vue's renderer to recurse infinitely.

--- a/apps/admin/index.html
+++ b/apps/admin/index.html
@@ -1,10 +1,17 @@
 <!doctype html>
-<html lang="en">
+<html
+  lang="en"
+  translate="no"
+>
   <head>
     <meta charset="UTF-8" />
     <meta
       name="viewport"
       content="width=device-width, initial-scale=1.0"
+    />
+    <meta
+      name="google"
+      content="notranslate"
     />
     <title>Admin</title>
   </head>

--- a/apps/frontend/index.html
+++ b/apps/frontend/index.html
@@ -1,10 +1,17 @@
 <!doctype html>
-<html lang="">
+<html
+  lang=""
+  translate="no"
+>
   <head>
     <meta charset="UTF-8" />
     <meta
       name="viewport"
       content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, interactive-widget=resizes-visual"
+    />
+    <meta
+      name="google"
+      content="notranslate"
     />
     <title>${SITE_NAME}</title>
 


### PR DESCRIPTION
## Summary
- Add `translate=\"no\"` on `<html>` and `<meta name=\"google\" content=\"notranslate\">` to both [apps/frontend/index.html](apps/frontend/index.html) and [apps/admin/index.html](apps/admin/index.html).

## Why
Sentry reports a `RangeError: Maximum call stack size exceeded` on **Chrome Mobile iOS only** (event `019dddda...`, release `frontend@0.57.0`), thrown shortly after a Hungarian-locale user landed on `/magic-link` from `/auth`. Breadcrumbs immediately *after* the crash include a click on `div.text-center > p.text-muted.fs-6 > font > font` — `<font>` element wrappers that Vue does not emit. They're injected by Chrome iOS's built-in Google Translate when it auto-translates the page (Hungarian app, `hu-HU` device, `.hu` host).

When Vue 3's renderer later patches a text node owned by the translator-mutated subtree, it recurses into a DOM it doesn't recognize and exhausts iOS WebKit's relatively shallow JS stack.

## Fix
The app ships its own i18n via `vue-i18n` for every supported locale (`en`, `hu`, …), so browser translation is redundant and only a source of bugs. Opting out at the document root removes the entire bug class for all browsers and translators (Chrome, Safari, Edge, Firefox, Yandex).

- `translate=\"no\"` on `<html>` is the modern standards-based opt-out (HTML Living Standard; honored by all major engines).
- `<meta name=\"google\" content=\"notranslate\">` is a belt-and-suspenders fallback for older Chrome iOS versions that ignored the attribute.

## Test plan
- [ ] CI green
- [ ] Manually verify the app still loads and renders correctly in dev (no UX impact expected — HTML metadata only)
- [ ] On a device that previously auto-translated, confirm the translator no longer activates (e.g. Chrome desktop with `Translate this page?` prompt suppressed; Safari iOS \"Translate Website\" greyed out)
- [ ] Verify the original Sentry signal stops appearing for the affected device class after release

🤖 Generated with [Claude Code](https://claude.com/claude-code)