### PR TITLE
fix(frontend): allow inline cross-domain bouncer under CSP via sha256 hash

### DIFF
--- a/.changeset/inline-bouncer-csp-hash.md
+++ b/.changeset/inline-bouncer-csp-hash.md
@@ -1,0 +1,5 @@
+---
+'@opencupid/frontend': patch
+---
+
+Allow the cross-domain bouncer script in index.html under CSP via a sha256 hash in script-src.

--- a/apps/frontend/index.html
+++ b/apps/frontend/index.html
@@ -80,6 +80,13 @@
       style="height: 100dvh"
     ></div>
     <script src="/config.js"></script>
+    <!--
+      WARNING: this inline script's body is pinned by a sha256 hash in
+      apps/frontend/security-headers.conf.tmpl (script-src). Any edit
+      here — including whitespace — changes the hash and silently
+      breaks the bouncer under CSP. Recompute the hash and update the
+      header file when editing.
+    -->
     <script>
       ;(function () {
         var m = document.cookie.match(/(?:^|;\s*)__o=([^;]+)/)

--- a/apps/frontend/security-headers.conf.tmpl
+++ b/apps/frontend/security-headers.conf.tmpl
@@ -2,5 +2,8 @@ add_header X-Content-Type-Options "nosniff" always;
 add_header X-Frame-Options "DENY" always;
 add_header Referrer-Policy "strict-origin-when-cross-origin" always;
 add_header Permissions-Policy 'camera=(self "https://${JITSI_DOMAIN}"), microphone=(self "https://${JITSI_DOMAIN}"), geolocation=(self)' always;
-add_header Content-Security-Policy "default-src 'self'; script-src 'self' https://*.${DOMAIN}; style-src 'self' 'unsafe-inline'; font-src 'self' data:; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; worker-src 'self' blob:; media-src 'self' blob:; frame-src https://*.${DOMAIN}; img-src 'self' data: blob: ${CSP_ALLOWED_DOMAINS}; connect-src 'self' blob: wss://${DOMAIN} https://*.${DOMAIN} ${CSP_ALLOWED_DOMAINS}; upgrade-insecure-requests${CSP_REPORT_DIRECTIVE}" always;
+# script-src includes a sha256 hash for the inline cross-domain bouncer in
+# apps/frontend/index.html. Editing that <script> body changes the hash and
+# silently breaks the bouncer — keep these in sync.
+add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'sha256-MykGAW6vyIrS8fJfNCuEJygLvvTx6a8HQsbO1MVSKJk=' https://*.${DOMAIN}; style-src 'self' 'unsafe-inline'; font-src 'self' data:; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; worker-src 'self' blob:; media-src 'self' blob:; frame-src https://*.${DOMAIN}; img-src 'self' data: blob: ${CSP_ALLOWED_DOMAINS}; connect-src 'self' blob: wss://${DOMAIN} https://*.${DOMAIN} ${CSP_ALLOWED_DOMAINS}; upgrade-insecure-requests${CSP_REPORT_DIRECTIVE}" always;
 add_header Cache-Control "no-cache" always;


### PR DESCRIPTION
## Summary

- The inline `<script>` IIFE in [apps/frontend/index.html](apps/frontend/index.html#L83-L98) — the cross-domain `__o` cookie bouncer that redirects users to their originating host via `/_migrate` — was blocked by CSP after #1416 restored the security-header stack on SPA paths.
- The block was confirmed in production (`gaians.net/home`): Firefox reported `Content-Security-Policy: blocked an inline script (script-src-elem)` and the existing `report-uri` correctly fired a `201` to `log.gaians.net`. APIs themselves were unaffected — `script-src` `'self'` plus `https://*.${DOMAIN}` already covers all external scripts (`/config.js`, `u.gaians.net/script.js`, the bundle, etc.). Only inline scripts were broken.
- Fix: add `'sha256-MykGAW6vyIrS8fJfNCuEJygLvvTx6a8HQsbO1MVSKJk='` to `script-src` in `security-headers.conf.tmpl`. The hash matches the bouncer body verbatim (verified locally and against the hash Firefox reported).
- Added an HTML comment directly above the inline script and a comment on the CSP line, both warning that the body is hash-pinned and any edit (including whitespace) invalidates the hash.

## Why hash and not an external script

Considered moving the bouncer to `/bouncer.js` so it'd be covered by `'self'` with no hash plumbing. Hash chosen instead per maintainer preference; trade-off acknowledged in the inline comments so future editors don't get silently bitten.

## Test plan

- [ ] After deploy: navigate to `https://gaians.net/home` in a browser, confirm DevTools console shows zero CSP violations and no `script-src-elem` block for the bouncer.
- [ ] Same on `https://komaterkep.hu/home`.
- [ ] `curl -sI https://gaians.net/auth | grep -i content-security-policy` shows the hash inside `script-src`.
- [ ] Verify GlitchTip stops receiving CSP reports for the inline bouncer hash on both hosts within ~10 min after deploy.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)