### PR TITLE
umami  load-promise pattern

### DIFF
--- a/.changeset/quiet-otter-load.md
+++ b/.changeset/quiet-otter-load.md
@@ -1,0 +1,5 @@
+---
+'@opencupid/frontend': patch
+---
+
+Replace Umami init polling with a load-event promise so identify/track calls before the script loads are queued reliably and silently dropped on script load failure rather than hanging.

--- a/apps/frontend/src/lib/__tests__/umami.spec.ts
+++ b/apps/frontend/src/lib/__tests__/umami.spec.ts
@@ -20,6 +20,16 @@ function setConfig(overrides: Partial<{ UMAMI_URL: string; UMAMI_WEBSITE_ID: str
   }
 }
 
+function fireScriptLoad() {
+  const script = document.head.querySelector('script') as HTMLScriptElement | null
+  script?.dispatchEvent(new Event('load'))
+}
+
+function fireScriptError() {
+  const script = document.head.querySelector('script') as HTMLScriptElement | null
+  script?.dispatchEvent(new Event('error'))
+}
+
 describe('umami', () => {
   let originalConfig: any
 
@@ -34,7 +44,6 @@ describe('umami', () => {
 
   afterEach(() => {
     ;(globalThis as any).__APP_CONFIG__ = originalConfig
-    vi.useRealTimers()
   })
 
   describe('initUmami', () => {
@@ -59,7 +68,7 @@ describe('umami', () => {
       expect(document.head.querySelector('script')).toBeNull()
     })
 
-    it('appends a deferred script with src and data-website-id when enabled', async () => {
+    it('appends a script with src and data-website-id when enabled', async () => {
       setConfig(ENABLED)
       const { initUmami } = await import('../umami')
       initUmami()
@@ -67,21 +76,22 @@ describe('umami', () => {
       expect(script).not.toBeNull()
       expect(script!.src).toBe('https://u.example.com/script.js')
       expect(script!.getAttribute('data-website-id')).toBe('abc-123')
-      expect(script!.defer).toBe(true)
+      expect(script!.getAttribute('data-performance')).toBe('true')
     })
   })
 
   describe('identifyUmami / resetUmamiIdentity', () => {
-    it('calls window.umami.identify with userId as session data once umami is ready', async () => {
+    it('calls window.umami.identify with userId as session data once the script loads', async () => {
       setConfig(ENABLED)
-      vi.useFakeTimers()
-      const { identifyUmami } = await import('../umami')
+      const { initUmami, identifyUmami } = await import('../umami')
       const identify = vi.fn()
 
+      initUmami()
       identifyUmami('user-1')
       expect(identify).not.toHaveBeenCalled()
       ;(window as any).umami = { identify, track: vi.fn() }
-      await vi.advanceTimersByTimeAsync(150)
+      fireScriptLoad()
+      await Promise.resolve()
 
       // Pass userId as data, not as the unique-id arg, so Umami doesn't pivot
       // the sessionId hash and fragment the visit into separate session rows.
@@ -90,61 +100,69 @@ describe('umami', () => {
 
     it('calls window.umami.identify with { user: null } on reset', async () => {
       setConfig(ENABLED)
+      const { initUmami, resetUmamiIdentity } = await import('../umami')
       const identify = vi.fn()
+
+      initUmami()
       ;(window as any).umami = { identify, track: vi.fn() }
-      const { resetUmamiIdentity } = await import('../umami')
+      fireScriptLoad()
+      await Promise.resolve()
 
       resetUmamiIdentity()
+      await Promise.resolve()
       expect(identify).toHaveBeenCalledWith({ user: null })
     })
 
-    it('gives up polling without throwing if window.umami never appears', async () => {
+    it('does not throw when the script load fails', async () => {
       setConfig(ENABLED)
-      vi.useFakeTimers()
-      const { identifyUmami } = await import('../umami')
+      const { initUmami, identifyUmami } = await import('../umami')
 
+      initUmami()
       identifyUmami('profile-1')
-      // Past the 5s budget; no global ever appears.
-      await vi.advanceTimersByTimeAsync(6000)
+      fireScriptError()
+      await Promise.resolve()
 
       expect(window.umami).toBeUndefined()
     })
 
-    it('is a no-op (no setTimeout, no script) when umami is disabled', async () => {
+    it('is a no-op when umami is disabled', async () => {
       setConfig(DISABLED)
-      const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout')
-      const { identifyUmami, resetUmamiIdentity } = await import('../umami')
+      const { initUmami, identifyUmami, resetUmamiIdentity } = await import('../umami')
 
+      initUmami()
       identifyUmami('profile-1')
       resetUmamiIdentity()
+      await Promise.resolve()
 
-      expect(setTimeoutSpy).not.toHaveBeenCalled()
+      expect(document.head.querySelector('script')).toBeNull()
     })
   })
 
   describe('tracker.track', () => {
-    it('calls window.umami.track once umami is ready', async () => {
+    it('calls window.umami.track once the script loads', async () => {
       setConfig(ENABLED)
-      vi.useFakeTimers()
-      const { tracker } = await import('../umami')
+      const { initUmami, tracker } = await import('../umami')
       const track = vi.fn()
 
+      initUmami()
       tracker.track('event-x', { a: 1 })
       expect(track).not.toHaveBeenCalled()
       ;(window as any).umami = { identify: vi.fn(), track }
-      await vi.advanceTimersByTimeAsync(150)
+      fireScriptLoad()
+      await Promise.resolve()
 
       expect(track).toHaveBeenCalledWith('event-x', { a: 1 })
     })
 
     it('is a no-op when umami is disabled', async () => {
       setConfig(DISABLED)
-      const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout')
-      const { tracker } = await import('../umami')
+      const { initUmami, tracker } = await import('../umami')
 
+      initUmami()
       tracker.track('event-x')
+      await Promise.resolve()
 
-      expect(setTimeoutSpy).not.toHaveBeenCalled()
+      expect(document.head.querySelector('script')).toBeNull()
     })
   })
 
@@ -165,21 +183,31 @@ describe('umami', () => {
 
     it('auth:login handler invokes umami.identify with the userId as session data', async () => {
       setConfig(ENABLED)
+      const { initUmami } = await import('../umami')
       const identify = vi.fn()
+
+      initUmami()
       ;(window as any).umami = { identify, track: vi.fn() }
-      await import('../umami')
+      fireScriptLoad()
+      await Promise.resolve()
 
       busHandlers['auth:login']?.({ userId: 'user-42' })
+      await Promise.resolve()
       expect(identify).toHaveBeenCalledWith({ user: 'user-42' })
     })
 
     it('auth:logged-out handler invokes umami.identify with { user: null }', async () => {
       setConfig(ENABLED)
+      const { initUmami } = await import('../umami')
       const identify = vi.fn()
+
+      initUmami()
       ;(window as any).umami = { identify, track: vi.fn() }
-      await import('../umami')
+      fireScriptLoad()
+      await Promise.resolve()
 
       busHandlers['auth:logged-out']?.(undefined)
+      await Promise.resolve()
       expect(identify).toHaveBeenCalledWith({ user: null })
     })
   })

--- a/apps/frontend/src/lib/umami.ts
+++ b/apps/frontend/src/lib/umami.ts
@@ -1,69 +1,69 @@
 import { bus } from '@/lib/bus'
 
+interface UmamiInstance {
+  identify: (id?: string | Record<string, unknown>, data?: Record<string, unknown>) => void
+  track: (...args: unknown[]) => void
+}
+
 declare global {
   interface Window {
-    umami?: {
-      identify: (id?: string | Record<string, unknown>, data?: Record<string, unknown>) => void
-      track: (...args: unknown[]) => void
-    }
+    umami?: UmamiInstance
   }
 }
 
 const enabled = Boolean(__APP_CONFIG__.UMAMI_URL && __APP_CONFIG__.UMAMI_WEBSITE_ID)
 
-export function initUmami() {
-  if (!enabled) return
+let isLoaded: Promise<UmamiInstance | undefined>
 
-  const script = document.createElement('script')
-  script.defer = true
-  script.src = `${__APP_CONFIG__.UMAMI_URL}/script.js`
-  script.setAttribute('data-website-id', __APP_CONFIG__.UMAMI_WEBSITE_ID)
-  script.setAttribute('data-performance', 'true')
-  document.head.appendChild(script)
-}
+export function useUmami() {
+  function initUmami() {
+    isLoaded = new Promise((resolve) => {
+      if (!enabled) return resolve(undefined)
 
-// Umami loads with `defer`, so window.umami may not exist yet when an
-// auth:login fires very early (e.g. cookie-restore on page reload runs
-// before the script tag is appended in main.ts). Programmatic identify()
-// must wait for the global. Poll briefly, then give up.
-function whenUmamiReady(fn: (umami: NonNullable<Window['umami']>) => void) {
-  if (!enabled) return
-  const start = Date.now()
-  const tick = () => {
-    if (window.umami?.identify) {
-      fn(window.umami)
-      return
-    }
-    if (Date.now() - start > 5000) return
-    setTimeout(tick, 100)
+      const script = document.createElement('script')
+      script.src = `${__APP_CONFIG__.UMAMI_URL}/script.js`
+      script.setAttribute('id', 'u')
+      script.setAttribute('data-website-id', __APP_CONFIG__.UMAMI_WEBSITE_ID)
+      script.setAttribute('data-performance', 'true')
+      document.head.appendChild(script)
+
+      document.getElementById('u')?.addEventListener(
+        'load',
+        async () => {
+          resolve(window.umami)
+        },
+        { once: true }
+      )
+    })
   }
-  tick()
-}
 
-export function identifyUmami(userId: string) {
-  // Pass userId as session data, not as the unique ID. Calling identify(userId)
-  // makes Umami pivot the sessionId hash from (ip+ua+salt) to (userId), which
-  // splits the visit into separate "session" rows in the dashboard — anonymous
-  // events on /auth become one row, post-login events become another. Passing
-  // a data-only object keeps the same anonymous sessionId hash and attaches
-  // userId as queryable session metadata, preserving continuity of the visit.
-  whenUmamiReady((umami) => umami.identify({ user: userId }))
-}
+  function identifyUmami(userId: string) {
+    // Pass userId as session data, not as the unique ID. Calling identify(userId)
+    // makes Umami pivot the sessionId hash from (ip+ua+salt) to (userId), which
+    // splits the visit into separate "session" rows in the dashboard — anonymous
+    // events on /auth become one row, post-login events become another. Passing
+    // a data-only object keeps the same anonymous sessionId hash and attaches
+    // userId as queryable session metadata, preserving continuity of the visit.
+    isLoaded?.then((umami) => {
+      if (umami) umami.identify({ user: userId })
+    })
+  }
 
-export function resetUmamiIdentity() {
-  // Explicitly null out the `user` session-data key on logout so the post-logout
-  // portion of the visit isn't still attributed to the previous user when
-  // querying by session metadata.
-  whenUmamiReady((umami) => umami.identify({ user: null }))
-}
+  function resetUmamiIdentity() {
+    // Explicitly null out the `user` session-data key on logout so the post-logout
+    // portion of the visit isn't still attributed to the previous user when
+    // querying by session metadata.
+    isLoaded?.then((umami) => {
+      if (umami) umami.identify({ user: null })
+    })
+  }
 
-export const tracker = {
-  track(eventName: string, data?: Record<string, unknown>) {
-    whenUmamiReady((umami) => umami.track(eventName, data))
-  },
-}
+  function track(eventName: string, data?: Record<string, unknown>) {
+    isLoaded?.then((umami) => {
+      if (umami) umami.track(eventName, data)
+    })
+  }
 
-if (enabled) {
   bus.on('auth:login', ({ userId }) => {
     if (userId) identifyUmami(userId)
   })
@@ -71,4 +71,9 @@ if (enabled) {
   bus.on('auth:logged-out', () => {
     resetUmamiIdentity()
   })
+
+  return {
+    initUmami,
+    track,
+  }
 }

--- a/apps/frontend/src/lib/umami.ts
+++ b/apps/frontend/src/lib/umami.ts
@@ -13,57 +13,50 @@ declare global {
 
 const enabled = Boolean(__APP_CONFIG__.UMAMI_URL && __APP_CONFIG__.UMAMI_WEBSITE_ID)
 
-let isLoaded: Promise<UmamiInstance | undefined>
+let resolveReady!: (umami: UmamiInstance | undefined) => void
+const ready = new Promise<UmamiInstance | undefined>((resolve) => {
+  resolveReady = resolve
+})
 
-export function useUmami() {
-  function initUmami() {
-    isLoaded = new Promise((resolve) => {
-      if (!enabled) return resolve(undefined)
-
-      const script = document.createElement('script')
-      script.src = `${__APP_CONFIG__.UMAMI_URL}/script.js`
-      script.setAttribute('id', 'u')
-      script.setAttribute('data-website-id', __APP_CONFIG__.UMAMI_WEBSITE_ID)
-      script.setAttribute('data-performance', 'true')
-      document.head.appendChild(script)
-
-      document.getElementById('u')?.addEventListener(
-        'load',
-        async () => {
-          resolve(window.umami)
-        },
-        { once: true }
-      )
-    })
+export function initUmami() {
+  if (!enabled) {
+    resolveReady(undefined)
+    return
   }
 
-  function identifyUmami(userId: string) {
-    // Pass userId as session data, not as the unique ID. Calling identify(userId)
-    // makes Umami pivot the sessionId hash from (ip+ua+salt) to (userId), which
-    // splits the visit into separate "session" rows in the dashboard — anonymous
-    // events on /auth become one row, post-login events become another. Passing
-    // a data-only object keeps the same anonymous sessionId hash and attaches
-    // userId as queryable session metadata, preserving continuity of the visit.
-    isLoaded?.then((umami) => {
-      if (umami) umami.identify({ user: userId })
-    })
-  }
+  const script = document.createElement('script')
+  script.src = `${__APP_CONFIG__.UMAMI_URL}/script.js`
+  script.setAttribute('data-website-id', __APP_CONFIG__.UMAMI_WEBSITE_ID)
+  script.setAttribute('data-performance', 'true')
+  script.addEventListener('load', () => resolveReady(window.umami), { once: true })
+  script.addEventListener('error', () => resolveReady(undefined), { once: true })
+  document.head.appendChild(script)
+}
 
-  function resetUmamiIdentity() {
-    // Explicitly null out the `user` session-data key on logout so the post-logout
-    // portion of the visit isn't still attributed to the previous user when
-    // querying by session metadata.
-    isLoaded?.then((umami) => {
-      if (umami) umami.identify({ user: null })
-    })
-  }
+export function identifyUmami(userId: string) {
+  // Pass userId as session data, not as the unique ID. Calling identify(userId)
+  // makes Umami pivot the sessionId hash from (ip+ua+salt) to (userId), which
+  // splits the visit into separate "session" rows in the dashboard — anonymous
+  // events on /auth become one row, post-login events become another. Passing
+  // a data-only object keeps the same anonymous sessionId hash and attaches
+  // userId as queryable session metadata, preserving continuity of the visit.
+  ready.then((umami) => umami?.identify({ user: userId }))
+}
 
-  function track(eventName: string, data?: Record<string, unknown>) {
-    isLoaded?.then((umami) => {
-      if (umami) umami.track(eventName, data)
-    })
-  }
+export function resetUmamiIdentity() {
+  // Explicitly null out the `user` session-data key on logout so the post-logout
+  // portion of the visit isn't still attributed to the previous user when
+  // querying by session metadata.
+  ready.then((umami) => umami?.identify({ user: null }))
+}
 
+export const tracker = {
+  track(eventName: string, data?: Record<string, unknown>) {
+    ready.then((umami) => umami?.track(eventName, data))
+  },
+}
+
+if (enabled) {
   bus.on('auth:login', ({ userId }) => {
     if (userId) identifyUmami(userId)
   })
@@ -71,9 +64,4 @@ export function useUmami() {
   bus.on('auth:logged-out', () => {
     resetUmamiIdentity()
   })
-
-  return {
-    initUmami,
-    track,
-  }
 }

--- a/apps/frontend/src/main.ts
+++ b/apps/frontend/src/main.ts
@@ -6,7 +6,7 @@ import registerToast from './lib/toast'
 import { useBootstrap } from './lib/bootstrap'
 import { appUseI18n } from './lib/i18n'
 import { useAuthStore } from './features/auth/stores/authStore'
-import { initUmami } from './lib/umami'
+import { useUmami } from './lib/umami'
 import { initSentry } from './lib/sentry'
 
 // Register push-only service worker
@@ -91,5 +91,5 @@ appUseI18n(app)
   // Load observability tools after mount
   initSentry(app)
   initOpenReplay()
-  initUmami()
+  useUmami().initUmami()
 })()

--- a/apps/frontend/src/main.ts
+++ b/apps/frontend/src/main.ts
@@ -6,7 +6,7 @@ import registerToast from './lib/toast'
 import { useBootstrap } from './lib/bootstrap'
 import { appUseI18n } from './lib/i18n'
 import { useAuthStore } from './features/auth/stores/authStore'
-import { useUmami } from './lib/umami'
+import { initUmami } from './lib/umami'
 import { initSentry } from './lib/sentry'
 
 // Register push-only service worker
@@ -91,5 +91,5 @@ appUseI18n(app)
   // Load observability tools after mount
   initSentry(app)
   initOpenReplay()
-  useUmami().initUmami()
+  initUmami()
 })()


### PR DESCRIPTION
## Summary
- Replace the `setTimeout`-based `whenUmamiReady` polling helper with a module-level `ready` promise that is resolved by the umami `<script>` element's `load` event, eliminating the 5-second timeout window and the racy ordering assumption that early `identify()` calls would land before the global appears.
- Add an `error` listener that resolves the same promise with `undefined` so a blocked or 404'd umami script does not leave queued `identify` / `track` calls hanging on a never-resolving promise.
- Initialize the `ready` promise eagerly at module import so callers that fire before `initUmami()` runs are still queued and dispatched once the script loads.
- Extract the `Window['umami']` shape into a named `UmamiInstance` interface for reuse.
- Public exports (`initUmami`, `identifyUmami`, `resetUmamiIdentity`, `tracker`) and the `bus.on('auth:login' | 'auth:logged-out')` wiring are unchanged.

## Test plan
- [x] `pnpm --filter frontend exec vitest run src/lib/__tests__/umami.spec.ts` — 14/14 passing (suite rewritten to drive the listener pattern via dispatched `load` / `error` events; new case covers script-load failure)
- [x] `pnpm --filter frontend exec vue-tsc --noEmit` — clean
- [ ] Manual smoke in dev: load `/auth`, complete login, verify a single Umami session in the dashboard with `user` set
- [ ] Manual smoke with the umami script blocked (e.g. uBlock Origin enabled): confirm the app still functions and no console errors surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)