### PR TITLE
fix(frontend): restore CSP and security headers on SPA paths

### DIFF
--- a/.changeset/quiet-nginx-headers-restore.md
+++ b/.changeset/quiet-nginx-headers-restore.md
@@ -1,0 +1,5 @@
+---
+'@opencupid/frontend': patch
+---
+
+Restore CSP and other security headers on SPA-served paths. nginx's per-location `add_header` was suppressing the server-level stack on every HTML response.

--- a/apps/frontend/nginx.conf
+++ b/apps/frontend/nginx.conf
@@ -7,22 +7,21 @@ server {
 
   include /etc/nginx/security-headers.conf;
 
+  # nginx add_header is replace-not-merge: any per-location add_header drops
+  # the inherited stack. Keep these blocks free of add_header.
+
   location = /config.js {
-    add_header Cache-Control "no-cache";
     try_files $uri =404;
   }
 
   location = /sw.js {
-    add_header Cache-Control "no-cache";
     try_files $uri =404;
   }
 
   location = /index.html {
-    add_header Cache-Control "no-cache";
   }
 
   location = /assets/site.webmanifest {
-    add_header Cache-Control "no-cache";
     types { application/manifest+json webmanifest; }
   }
 
@@ -30,6 +29,8 @@ server {
     return 404;
   }
 
+  # Fingerprinted bundle output: skip the security-header inheritance to keep
+  # the long Cache-Control.
   location /assets/ {
     add_header Cache-Control "public, max-age=43200";
     try_files $uri =404;

--- a/apps/frontend/security-headers.conf.tmpl
+++ b/apps/frontend/security-headers.conf.tmpl
@@ -3,3 +3,4 @@ add_header X-Frame-Options "DENY" always;
 add_header Referrer-Policy "strict-origin-when-cross-origin" always;
 add_header Permissions-Policy 'camera=(self "https://${JITSI_DOMAIN}"), microphone=(self "https://${JITSI_DOMAIN}"), geolocation=(self)' always;
 add_header Content-Security-Policy "default-src 'self'; script-src 'self' https://*.${DOMAIN}; style-src 'self' 'unsafe-inline'; font-src 'self' data:; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; worker-src 'self' blob:; media-src 'self' blob:; frame-src https://*.${DOMAIN}; img-src 'self' data: blob: ${CSP_ALLOWED_DOMAINS}; connect-src 'self' blob: wss://${DOMAIN} https://*.${DOMAIN} ${CSP_ALLOWED_DOMAINS}; upgrade-insecure-requests${CSP_REPORT_DIRECTIVE}" always;
+add_header Cache-Control "no-cache" always;


### PR DESCRIPTION
## Summary

- nginx's \`add_header\` directives don't merge across configuration levels — any per-location \`add_header\` silently drops the entire server-level stack. The SPA \`location = /index.html\` block was setting \`Cache-Control: no-cache\` per-location, which suppressed CSP, X-Frame-Options, Referrer-Policy, Permissions-Policy and X-Content-Type-Options on every SPA-served HTML response.
- Move \`Cache-Control: no-cache\` into \`security-headers.conf\` so the four no-cache locations (\`/config.js\`, \`/sw.js\`, \`/index.html\`, \`/assets/site.webmanifest\`) can stay free of \`add_header\` and inherit the full stack from the server-level include.
- \`/assets/\` keeps its own \`Cache-Control: public, max-age=43200\` and intentionally does not inherit; documented inline. Behavior on \`/assets/\` is unchanged from pre-fix on every response code.

## Why this regressed silently

There's no test that asserts CSP presence on a deployed response. The whole policy is correctly templated and \`CSP_ALLOWED_DOMAINS\` is set in prod, but nothing catches the absence of the rendered header. Worth a follow-up smoke test in the deploy pipeline.

## Test plan

- [ ] After deploy: \`curl -sI https://gaians.net/auth | grep -iE "content-security-policy|x-frame-options"\` returns both headers
- [ ] \`curl -sI https://gaians.net/assets/<any-hashed-file>\` still shows \`Cache-Control: public, max-age=43200\` only (no security-header leakage)
- [ ] Geocoder on \`/onboarding\` continues to work (rendered CSP \`connect-src\` includes \`https://photon.komoot.io\`)
- [ ] Same checks pass on komaterkep.hu
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)