### PR TITLE
Hide scrollbar on MyProfile component scroll container

### DIFF
--- a/.changeset/nasty-windows-guess.md
+++ b/.changeset/nasty-windows-guess.md
@@ -1,0 +1,5 @@
+---
+"@opencupid/frontend": patch
+---
+
+Hide scrollbar on MyProfile component scroll container

--- a/apps/frontend/src/features/myprofile/components/MyProfile.vue
+++ b/apps/frontend/src/features/myprofile/components/MyProfile.vue
@@ -67,7 +67,7 @@ const toggleDating = async () => {
         :editState="viewState.isEditable"
         @updated="updateProfile"
         :class="[viewState.currentScope, { editable: viewState.isEditable }]"
-        class="scroll"
+        class="scroll hide-scrollbar"
       >
         <ProfileContent
           v-if="profilePreview"


### PR DESCRIPTION
## Summary
Updated the MyProfile component to hide the scrollbar on the profile content scroll container while maintaining scroll functionality.

## Changes
- Added `hide-scrollbar` class to the profile content scroll container in MyProfile.vue
- This provides a cleaner UI by hiding the native scrollbar while preserving the ability to scroll through profile content

## Implementation Details
The `hide-scrollbar` utility class is applied alongside the existing `scroll` class on the profile content wrapper element. This allows the component to maintain its scrolling behavior while presenting a more polished visual appearance without the visible scrollbar.

https://claude.ai/code/session_016fRNWUmtri74dwR7Pk9S84