### PR TITLE
Always mount BrowseProfiles map with fallback center

### DIFF
--- a/.changeset/violet-maps-mount.md
+++ b/.changeset/violet-maps-mount.md
@@ -1,0 +1,5 @@
+---
+'@opencupid/frontend': patch
+---
+
+Always mount the BrowseProfiles map, falling back to a default centroid when the viewer profile lacks coordinates (#1420)

--- a/apps/frontend/src/features/browse/views/BrowseProfiles.vue
+++ b/apps/frontend/src/features/browse/views/BrowseProfiles.vue
@@ -11,6 +11,7 @@ import { useBrowseViewModel } from '../composables/useBrowseViewModel'
 import { useSearchStore } from '@/features/browse/stores/searchStore'
 import { useFindProfileStore } from '@/features/browse/stores/findProfileStore'
 import { isValidLatLng, toLatLng } from '@/features/map/utils/mapUtils'
+import { MAP_DEFAULT_CENTER } from '@shared/maps'
 import { useDetailRouteState } from '@/features/shared/composables/useDetailRouteState'
 import { useDetailPanel } from '@/features/app/composables/useDetailPanel'
 
@@ -67,10 +68,11 @@ function onMapReady() {
 }
 
 // Initial center for the map's first mount. Read once by OsmPoiMap; not
-// reactive after mount.
-const initialMapCenter = computed<[number, number] | undefined>(() => {
+// reactive after mount. Falls back to MAP_DEFAULT_CENTER when the viewer
+// profile has no resolved coordinates so the map still mounts and renders.
+const initialMapCenter = computed<[number, number]>(() => {
   const fromProfile = toLatLng(viewerProfile.value?.location)
-  return isValidLatLng(fromProfile) ? fromProfile : undefined
+  return isValidLatLng(fromProfile) ? fromProfile : MAP_DEFAULT_CENTER
 })
 
 const highlightedLocation = ref<[number, number] | null>(null)
@@ -238,7 +240,7 @@ onMounted(async () => {
         />
 
         <OsmPoiMap
-          v-if="initialMapCenter"
+          v-if="viewerProfile"
           :items="allPois"
           :clusters="clusters"
           :icon-resolver="

--- a/apps/frontend/src/features/browse/views/__tests__/BrowseProfiles.spec.ts
+++ b/apps/frontend/src/features/browse/views/__tests__/BrowseProfiles.spec.ts
@@ -11,7 +11,15 @@ vi.mock('@/features/map/components/OsmPoiMap.vue', () => ({
   default: {
     name: 'OsmPoiMap',
     template: '<div class="map-view"><div class="osm-poi-map" /></div>',
-    props: ['items', 'clusters', 'iconResolver', 'center', 'popupComponent', 'fetchPopupData'],
+    props: [
+      'items',
+      'clusters',
+      'iconResolver',
+      'initialCenter',
+      'highlightedLocation',
+      'popupResolver',
+      'fetchPopupData',
+    ],
     emits: ['map:ready', 'item:select', 'bounds:changed'],
   },
 }))
@@ -177,10 +185,15 @@ const BContainer = { template: '<div class="container"><slot /></div>' }
 const ShareDialog = { template: '<div class="share-dialog"><slot /></div>', props: ['trigger'] }
 
 import BrowseProfiles from '../BrowseProfiles.vue'
+import { MAP_DEFAULT_CENTER } from '@shared/maps'
 
 describe('BrowseProfiles view', () => {
   beforeEach(() => {
     vmState.isNoOneAround.value = false
+    vmState.viewerProfile.value = {
+      isSocialActive: true,
+      location: { country: 'HU', cityName: 'Budapest', lat: 47.5, lon: 19.0 },
+    }
     mockRouteName.value = 'Browse'
     mockDetail.value = null
     mockPostSummaries.value = []
@@ -242,6 +255,25 @@ describe('BrowseProfiles view', () => {
     }
     const wrapper = mountComponent()
     expect(wrapper.find('.map-view').exists()).toBe(true)
+    const map = wrapper.findComponent({ name: 'OsmPoiMap' })
+    expect(map.props('initialCenter')).toEqual([47.5, 19.0])
+  })
+
+  it('mounts the map with MAP_DEFAULT_CENTER when viewer profile lacks lat/lon', () => {
+    vmState.viewerProfile.value = {
+      isSocialActive: true,
+      location: { country: 'HU', cityName: 'Budapest', lat: null, lon: null },
+    }
+    const wrapper = mountComponent()
+    const map = wrapper.findComponent({ name: 'OsmPoiMap' })
+    expect(map.exists()).toBe(true)
+    expect(map.props('initialCenter')).toEqual(MAP_DEFAULT_CENTER)
+  })
+
+  it('does not mount the map until viewerProfile has loaded', () => {
+    vmState.viewerProfile.value = null as unknown as Record<string, any>
+    const wrapper = mountComponent()
+    expect(wrapper.findComponent({ name: 'OsmPoiMap' }).exists()).toBe(false)
   })
 
   it('shows MapPlaceholder and hides it after OsmPoiMap emits map:ready', async () => {

--- a/packages/shared/maps.ts
+++ b/packages/shared/maps.ts
@@ -4,5 +4,12 @@ export const MAP_MAX_ZOOM = 12
 /** Default zoom level used on map initialization. */
 export const MAP_DEFAULT_ZOOM = 8
 
+/**
+ * Fallback map center used when the viewer profile has no resolved
+ * coordinates. A centroid over Central Europe so users land somewhere
+ * usable and can pan from there.
+ */
+export const MAP_DEFAULT_CENTER: [number, number] = [50, 14]
+
 /** Maximum number of tag IDs accepted for browse filtering. */
 export const MAX_BROWSE_TAGS = 5


### PR DESCRIPTION
## Summary
This PR ensures the BrowseProfiles map always mounts, even when the viewer profile lacks resolved coordinates. Previously, the map would not render until coordinates were available. Now it falls back to a sensible default center point over Central Europe.

## Key Changes
- **Map mounting logic**: Changed the `v-if` condition from checking `initialMapCenter` to checking `viewerProfile`, allowing the map to mount as soon as the profile loads
- **Fallback center**: Introduced `MAP_DEFAULT_CENTER` constant (`[50, 14]`) in the shared maps module as a centroid over Central Europe
- **Computed property update**: Modified `initialMapCenter` to always return a valid `[number, number]` coordinate pair, using `MAP_DEFAULT_CENTER` when the viewer profile has no resolved lat/lon
- **Props refactoring**: Updated the mocked OsmPoiMap component props to reflect the new API (`initialCenter`, `highlightedLocation`, `popupResolver` instead of `center`, `popupComponent`)
- **Test coverage**: Added comprehensive tests for:
  - Map mounting with viewer profile coordinates
  - Map mounting with fallback center when coordinates are missing
  - Map not mounting until profile loads

## Implementation Details
- The `initialMapCenter` computed property now guarantees a valid coordinate return type, eliminating the need for conditional rendering based on center availability
- The fallback center is positioned at `[50, 14]` (approximately Prague/Central Europe) to provide a reasonable starting point for users without resolved location data
- The map will only render once `viewerProfile` is loaded (not null), ensuring proper initialization while gracefully handling missing coordinates

https://claude.ai/code/session_01XTkrDj5inJrvbD62NwuENH