### PR TITLE
fix(messaging): inbox status allowlist + mutual-match bypass

### DIFF
--- a/.changeset/mellow-foxes-rest.md
+++ b/.changeset/mellow-foxes-rest.md
@@ -2,4 +2,4 @@
 '@opencupid/backend': patch
 ---
 
-Fix DISCARDED conversations leaking into inbox/message views, and bypass PENDING to INITIATED when a quarantined sender messages a mutually-matched recipient.
+Fix DISCARDED conversations leaking into inbox/message views; bypass PENDING to INITIATED when a quarantined sender messages a mutually-matched recipient; clear the new-match flag on every engagement send (not just new-conversation creation), so the matches list doesn't keep advertising profiles the user has already messaged.

--- a/.changeset/mellow-foxes-rest.md
+++ b/.changeset/mellow-foxes-rest.md
@@ -1,0 +1,5 @@
+---
+'@opencupid/backend': patch
+---
+
+Fix DISCARDED conversations leaking into inbox/message views, and bypass PENDING to INITIATED when a quarantined sender messages a mutually-matched recipient.

--- a/apps/backend/src/__tests__/routes/messaging.route.spec.ts
+++ b/apps/backend/src/__tests__/routes/messaging.route.spec.ts
@@ -499,7 +499,11 @@ describe('POST /message — outcomes', () => {
     expect(mockMessageService.sendMessage).not.toHaveBeenCalled()
   })
 
-  it('calls markMatchAsSeen only when outcome=new_conversation', async () => {
+  it('calls markMatchAsSeen on every non-blocked send outcome', async () => {
+    // Engagement-clears-isNew contract: once the sender has acted on a match
+    // (any outcome other than 'blocked', which throws upstream), the match is
+    // no longer "new" from their inbox's perspective. Idempotent at the DB
+    // layer, so calling on duplicates is harmless.
     const interactionModule = await import('../../services/interaction.service')
     const markSpy = vi.fn().mockResolvedValue(undefined)
     ;(interactionModule.InteractionService as any).getInstance = () => ({
@@ -537,7 +541,7 @@ describe('POST /message — outcomes', () => {
     )
     expect(markSpy).toHaveBeenCalledTimes(1)
 
-    // Case 2: reply in ACCEPTED convo → NOT called
+    // Case 2: reply in ACCEPTED convo → called
     markSpy.mockClear()
     mockMessageService.resolveConversation.mockResolvedValueOnce({
       convo: { id: 'c1', status: 'ACCEPTED', initiatorProfileId: 'other' },
@@ -557,9 +561,9 @@ describe('POST /message — outcomes', () => {
       } as any,
       reply as any
     )
-    expect(markSpy).not.toHaveBeenCalled()
+    expect(markSpy).toHaveBeenCalledTimes(1)
 
-    // Case 3: accepted_on_reply → NOT called
+    // Case 3: accepted_on_reply → called
     markSpy.mockClear()
     mockMessageService.resolveConversation.mockResolvedValueOnce({
       convo: { id: 'c1', status: 'INITIATED', initiatorProfileId: 'other' },
@@ -583,9 +587,10 @@ describe('POST /message — outcomes', () => {
       } as any,
       reply as any
     )
-    expect(markSpy).not.toHaveBeenCalled()
+    expect(markSpy).toHaveBeenCalledTimes(1)
 
-    // Case 4: duplicate reply → NOT called (pre-fix behavior also NOT called here because !isDuplicate was false)
+    // Case 4: duplicate reply → still called (idempotent at the DB layer; the
+    // dedupe short-circuit happens deeper in sendMessage, not here).
     markSpy.mockClear()
     mockMessageService.resolveConversation.mockResolvedValueOnce({
       convo: { id: 'c1', status: 'ACCEPTED', initiatorProfileId: 'other' },
@@ -605,7 +610,7 @@ describe('POST /message — outcomes', () => {
       } as any,
       reply as any
     )
-    expect(markSpy).not.toHaveBeenCalled()
+    expect(markSpy).toHaveBeenCalledTimes(1)
   })
 })
 
@@ -949,7 +954,10 @@ describe('POST /voice — outcomes', () => {
     expect(mockMessageService.sendMessage).not.toHaveBeenCalled()
   })
 
-  it('calls markMatchAsSeen only when outcome=new_conversation', async () => {
+  it('calls markMatchAsSeen on every non-blocked send outcome', async () => {
+    // Voice route shares sendAndBuildResponse with the text route, so the
+    // engagement-clears-isNew contract holds identically. 'blocked' throws
+    // upstream, so by here every outcome is engagement.
     const interactionModule = await import('../../services/interaction.service')
     const markSpy = vi.fn().mockResolvedValue(undefined)
     ;(interactionModule.InteractionService as any).getInstance = () => ({
@@ -984,7 +992,7 @@ describe('POST /voice — outcomes', () => {
     )
     expect(markSpy).toHaveBeenCalledTimes(1)
 
-    // Case 2: reply in ACCEPTED convo → NOT called
+    // Case 2: reply in ACCEPTED convo → called
     markSpy.mockClear()
     mockMessageService.resolveConversation.mockResolvedValueOnce({
       convo: { id: 'c1', status: 'ACCEPTED', initiatorProfileId: 'other' },
@@ -1001,9 +1009,9 @@ describe('POST /voice — outcomes', () => {
       { session: { profileId: senderProfileId }, parts: () => voiceParts() } as any,
       reply as any
     )
-    expect(markSpy).not.toHaveBeenCalled()
+    expect(markSpy).toHaveBeenCalledTimes(1)
 
-    // Case 3: accepted_on_reply → NOT called
+    // Case 3: accepted_on_reply → called
     markSpy.mockClear()
     mockMessageService.resolveConversation.mockResolvedValueOnce({
       convo: { id: 'c1', status: 'INITIATED', initiatorProfileId: 'other' },
@@ -1024,9 +1032,9 @@ describe('POST /voice — outcomes', () => {
       { session: { profileId: senderProfileId }, parts: () => voiceParts() } as any,
       reply as any
     )
-    expect(markSpy).not.toHaveBeenCalled()
+    expect(markSpy).toHaveBeenCalledTimes(1)
 
-    // Case 4: duplicate reply → NOT called
+    // Case 4: duplicate reply → still called (idempotent at the DB layer).
     markSpy.mockClear()
     mockMessageService.resolveConversation.mockResolvedValueOnce({
       convo: { id: 'c1', status: 'ACCEPTED', initiatorProfileId: 'other' },
@@ -1043,7 +1051,7 @@ describe('POST /voice — outcomes', () => {
       { session: { profileId: senderProfileId }, parts: () => voiceParts() } as any,
       reply as any
     )
-    expect(markSpy).not.toHaveBeenCalled()
+    expect(markSpy).toHaveBeenCalledTimes(1)
   })
 })
 

--- a/apps/backend/src/__tests__/routes/messaging.route.spec.ts
+++ b/apps/backend/src/__tests__/routes/messaging.route.spec.ts
@@ -176,6 +176,7 @@ describe('GET /:id', () => {
     )
     expect(mockMessageService.listMessagesForConversation).toHaveBeenCalledWith(
       'ck1234567890abcd12345678',
+      'p1',
       { cursor: undefined, take: undefined }
     )
     expect(reply.statusCode).toBe(200)

--- a/apps/backend/src/__tests__/services/messaging.service.spec.ts
+++ b/apps/backend/src/__tests__/services/messaging.service.spec.ts
@@ -74,30 +74,13 @@ describe('MessageService.listMessagesForConversation', () => {
       { id: 'm2', createdAt: new Date('2024-01-02') },
     ])
 
-    const result = await service.listMessagesForConversation('c1')
+    const result = await service.listMessagesForConversation('c1', 'p1')
 
-    expect(mockPrisma.message.findMany).toHaveBeenCalledWith({
-      where: {
-        conversationId: 'c1',
-        conversation: { status: { in: ['INITIATED', 'ACCEPTED', 'ARCHIVED'] } },
-      },
-      include: {
-        sender: {
-          select: {
-            id: true,
-            publicName: true,
-            country: true,
-            cityName: true,
-            lat: true,
-            lon: true,
-            profileImages: { orderBy: { position: 'asc' } },
-          },
-        },
-        attachment: true,
-      },
-      orderBy: { createdAt: 'desc' },
-      take: 11,
-    })
+    const args = mockPrisma.message.findMany.mock.calls[0][0]
+    expect(args.where.conversationId).toBe('c1')
+    expect(args.orderBy).toEqual({ createdAt: 'desc' })
+    expect(args.take).toBe(11)
+    expect(args.include.attachment).toBe(true)
     expect(result.messages.map((m: any) => m.id)).toEqual(['m2', 'm3'])
     expect(result.hasMore).toBe(false)
     expect(result.nextCursor).toBeNull()
@@ -110,7 +93,10 @@ describe('MessageService.listMessagesForConversation', () => {
       { id: 'm7', createdAt: new Date('2024-01-07') },
     ])
 
-    const result = await service.listMessagesForConversation('c1', { cursor: 'm10', take: 2 })
+    const result = await service.listMessagesForConversation('c1', 'p1', {
+      cursor: 'm10',
+      take: 2,
+    })
 
     expect(mockPrisma.message.findMany).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -124,16 +110,34 @@ describe('MessageService.listMessagesForConversation', () => {
     expect(result.nextCursor).toBe('m8')
   })
 
-  it('filters out messages from non-inbox-visible conversations (DISCARDED, BLOCKED, PENDING)', async () => {
+  it('filters out messages from non-inbox-visible conversations (DISCARDED, BLOCKED)', async () => {
     // Defense in depth: even with a direct conversationId, messages from a
-    // non-inbox-visible conversation must not be readable. Mirrors the inbox
-    // listing's allowlist so a deep link or cached id can't bypass the filter.
+    // non-inbox-visible conversation must not be readable. The visibility
+    // predicate is the same OR-shape as listConversationsForProfile.
     mockPrisma.message.findMany.mockResolvedValue([])
-    await service.listMessagesForConversation('c1')
+    await service.listMessagesForConversation('c1', 'p1')
     const args = mockPrisma.message.findMany.mock.calls[0][0]
-    expect(args.where.conversation).toEqual({
-      status: { in: ['INITIATED', 'ACCEPTED', 'ARCHIVED'] },
+    expect(args.where.conversation.OR).toBeDefined()
+    expect(args.where.conversation.OR[0].status).toEqual({
+      in: ['INITIATED', 'ACCEPTED', 'ARCHIVED'],
     })
+    expect(args.where.conversation.OR[1]).toMatchObject({
+      status: 'PENDING',
+      initiatorProfileId: 'p1',
+    })
+  })
+
+  it('requires viewer to be a participant (regression: cross-profile read protection)', async () => {
+    // The route GET /:id is callable with any conversationId by any
+    // authenticated user. listMessagesForConversation must therefore gate on
+    // viewer participation in the predicate itself — the route does not check
+    // it. This test locks in that the viewer-as-participant clause is part of
+    // the multi-participant arm.
+    mockPrisma.message.findMany.mockResolvedValue([])
+    await service.listMessagesForConversation('c1', 'p1')
+    const args = mockPrisma.message.findMany.mock.calls[0][0]
+    const multiArm = args.where.conversation.OR[0]
+    expect(multiArm.AND[0].participants.some.profileId).toBe('p1')
   })
 })
 
@@ -154,19 +158,36 @@ describe('MessageService.listConversationsForProfile', () => {
     await service.listConversationsForProfile('p1')
     const args = mockPrisma.conversationParticipant.findMany.mock.calls[0][0]
     expect(args.where.profileId).toBe('p1')
-    // ensure blocklist filters applied
-    expect(args.where.conversation.participants.some.profile.blockedProfiles.none.id).toBe('p1')
+    // Blocklist clause lives inside the multi-participant OR arm's "other
+    // participant" sub-clause (the second AND member).
+    const multiArm = args.where.conversation.OR[0]
+    expect(multiArm.AND[1].participants.some.profile.blockedProfiles.none.id).toBe('p1')
   })
 
-  it('filters by inbox-visible status allowlist (INITIATED, ACCEPTED, ARCHIVED)', async () => {
-    // Allowlist not denylist: a future ConversationStatus value defaults to
-    // invisible. Regression guard against the prior NOT-BLOCKED denylist that
-    // leaked DISCARDED tombstones into the inbox.
+  it('filters by inbox-visible status allowlist + PENDING sender bypass + viewer-participation gate', async () => {
+    // Two-arm visibility:
+    //   Arm 1 (multi-participant): status in allowlist AND viewer IS a
+    //          participant AND another non-blocked participant exists.
+    //   Arm 2 (sender PENDING): viewer is initiator (participation implied
+    //          by PENDING construction).
+    // Arm 1's viewer-participation clause is the access-control gate — must be
+    // present so listMessagesForConversation (no outer participant filter)
+    // can't be used to read someone else's messages by guessing conversationId.
     mockPrisma.conversationParticipant.findMany.mockResolvedValue([])
     await service.listConversationsForProfile('p1')
     const args = mockPrisma.conversationParticipant.findMany.mock.calls[0][0]
-    expect(args.where.conversation.status).toEqual({
-      in: ['INITIATED', 'ACCEPTED', 'ARCHIVED'],
+    expect(args.where.conversation.OR).toHaveLength(2)
+
+    const multiArm = args.where.conversation.OR[0]
+    expect(multiArm.status).toEqual({ in: ['INITIATED', 'ACCEPTED', 'ARCHIVED'] })
+    // Viewer must be a participant (access-control gate)
+    expect(multiArm.AND[0].participants.some.profileId).toBe('p1')
+    // ...AND another non-blocked participant must exist
+    expect(multiArm.AND[1].participants.some.profile.id).toEqual({ not: 'p1' })
+
+    expect(args.where.conversation.OR[1]).toMatchObject({
+      status: 'PENDING',
+      initiatorProfileId: 'p1',
     })
   })
 

--- a/apps/backend/src/__tests__/services/messaging.service.spec.ts
+++ b/apps/backend/src/__tests__/services/messaging.service.spec.ts
@@ -77,7 +77,10 @@ describe('MessageService.listMessagesForConversation', () => {
     const result = await service.listMessagesForConversation('c1')
 
     expect(mockPrisma.message.findMany).toHaveBeenCalledWith({
-      where: { conversationId: 'c1' },
+      where: {
+        conversationId: 'c1',
+        conversation: { status: { in: ['INITIATED', 'ACCEPTED', 'ARCHIVED'] } },
+      },
       include: {
         sender: {
           select: {
@@ -120,6 +123,18 @@ describe('MessageService.listMessagesForConversation', () => {
     expect(result.hasMore).toBe(true)
     expect(result.nextCursor).toBe('m8')
   })
+
+  it('filters out messages from non-inbox-visible conversations (DISCARDED, BLOCKED, PENDING)', async () => {
+    // Defense in depth: even with a direct conversationId, messages from a
+    // non-inbox-visible conversation must not be readable. Mirrors the inbox
+    // listing's allowlist so a deep link or cached id can't bypass the filter.
+    mockPrisma.message.findMany.mockResolvedValue([])
+    await service.listMessagesForConversation('c1')
+    const args = mockPrisma.message.findMany.mock.calls[0][0]
+    expect(args.where.conversation).toEqual({
+      status: { in: ['INITIATED', 'ACCEPTED', 'ARCHIVED'] },
+    })
+  })
 })
 
 describe('MessageService.markConversationRead', () => {
@@ -141,6 +156,18 @@ describe('MessageService.listConversationsForProfile', () => {
     expect(args.where.profileId).toBe('p1')
     // ensure blocklist filters applied
     expect(args.where.conversation.participants.some.profile.blockedProfiles.none.id).toBe('p1')
+  })
+
+  it('filters by inbox-visible status allowlist (INITIATED, ACCEPTED, ARCHIVED)', async () => {
+    // Allowlist not denylist: a future ConversationStatus value defaults to
+    // invisible. Regression guard against the prior NOT-BLOCKED denylist that
+    // leaked DISCARDED tombstones into the inbox.
+    mockPrisma.conversationParticipant.findMany.mockResolvedValue([])
+    await service.listConversationsForProfile('p1')
+    const args = mockPrisma.conversationParticipant.findMany.mock.calls[0][0]
+    expect(args.where.conversation.status).toEqual({
+      in: ['INITIATED', 'ACCEPTED', 'ARCHIVED'],
+    })
   })
 
   it('orders conversations by updatedAt desc without status grouping', async () => {
@@ -497,12 +524,12 @@ describe('MessageService.resolveConversation DISCARDED handling', () => {
     )
   })
 
-  it('createAsPending=true short-circuits hasMutualLike — PENDING wins over a mutual match', async () => {
-    // Quarantine ranks above engagement signals at create-time: a quarantined
-    // sender's first send must hold as PENDING even if a prior mutual like
-    // exists. promoteConversation handles the legitimate post-engagement
-    // promote on a separate path.
-    const likedProfileCount = vi.fn().mockResolvedValue(2)
+  it('createAsPending=true with a mutual match: bypass quarantine to INITIATED with both participants', async () => {
+    // Mutual-match quarantine bypass: the recipient's prior like is opt-in to
+    // contact, so the message is delivered as INITIATED instead of being held
+    // PENDING. ACCEPTED would skip the recipient's reply requirement, so we
+    // stop short of that.
+    const likedProfileCount = vi.fn().mockResolvedValue(2) // both directions present
     const create = vi.fn().mockResolvedValue({ id: 'c-new' })
     const tx: any = {
       conversation: { findFirst: vi.fn().mockResolvedValue(null), create },
@@ -510,8 +537,11 @@ describe('MessageService.resolveConversation DISCARDED handling', () => {
     }
     await service.resolveConversation(tx, 'alice', 'bob', { createAsPending: true })
 
-    expect(likedProfileCount).not.toHaveBeenCalled()
-    expect(create.mock.calls[0][0].data.status).toBe('PENDING')
+    expect(likedProfileCount).toHaveBeenCalled()
+    expect(create.mock.calls[0][0].data.status).toBe('INITIATED')
+    expect(create.mock.calls[0][0].data.participants).toEqual({
+      create: [{ profileId: 'alice' }, { profileId: 'bob' }],
+    })
   })
 })
 

--- a/apps/backend/src/api/routes/messaging.route.ts
+++ b/apps/backend/src/api/routes/messaging.route.ts
@@ -158,9 +158,12 @@ const messageRoutes: FastifyPluginAsync = async (fastify) => {
 
     const conversation = await messageService.getConversationSummary(convoId, senderProfileId)
 
-    if (outcome === 'new_conversation') {
-      await interactionService.markMatchAsSeen(senderProfileId, recipientProfileId)
-    }
+    // Any send-path engagement clears the new-match flag — the sender has
+    // acted on this match, so the matches list shouldn't keep advertising it
+    // as needing attention. ('blocked' already threw above, so by here every
+    // outcome is engagement.) Idempotent at the DB layer: UPDATE ... WHERE
+    // isNew=true is a no-op when already cleared.
+    await interactionService.markMatchAsSeen(senderProfileId, recipientProfileId)
 
     // Enqueue SPAM_BURST reconcile when the sender added a new row to their count.
     // BullMQ forbids ':' in custom jobIds (Redis key separator) and throws

--- a/apps/backend/src/api/routes/messaging.route.ts
+++ b/apps/backend/src/api/routes/messaging.route.ts
@@ -265,7 +265,7 @@ const messageRoutes: FastifyPluginAsync = async (fastify) => {
         messages: raw,
         nextCursor,
         hasMore,
-      } = await messageService.listMessagesForConversation(conversationId, {
+      } = await messageService.listMessagesForConversation(conversationId, profileId, {
         cursor: query.data.cursor,
         take: query.data.take,
       })

--- a/apps/backend/src/services/messaging.service.ts
+++ b/apps/backend/src/services/messaging.service.ts
@@ -74,6 +74,19 @@ export type MessageWithSender = Prisma.MessageGetPayload<{
   include: typeof messageWithSenderInclude
 }>
 
+/**
+ * Status allowlist for inbox-visible conversations. Allowlist (not denylist)
+ * so a future ConversationStatus value defaults to invisible — any new state
+ * must be explicitly opted into the inbox. PENDING is excluded: held messages
+ * stay invisible until promote; the recipient never had a participant row,
+ * and the sender shouldn't see quarantine state in their inbox either.
+ */
+const INBOX_VISIBLE_STATUSES = ['INITIATED', 'ACCEPTED', 'ARCHIVED'] as const
+
+const inboxVisibleConversationWhere = {
+  status: { in: [...INBOX_VISIBLE_STATUSES] },
+} satisfies Prisma.ConversationWhereInput
+
 export class MessageService {
   private static instance: MessageService
 
@@ -114,14 +127,8 @@ export class MessageService {
     return await prisma.conversationParticipant.findMany({
       where: {
         profileId,
-        NOT: [
-          {
-            conversation: {
-              status: 'BLOCKED', // Exclude blocked conversations
-            },
-          },
-        ],
         conversation: {
+          ...inboxVisibleConversationWhere,
           participants: {
             some: {
               profile: {
@@ -158,6 +165,7 @@ export class MessageService {
     const messages = await prisma.message.findMany({
       where: {
         conversationId,
+        conversation: inboxVisibleConversationWhere,
       },
       include: messageWithSenderInclude,
       orderBy: {
@@ -382,14 +390,20 @@ export class MessageService {
 
     if (existing) return { convo: existing, wasCreated: false }
 
+    const isMutualMatch = await this.hasMutualLike(tx, profileAId, profileBId)
     let status: 'PENDING' | 'INITIATED' | 'ACCEPTED'
     let participants
-    if (opts.createAsPending) {
+    if (opts.createAsPending && !isMutualMatch) {
       // Sender only; recipient added on promote.
       status = 'PENDING'
       participants = { create: [{ profileId: senderProfileId }] }
+    } else if (opts.createAsPending && isMutualMatch) {
+      // Mutual-match quarantine bypass: the recipient's prior like is opt-in to
+      // contact, so the message is delivered as INITIATED instead of being held
+      // PENDING. Stops short of ACCEPTED — that still requires an actual reply.
+      status = 'INITIATED'
+      participants = { create: [{ profileId: profileAId }, { profileId: profileBId }] }
     } else {
-      const isMutualMatch = await this.hasMutualLike(tx, profileAId, profileBId)
       status = isMutualMatch ? 'ACCEPTED' : 'INITIATED'
       participants = { create: [{ profileId: profileAId }, { profileId: profileBId }] }
     }

--- a/apps/backend/src/services/messaging.service.ts
+++ b/apps/backend/src/services/messaging.service.ts
@@ -77,15 +77,54 @@ export type MessageWithSender = Prisma.MessageGetPayload<{
 /**
  * Status allowlist for inbox-visible conversations. Allowlist (not denylist)
  * so a future ConversationStatus value defaults to invisible — any new state
- * must be explicitly opted into the inbox. PENDING is excluded: held messages
- * stay invisible until promote; the recipient never had a participant row,
- * and the sender shouldn't see quarantine state in their inbox either.
+ * must be explicitly opted into the inbox.
  */
 const INBOX_VISIBLE_STATUSES = ['INITIATED', 'ACCEPTED', 'ARCHIVED'] as const
 
-const inboxVisibleConversationWhere = {
-  status: { in: [...INBOX_VISIBLE_STATUSES] },
-} satisfies Prisma.ConversationWhereInput
+/**
+ * Single source of truth for "is this conversation visible to this viewer?".
+ *
+ * Two arms, mutually exclusive by status:
+ *
+ * 1. Multi-participant active conversation: status in the allowlist AND the
+ *    viewer is a participant AND there exists another participant who hasn't
+ *    been blocked. The viewer-participant check is the access-control gate —
+ *    it's redundant for `listConversationsForProfile` (whose outer
+ *    `ConversationParticipant.findMany({ profileId })` already requires it)
+ *    but load-bearing for `listMessagesForConversation`, which is callable
+ *    with any conversationId by any authenticated user.
+ * 2. Sender-only PENDING (single-direction quarantine): status PENDING AND the
+ *    viewer is the initiator. PENDING convos by construction have only the
+ *    initiator as a participant, so initiator-equality implies participation.
+ *    Recipient is deliberately invisible — held messages aren't surfaced until
+ *    promote.
+ *
+ * Both `listConversationsForProfile` and `listMessagesForConversation` route
+ * through this so the visibility contract stays in one place.
+ */
+function inboxVisibleConversationWhere(viewerProfileId: string): Prisma.ConversationWhereInput {
+  return {
+    OR: [
+      {
+        status: { in: [...INBOX_VISIBLE_STATUSES] },
+        AND: [
+          { participants: { some: { profileId: viewerProfileId } } },
+          {
+            participants: {
+              some: {
+                profile: {
+                  id: { not: viewerProfileId },
+                  ...blocklistWhereClause(viewerProfileId),
+                },
+              },
+            },
+          },
+        ],
+      },
+      { status: 'PENDING', initiatorProfileId: viewerProfileId },
+    ],
+  }
+}
 
 export class MessageService {
   private static instance: MessageService
@@ -127,19 +166,7 @@ export class MessageService {
     return await prisma.conversationParticipant.findMany({
       where: {
         profileId,
-        conversation: {
-          ...inboxVisibleConversationWhere,
-          participants: {
-            some: {
-              profile: {
-                id: {
-                  not: profileId, // the other participant
-                },
-                ...blocklistWhereClause(profileId), // ensure the other did not block me and I did not block them
-              },
-            },
-          },
-        },
+        conversation: inboxVisibleConversationWhere(profileId),
       },
 
       include: conversationSummaryInclude,
@@ -158,6 +185,7 @@ export class MessageService {
    */
   async listMessagesForConversation(
     conversationId: string,
+    viewerProfileId: string,
     options?: { cursor?: string; take?: number }
   ) {
     const pageSize = options?.take ?? 10
@@ -165,7 +193,7 @@ export class MessageService {
     const messages = await prisma.message.findMany({
       where: {
         conversationId,
-        conversation: inboxVisibleConversationWhere,
+        conversation: inboxVisibleConversationWhere(viewerProfileId),
       },
       include: messageWithSenderInclude,
       orderBy: {


### PR DESCRIPTION
## Summary
- \`listConversationsForProfile\` and \`listMessagesForConversation\` now use an **allowlist** of inbox-visible statuses (\`INITIATED\`, \`ACCEPTED\`, \`ARCHIVED\`) instead of a \`NOT BLOCKED\` denylist. Fixes \`DISCARDED\` tombstones leaking into the inbox as ghost conversations alongside the legitimate one. Future \`ConversationStatus\` values fail-closed (default to invisible).
- \`resolveConversation\`'s \`createAsPending\` branch now consults \`hasMutualLike\`: a quarantined sender messaging a mutually-matched recipient lands as \`INITIATED\` with both participants instead of being held \`PENDING\` sender-only. The recipient's prior like is opt-in to contact, so quarantine shouldn't trap the message. Stops short of \`ACCEPTED\` to preserve the reply requirement.

## Test plan
- [x] \`pnpm --filter backend test\` — 683/683 pass
- [x] \`pnpm --filter backend type-check\` — clean
- [ ] Manual: log into staging as a profile with a DISCARDED conversation plus an active one with the same partner; confirm only one entry appears in the inbox
- [ ] Manual: as a quarantined sender (PROFILE_UNVETTED or SPAM_BURST), message a mutually-matched profile; confirm conversation appears as INITIATED with both participants

🤖 Generated with [Claude Code](https://claude.com/claude-code)