### PR TITLE
fix(settings): tighten Settings view layout

### DIFF
--- a/.changeset/calm-foxes-tidy.md
+++ b/.changeset/calm-foxes-tidy.md
@@ -1,0 +1,5 @@
+---
+'@opencupid/frontend': patch
+---
+
+Tighten Settings view layout: remove empty fieldset placeholders, swap legend for h6, tighten responsive margins, smaller form-hint typography.

--- a/apps/frontend/src/features/settings/components/OptInCheckboxes.vue
+++ b/apps/frontend/src/features/settings/components/OptInCheckboxes.vue
@@ -76,8 +76,6 @@ async function handleOptInChange(event: Event, patch: UpdateProfileOptInPayload)
     </div>
   </fieldset>
 
-  <fieldset class="mb-2 mb-md-3"></fieldset>
-
   <fieldset class="mb-2 mb-md-4">
     <div class="form-check">
       <input

--- a/apps/frontend/src/features/settings/components/Settings.vue
+++ b/apps/frontend/src/features/settings/components/Settings.vue
@@ -53,22 +53,21 @@ function handleLogout() {
 
 <template>
   <div class="px-3 p-md-5 h-100 w-100 d-flex flex-column justify-content-center">
-    <fieldset class="d-flex align-items-center mb-5">
+    <fieldset class="d-flex align-items-center mb-3 mb-lg-5">
       <IconGlobe class="svg-icon svg-icon-lg me-2" />
       <LanguageSelectorDropdown size="md" />
     </fieldset>
 
-    <fieldset class="mb-3">
-      <legend class="h6">{{ $t('settings.notifications_label') }}</legend>
+    <div class="mb-md-3">
+      <h6>{{ $t('settings.notifications_label') }}</h6>
       <OptInCheckboxes v-model="optInModel" />
-    </fieldset>
-    <fieldset class="mb-3">
+    </div>
+    <fieldset class="mb-md-3">
       <PwaInstallButton />
     </fieldset>
-    <hr />
     <fieldset class="d-flex flex-wrap align-items-center gap-2">
       <div
-        class="flex-grow-1 form-hint"
+        class="flex-grow-1 form-hint small lh-sm"
         style="min-width: 0; word-break: break-all"
       >
         <template v-if="userStore.user">


### PR DESCRIPTION
## Summary
- Removed an empty `<fieldset>` placeholder in `OptInCheckboxes.vue` and a stray `<hr/>` separator in `Settings.vue`.
- Replaced `<legend>` with `<h6>` for the notifications heading (the wrapping element no longer needs to be a `<fieldset>`).
- Tightened responsive vertical margins on the language-selector fieldset (`mb-3 mb-lg-5` instead of `mb-5`) and the notifications/PWA fieldsets (`mb-md-3` instead of `mb-3`).
- Reduced the user-info form hint to `small lh-sm` so the email/version line takes less vertical space.

Pure markup/CSS tweaks — no behavior change, no template logic changes, no script changes.

## Test plan
- [ ] Settings view renders correctly at xs, sm, md, lg breakpoints.
- [ ] Notifications heading remains accessible (semantic `<h6>` is announced as a heading by screen readers).
- [ ] PWA install button still appears in the right place.
- [ ] Logout button + version/email line still wrap sensibly on narrow screens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)