### PR TITLE
feat(i18n): rebrand "like" as "smile" in HU and EN copy

### DIFF
--- a/.changeset/bright-emoji-smile.md
+++ b/.changeset/bright-emoji-smile.md
@@ -1,0 +1,6 @@
+---
+'@opencupid/frontend': patch
+'@opencupid/shared': patch
+---
+
+Rebrand the "like" feature as "smile" in user-facing copy (HU + EN). Heart icon swapped for smiling-emoji.svg in InteractionButtons. Like feature behavior is unchanged.

--- a/apps/frontend/src/features/interaction/components/InteractionButtons.vue
+++ b/apps/frontend/src/features/interaction/components/InteractionButtons.vue
@@ -2,8 +2,9 @@
 import { computed, ref, watch } from 'vue'
 import { type InteractionContext } from '@zod/interaction/interactionContext.dto'
 
-import IconHeart from '@/assets/icons/interface/heart.svg'
-import IconCross from '@/assets/icons/interface/cross.svg'
+import IconLike from '@/assets/icons/emojis/smiling-emoji.svg'
+import IconPass from '@/assets/icons/interface/cross.svg'
+
 import IconMessage from '@/assets/icons/interface/message.svg'
 import AnonymousToggle from './AnonymousToggle.vue'
 import ConfirmPassDialog from './ConfirmPassDialog.vue'
@@ -90,7 +91,7 @@ const handleAnonymousChange = (value: boolean) => {
             :disabled="!context.canPass"
             :title="$t('interactions.pass_button_title')"
           >
-            <IconCross class="svg-icon-lg" />
+            <IconPass class="svg-icon-lg" />
           </BButton>
         </template>
         <ConfirmPassDialog
@@ -134,7 +135,7 @@ const handleAnonymousChange = (value: boolean) => {
     >
       <template #target>
         <BButton class="btn-icon-lg btn-dating btn-shadow">
-          <IconHeart class="svg-icon-lg" />
+          <IconLike class="svg-icon-lg" />
         </BButton>
       </template>
       <AnonymousToggle
@@ -154,7 +155,7 @@ const handleAnonymousChange = (value: boolean) => {
             {{ $t('interactions.they_liked_you') }}
           </span>
           <span class="flex-grow-0 text-dating flex-shrink-1">
-            <IconHeart class="svg-icon" />
+            <IconLike class="svg-icon" />
           </span>
         </span>
       </template>
@@ -164,7 +165,7 @@ const handleAnonymousChange = (value: boolean) => {
           class="btn-icon-lg btn-dating btn-shadow"
           @click="handleLikeClick"
         >
-          <IconHeart class="svg-icon-lg" />
+          <IconLike class="svg-icon-lg" />
         </BButton>
       </template>
       <span class="mb-2 d-block">
@@ -184,7 +185,7 @@ const handleAnonymousChange = (value: boolean) => {
             {{ $t('interactions.send_a_like') }}
           </span>
           <span class="flex-grow-0 text-dating flex-shrink-1">
-            <IconHeart class="svg-icon" />
+            <IconLike class="svg-icon" />
           </span>
         </span>
       </template>
@@ -193,7 +194,7 @@ const handleAnonymousChange = (value: boolean) => {
           class="btn-icon-lg btn-dating btn-shadow"
           @click="handleLikeClick"
         >
-          <IconHeart class="svg-icon-lg" />
+          <IconLike class="svg-icon-lg" />
         </BButton>
       </template>
       <AnonymousToggle v-model="selectedAnonymous" />

--- a/apps/frontend/src/features/interaction/components/__tests__/InteractionButtons.spec.ts
+++ b/apps/frontend/src/features/interaction/components/__tests__/InteractionButtons.spec.ts
@@ -2,7 +2,7 @@ import { mount } from '@vue/test-utils'
 import { describe, it, expect, vi } from 'vitest'
 import { nextTick } from 'vue'
 
-vi.mock('@/assets/icons/interface/heart.svg', () => ({
+vi.mock('@/assets/icons/emojis/smiling-emoji.svg', () => ({
   default: { template: '<span />' },
 }))
 vi.mock('@/assets/icons/interface/cross.svg', () => ({

--- a/packages/shared/i18n/en.json
+++ b/packages/shared/i18n/en.json
@@ -54,13 +54,13 @@
     },
     "new_like": {
       "callToActionLabel": "Find out who",
-      "contentBody": "Hey there, someone sent you a  ❤️.",
-      "subject": "You have a new like"
+      "contentBody": "Hey there, someone smiled at you.",
+      "subject": "Someone smiled at you"
     },
     "new_match": {
       "callToActionLabel": "Open matches",
-      "contentBody": "Hey there, you matched with {name}.",
-      "subject": "You have a new match!"
+      "contentBody": "Hey there, you and {name} smiled at each other.",
+      "subject": "You smiled at each other!"
     },
     "new_message": {
       "callToActionLabel": "Read message",
@@ -131,51 +131,51 @@
     "welcome_title": "Welcome to {siteName}!"
   },
   "interactions": {
-    "anonymous_like_explanation": "They will not know who sent it until they like you back.",
+    "anonymous_like_explanation": "They won't know who sent it until they smile back at you.",
     "anonymous_toggle_anonymous": "Stay anonymous",
     "anonymous_toggle_reveal": "Reveal my profile",
     "cancel_button": "Maybe later",
     "its_a_match": "It's a match!",
-    "like_button_title": "Like",
+    "like_button_title": "Smile",
     "like_error": "Oops, this didn't work. Please try again.",
-    "like_them_back": "Like them back to match.",
+    "like_them_back": "Smile back at them?",
     "message_confirmation": "Nice!",
     "pass_button_title": "Pass",
     "revealed_like_explanation": "They will see who sent it.",
-    "send_a_like": "Send them a like",
+    "send_a_like": "Smile at them",
     "send_a_message": "Send a message",
     "send_them_a_message": "Send {name} a message",
-    "they_liked_you": "They liked you!",
-    "you_liked_them": "You liked them",
-    "you_matched_with_them": "You matched with them",
+    "they_liked_you": "They smiled at you!",
+    "you_liked_them": "You smiled at them",
+    "you_matched_with_them": "{name} smiled back!",
     "you_messaged_them": "You messaged them"
   },
   "matches": {
-    "anonymous_like_hint": "They didn't want you to know who they are, at least not yet. But you will find out when you like them back. You can bump into them on the map — if you see someone marked like this, your preferences match.",
+    "anonymous_like_hint": "They smiled at you anonymously, at least for now. You'll find out who when you smile back. You can bump into them on the map — if you see someone marked like this, your preferences match.",
     "anonymous_like_hint_cta": "Discover the community",
     "find_button_cta": "Go connect",
-    "no_match_have_sent_like": "They will surely like you back.",
+    "no_match_have_sent_like": "They will surely smile back at you.",
     "no_match_have_sent_like_cta": "Keep lookin'",
-    "no_match_no_sent_like": "There's gotta be someone you like out there?  ",
+    "no_match_no_sent_like": "There's gotta be someone out there worth smiling at?  ",
     "no_match_no_sent_like_cta": "Start lookin'",
     "notifications": {
       "and": "and",
       "matches": "{count, plural, one {# new match} other {# new matches}}",
-      "you_have_likes": "{count, plural, one {You have # ❤️} other {You have # ❤️}}"
+      "you_have_likes": "{count, plural, one {Someone smiled at you} other {# people smiled at you}}"
     },
     "pass_confirm_dialog": {
       "liked_button_no": "No, don't pass",
       "liked_button_yes": "Yes, pass",
       "matched_button_no": "No!",
       "matched_button_yes": "Yes, unmatch",
-      "question_liked": "You already liked them. Are you sure you want to pass?",
-      "question_matched": "You already matched with them. Do you REALLY want to unmatch?",
+      "question_liked": "You already smiled at them. Are you sure you want to pass?",
+      "question_matched": "You smiled at each other. Do you REALLY want to unmatch?",
       "title": "But wait..."
     },
-    "received_likes": "{count, plural, =0 {You have no likes.} one {You have # like.} other {You have # likes!}}",
+    "received_likes": "{count, plural, =0 {No smiles yet.} one {You have # smile.} other {You have # smiles!}}",
     "received_likes_cta": "Find out who sent it",
-    "you_matched_with": "You matched with {name}!",
-    "you_received_like": "You received a like!"
+    "you_matched_with": "{name} smiled back!",
+    "you_received_like": "Someone smiled at you!"
   },
   "messaging": {
     "already_sent_waiting": "You have already sent them a message. Once they answer, you can continue the conversation.",
@@ -508,7 +508,7 @@
     "language_label": "Language",
     "newsletter_opt_in": "Email newsletter",
     "newsletter_opt_in_hint": "Community updates, new features, that kind of stuff. You can unsubscribe any time.",
-    "notifications_opt_in": "When someone sends me a message, like or match...",
+    "notifications_opt_in": "When someone messages me, smiles at me, or matches with me...",
     "notifications_label": "Notifications",
     "push_notify_messages": "Popup and mobile notification",
     "title": "Settings"

--- a/packages/shared/i18n/hu.json
+++ b/packages/shared/i18n/hu.json
@@ -54,15 +54,15 @@
     },
     "new_like": {
       "callToActionLabel": "Megnyitom",
-      "contentBody": "Szia, valaki komál téged.",
+      "contentBody": "Szia, valaki Rád mosolygott!'",
       "footer": " ",
-      "subject": "Valaki komál téged"
+      "subject": "Valaki rád mosolygott"
     },
     "new_match": {
       "callToActionLabel": "Megnyitom",
-      "contentBody": "Szia, {name} és Te kölcsönösen komáljátok egymást.",
+      "contentBody": "Szia, {name} és Te egymásra mosolyogtatok.",
       "footer": " ",
-      "subject": "Komáljátok egymást"
+      "subject": "Rámosolyogtatok egymásra"
     },
     "new_message": {
       "callToActionLabel": "Üzenet megnyitása",
@@ -135,27 +135,27 @@
     "welcome_title": "Légy üdvözölve nálunk."
   },
   "interactions": {
-    "anonymous_like_explanation": "Csak akkor fogja tudni, ki küldte, ha ő is komál téged.",
+    "anonymous_like_explanation": "Csak akkor derül ki, hogy tőled jött, ha visszamosolyog rád.",
     "anonymous_toggle_anonymous": "Névtelenül",
     "anonymous_toggle_reveal": "Mutasd a profilom",
     "cancel_button": "Talán később",
     "its_a_match": "Kölcsönös!",
-    "like_button_title": "Komálom!",
+    "like_button_title": "Rámosolygok!",
     "like_error": "Hoppá, ez nem működött. Kérjük, próbáld meg újra.",
-    "like_them_back": "Jelöld vissza, ha Te is.  ",
+    "like_them_back": "Visszamosolyogsz?",
     "message_confirmation": "Elküldve!",
     "pass_button_title": "Passzolok",
     "revealed_like_explanation": "Látni fogja, hogy Te küldted.",
-    "send_a_like": "Komálom?",
+    "send_a_like": "Rámosolygok",
     "send_a_message": "Üzenetet küldök neki",
     "send_them_a_message": "Küldj neki egy üzenetet.",
-    "they_liked_you": "Komál téged!",
-    "you_liked_them": "Komálom",
-    "you_matched_with_them": "{name} visszajelölt!",
-    "you_messaged_them": "Üzenetet küldtél nekik"
+    "they_liked_you": "Rád mosolygott!",
+    "you_liked_them": "Rámosolygok",
+    "you_matched_with_them": "{name} visszamosolygott!",
+    "you_messaged_them": "Üzenetet küldtél neki"
   },
   "matches": {
-    "anonymous_like_hint": "Egyelőre névtelenül komál téged. De a Komakeresőben rátalálhatsz - ha Te is komálod őt, ki fog derülni, ki küldte. Ha valakit ilyen jelöléssel látsz, a preferenciáitok megegyeznek:",
+    "anonymous_like_hint": "Egyelőre névtelenül mosolygott rád. De a Komakeresőben rátalálhatsz - ha Te is rámosolyogsz, ki fog derülni, ki küldte. Ha valakit ilyen jelöléssel látsz, könnyen lehet, hogy egymást keresitek:",
     "anonymous_like_hint_cta": "A Komakeresőhöz",
     "find_button_cta": "Kapcsolódj",
     "no_match_have_sent_like": "Még nem lájkolt vissza senki",
@@ -165,21 +165,21 @@
     "notifications": {
       "and": "és",
       "matches": "{count, plural, one {# új kölcsönös ❤️} other {# új kölcsönös ❤️}}",
-      "you_have_likes": "{count, plural, one {Valaki komál téged} other {Többen komálnak}}"
+      "you_have_likes": "{count, plural, one {Valaki rád mosolygott} other {Többen rád mosolyogtak}}"
     },
     "pass_confirm_dialog": {
       "liked_button_no": "Nem!",
       "liked_button_yes": "Igen, visszavonom",
       "matched_button_no": "Inkább nem",
       "matched_button_yes": "Igen, passzolok",
-      "question_liked": "Már komáltad őt.  Meggondoltad magad?",
-      "question_matched": "Kölcsönösen komáljátok egymást. TÉNYLEG passzolni szeretnél?",
+      "question_liked": "Korábban rámosolyogtál.  Meggondoltad magad?",
+      "question_matched": "Egymásra mosolyogtatok. TÉNYLEG passzolni szeretnél?",
       "title": "De várj..."
     },
     "received_likes": "{count, plural, =0 {Még nincs ❤️-od} one {# ❤️-ot kaptál} other {# ❤️-od van}}",
     "received_likes_cta": "Vajon ki küldte?",
-    "you_matched_with": "{name} is komál téged",
-    "you_received_like": "Valaki komál! ❤️"
+    "you_matched_with": "{name} visszamosolygott",
+    "you_received_like": "Valaki rád mosolygott!"
   },
   "messaging": {
     "already_sent_waiting": "Már küldtél nekik üzenetet. Amint válaszolnak, folytathatod a beszélgetést.",
@@ -188,7 +188,7 @@
     "block_user_ok": "{name} letiltása",
     "conversation_options_title": "Beszélgetés beállításai",
     "loading_older_messages": "Régebbi üzenetek betöltése…",
-    "matches_list_title": "Komáljuk egymást ❤️",
+    "matches_list_title": "Egymásra mosolyogtunk ❤️",
     "message_input_hint": "Enter-rel küldheted",
     "message_input_hint_click": "Kattints a KÜLDÉS gombra",
     "message_input_placeholder": "...",


### PR DESCRIPTION
## Summary
- Rebrands the "like" feature as "smile" in user-facing copy across **HU** (`komál` → `rámosolyog`/`visszamosolyog`) and **EN** (`like` → `smile`/`smiled at you`/`smiled back`)
- Heart icon (`heart.svg`) swapped for `smiling-emoji.svg` in [InteractionButtons.vue](apps/frontend/src/features/interaction/components/InteractionButtons.vue); `IconCross` import alias renamed to `IconPass` for naming consistency
- **Like feature behavior is unchanged** — pure UX terminology refresh and icon swap

## Test plan
- [ ] Browse profiles → tap the smile button (formerly heart) → verify anonymous toggle still works
- [ ] Receive a like → verify "Someone smiled at you!" / "Valaki rád mosolygott!" copy in inbox + match toast
- [ ] Reciprocate a like → verify match popup shows "{name} smiled back!" / "{name} visszamosolygott!"
- [ ] Email triggers (`new_like`, `new_match`): verify subject & body in both EN and HU render correctly with `{siteName}` and `{name}` placeholders
- [ ] Settings → notifications opt-in label reads "When someone messages me, smiles at me, or matches with me…"
- [ ] `pnpm type-check` passes (running locally; CI will re-verify)

## Out of scope (deferred)
The `chore/i18n-orphan-cleanup-deferred` branch contains a follow-up cleanup that removes ~140 unreferenced i18n keys per locale (identified via static analysis of `t()` / `$t()` call sites) and adds `scripts/find-stale-i18n.mjs` as a reusable analyzer. Will land as a separate PR.

⚠ **Tolgee state divergence note**: the orphan cleanup has already been applied to the Tolgee dev server (310 EN / 314 HU keys). Local files in this PR carry the un-cleaned set (451 EN / 458 HU). The deferred PR will reconcile them. Until it lands, `pnpm tolgee:pull` will report ~140 deletions — that's the cleanup waiting to be applied locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)