### PR TITLE
feat(interaction): redesign like popover with explicit anonymous/revealed toggle

### DIFF
--- a/.changeset/clever-popover-redesign.md
+++ b/.changeset/clever-popover-redesign.md
@@ -1,0 +1,5 @@
+---
+'@opencupid/frontend': minor
+---
+
+Redesign the like popover with a button-pair anonymous/revealed toggle, add a "you smiled at X" confirmation toast, and split tracking into create/update/like-back events.

--- a/.changeset/clever-popover-redesign.md
+++ b/.changeset/clever-popover-redesign.md
@@ -1,5 +1,6 @@
 ---
 '@opencupid/frontend': minor
+'@opencupid/shared': patch
 ---
 
 Redesign the like popover with a button-pair anonymous/revealed toggle, add a "you smiled at X" confirmation toast, and split tracking into create/update/like-back events.

--- a/apps/frontend/src/css/components.scss
+++ b/apps/frontend/src/css/components.scss
@@ -198,11 +198,14 @@ main {
 
 // Anonymity-toggle choice button (outline dating-light).
 .btn-anon-choice {
-  @extend .btn;
-  @extend .btn-outline-dating-light;
+  // @extend .btn;
+  // @extend .btn-outline-dating-light;
   display: flex;
   align-items: center;
+  justify-content: center;
   padding: 1.5rem;
+  width: 4rem;
+  height: 4rem;
 }
 
 .dating {

--- a/apps/frontend/src/css/components.scss
+++ b/apps/frontend/src/css/components.scss
@@ -182,32 +182,6 @@ main {
   @include btn-colored-push($dating);
 }
 
-// Like / smile primary action (filled dating button with icon geometry).
-.btn-like {
-  @extend .btn;
-  @extend .btn-dating;
-  @extend .btn-icon-lg;
-  @extend .btn-shadow;
-}
-
-// Smile-back call-to-action (outline dating).
-.btn-like-back {
-  @extend .btn;
-  @extend .btn-outline-dating;
-}
-
-// Anonymity-toggle choice button (outline dating-light).
-.btn-anon-choice {
-  // @extend .btn;
-  // @extend .btn-outline-dating-light;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 1.5rem;
-  width: 4rem;
-  height: 4rem;
-}
-
 .dating {
   background-color: $dating-light;
 }

--- a/apps/frontend/src/css/components.scss
+++ b/apps/frontend/src/css/components.scss
@@ -182,6 +182,29 @@ main {
   @include btn-colored-push($dating);
 }
 
+// Like / smile primary action (filled dating button with icon geometry).
+.btn-like {
+  @extend .btn;
+  @extend .btn-dating;
+  @extend .btn-icon-lg;
+  @extend .btn-shadow;
+}
+
+// Smile-back call-to-action (outline dating).
+.btn-like-back {
+  @extend .btn;
+  @extend .btn-outline-dating;
+}
+
+// Anonymity-toggle choice button (outline dating-light).
+.btn-anon-choice {
+  @extend .btn;
+  @extend .btn-outline-dating-light;
+  display: flex;
+  align-items: center;
+  padding: 1.5rem;
+}
+
 .dating {
   background-color: $dating-light;
 }

--- a/apps/frontend/src/features/app/components/BottomSheet.vue
+++ b/apps/frontend/src/features/app/components/BottomSheet.vue
@@ -127,6 +127,7 @@ function onHidden() {
     header-class="p-0"
     @show="onShow"
     @hidden="onHidden"
+    :focus="false"
   >
     <template #header>
       <div

--- a/apps/frontend/src/features/interaction/components/AnonymousLikeCard.vue
+++ b/apps/frontend/src/features/interaction/components/AnonymousLikeCard.vue
@@ -3,6 +3,7 @@ import { inject, type Ref } from 'vue'
 import ProfileThumbnail from '@/features/images/components/ProfileThumbnail.vue'
 import type { OwnerProfile } from '@zod/profile/profile.dto'
 import IconSearch from '@/assets/icons/interface/search.svg'
+import AnonymousProfileChip from './AnonymousProfileChip.vue'
 
 const viewerProfile = inject<Ref<OwnerProfile | null>>('viewerProfile')
 </script>
@@ -16,16 +17,7 @@ const viewerProfile = inject<Ref<OwnerProfile | null>>('viewerProfile')
     style="min-width: 16rem"
   >
     <template #target>
-      <div class="ratio ratio-1x1 clickable like-card">
-        <div
-          class="dating rounded-3 d-flex flex-column align-items-center justify-content-center p-2"
-        >
-          <div class="placeholder-chip ratio ratio-1x1 dating-eligible-highlight"></div>
-          <small class="mt-1 w-100 text-center">
-            <span class="placeholder w-75 opacity-25" />
-          </small>
-        </div>
-      </div>
+      <AnonymousProfileChip class="clickable" />
     </template>
     <p class="mb-2">
       {{ $t('matches.anonymous_like_hint') }}
@@ -48,23 +40,8 @@ const viewerProfile = inject<Ref<OwnerProfile | null>>('viewerProfile')
 </template>
 
 <style scoped>
-.placeholder-chip {
-  width: 2.5rem;
-  background-color: var(--bs-secondary);
-  opacity: 0.4;
-}
-.placeholder {
-  opacity: 0.25;
-  background-color: var(--bs-secondary);
-}
-
 .clickable {
   cursor: pointer;
-}
-
-.like-card:hover {
-  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.15);
-  border-radius: var(--bs-border-radius-lg);
 }
 
 :deep(.popover-hint) {
@@ -75,4 +52,6 @@ const viewerProfile = inject<Ref<OwnerProfile | null>>('viewerProfile')
   width: 2.5rem;
   height: 2.5rem;
 }
+
+
 </style>

--- a/apps/frontend/src/features/interaction/components/AnonymousLikeCard.vue
+++ b/apps/frontend/src/features/interaction/components/AnonymousLikeCard.vue
@@ -1,11 +1,23 @@
 <script setup lang="ts">
-import { inject, type Ref } from 'vue'
+import { computed, inject, type Ref } from 'vue'
+import { storeToRefs } from 'pinia'
 import ProfileThumbnail from '@/features/images/components/ProfileThumbnail.vue'
 import type { OwnerProfile } from '@zod/profile/profile.dto'
+import type { GenderType } from '@zod/generated'
 import IconSearch from '@/assets/icons/interface/search.svg'
 import AnonymousProfileChip from './AnonymousProfileChip.vue'
+import { useOwnerProfileStore } from '@/features/myprofile/stores/ownerProfileStore'
 
 const viewerProfile = inject<Ref<OwnerProfile | null>>('viewerProfile')
+
+const { datingPrefs } = storeToRefs(useOwnerProfileStore())
+
+const likerGender = computed<GenderType | undefined>(() => {
+  const prefs = datingPrefs.value.prefGender ?? []
+  if (prefs.includes('male')) return 'male'
+  if (prefs.includes('female')) return 'female'
+  return undefined
+})
 </script>
 
 <template>
@@ -17,7 +29,7 @@ const viewerProfile = inject<Ref<OwnerProfile | null>>('viewerProfile')
     style="min-width: 16rem"
   >
     <template #target>
-      <AnonymousProfileChip class="clickable" />
+      <AnonymousProfileChip class="clickable" :gender="likerGender" />
     </template>
     <p class="mb-2">
       {{ $t('matches.anonymous_like_hint') }}

--- a/apps/frontend/src/features/interaction/components/AnonymousProfileChip.vue
+++ b/apps/frontend/src/features/interaction/components/AnonymousProfileChip.vue
@@ -1,0 +1,31 @@
+<script setup lang="ts">
+// Presentational chip rendering the placeholder-chip + placeholder line in
+// a square aspect-ratio container. Used directly as the visual for an
+// anonymous-like option (e.g. inside AnonymousToggle), and embedded in
+// AnonymousLikeCard which wraps it with a click popover for list contexts.
+</script>
+
+<template>
+  <div
+    class="rounded-3 d-flex flex-column align-items-center justify-content-center gap-2 p-2 h-100"
+  >
+    <div class="placeholder-chip dating-eligible-highlight"></div>
+    <span class="publicname-placeholder w-75"></span>
+  </div>
+</template>
+
+<style scoped>
+.placeholder-chip {
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 50%;
+  background-color: var(--bs-secondary);
+  opacity: 0.4;
+}
+.publicname-placeholder {
+  display: block;
+  height: 0.75rem;
+  background-color: var(--bs-secondary);
+  opacity: 0.3;
+}
+</style>

--- a/apps/frontend/src/features/interaction/components/AnonymousProfileChip.vue
+++ b/apps/frontend/src/features/interaction/components/AnonymousProfileChip.vue
@@ -3,13 +3,30 @@
 // a square aspect-ratio container. Used directly as the visual for an
 // anonymous-like option (e.g. inside AnonymousToggle), and embedded in
 // AnonymousLikeCard which wraps it with a click popover for list contexts.
+import { computed } from 'vue'
+import type { GenderType } from '@zod/generated'
+import IconFemale from '@/assets/icons/interface/user-female.svg'
+import IconMale from '@/assets/icons/interface/user-male.svg'
+import IconNeutral from '@/assets/icons/interface/user.svg'
+
+const props = defineProps<{
+  gender?: GenderType
+}>()
+
+const showMale = computed(() => props.gender === 'male')
+const showFemale = computed(() => props.gender === 'female')
+const showNeutral = computed(() => !showMale.value && !showFemale.value)
 </script>
 
 <template>
   <div
     class="rounded-3 d-flex flex-column align-items-center justify-content-center gap-2 p-2 h-100"
   >
-    <div class="placeholder-chip dating-eligible-highlight"></div>
+    <div class="placeholder-chip dating-eligible-highlight d-flex align-items-center justify-content-center">
+      <IconFemale v-if="showFemale" class="svg-icon-lg text-dating m-1 h-75" />
+      <IconMale v-if="showMale" class="svg-icon-lg text-dating m-1 h-75" />
+      <IconNeutral v-if="showNeutral" class="svg-icon-lg text-dating w-100 m-1 h-75" />
+    </div>
     <span class="publicname-placeholder w-75"></span>
   </div>
 </template>
@@ -19,13 +36,15 @@
   width: 2.5rem;
   height: 2.5rem;
   border-radius: 50%;
-  background-color: var(--bs-secondary);
+  /* background-color: var(--bs-dating); */
+  /* background-color: rgba(0,0,0,0.1); */
+  background-color: transparent;
   opacity: 0.4;
 }
 .publicname-placeholder {
   display: block;
   height: 0.75rem;
   background-color: var(--bs-secondary);
-  opacity: 0.3;
+  opacity: 0.1;
 }
 </style>

--- a/apps/frontend/src/features/interaction/components/AnonymousToggle.vue
+++ b/apps/frontend/src/features/interaction/components/AnonymousToggle.vue
@@ -1,37 +1,104 @@
 <script lang="ts" setup>
-const selectedAnonymous = defineModel<boolean>({ required: true })
+import { inject, ref, type Ref } from 'vue'
+import type { OwnerProfile } from '@zod/profile/profile.dto'
+import ProfileImage from '@/features/images/components/ProfileImage.vue'
+
+import IconAnonymousUser from '@/assets/icons/interface/user.svg'
+
+const props = defineProps<{
+  selectedAnonymous: boolean | null
+}>()
 
 const emit = defineEmits<{
   (e: 'change', isAnonymous: boolean): void
 }>()
+
+const viewerProfile = inject<Ref<OwnerProfile | null>>('viewerProfile')
+
+const hintAnonymous = ref<boolean | null>(null)
+
+const handleAnonymousClick = () => {
+  emit('change', true)
+}
+
+const handleRevealedClick = () => {
+  emit('change', false)
+}
 </script>
 
 <template>
-  <BFormRadioGroup
-    v-model="selectedAnonymous"
-    stacked
-  >
-    <BFormRadio
-      name="anonymous-toggle"
-      :value="true"
-      @change="emit('change', true)"
-    >
-      {{ $t('interactions.anonymous_toggle_anonymous') }}
-    </BFormRadio>
-    <BFormRadio
-      name="anonymous-toggle"
-      :value="false"
-      @change="emit('change', false)"
-    >
-      {{ $t('interactions.anonymous_toggle_reveal') }}
-    </BFormRadio>
-  </BFormRadioGroup>
-  <div class="form-hint mt-2">
-    <div v-if="selectedAnonymous">
-      {{ $t('interactions.anonymous_like_explanation') }}
+  <div>
+    <h6 class="text-center">{{ $t('interactions.anonymous_toggle_question') }}</h6>
+    <div class="d-flex justify-content-center gap-2">
+      <div>
+        <BButton
+          variant="outline-dating-light"
+          size="lg"
+          class="d-flex align-items-center mb-1 p-4"
+          @click="handleAnonymousClick"
+          @mouseover="hintAnonymous = true"
+          @mouseout="hintAnonymous = null"
+          :pressed="props.selectedAnonymous === true"
+        >
+          <div class="placeholder-chip ratio ratio-1x1 dating-eligible-highlight">
+            <div class="d-flex align-items-center justify-content-center w-100 h-100">
+              <IconAnonymousUser class="svg-icon text-dating" />
+            </div>
+          </div>
+        </BButton>
+        <div class="text-center">{{ $t('interactions.anonymous_toggle_anonymous') }}</div>
+      </div>
+
+      <div>
+        <BButton
+          variant="outline-dating-light"
+          size="lg"
+          class="d-flex align-items-center mb-1 p-4"
+          @click="handleRevealedClick"
+          @mouseover="hintAnonymous = false"
+          @mouseout="hintAnonymous = null"
+          :pressed="props.selectedAnonymous === false"
+        >
+          <span class="profile-thumbnail d-inline-flex">
+            <ProfileImage
+              v-if="viewerProfile"
+              :profile="viewerProfile"
+              variant="thumb"
+            />
+          </span>
+        </BButton>
+        <div class="text-center">{{ $t('interactions.anonymous_toggle_reveal') }}</div>
+      </div>
     </div>
-    <div v-else>
-      {{ $t('interactions.revealed_like_explanation') }}
+    <div
+      class="form-hint mb-2 text-muted"
+      style="height: 1rem"
+    >
+      <span
+        class="hint"
+        :class="{ 'd-block': hintAnonymous === true }"
+        >{{ $t('interactions.anonymous_like_explanation') }}</span
+      >
+      <span
+        class="hint"
+        :class="{ 'd-block': hintAnonymous === false }"
+        >{{ $t('interactions.revealed_like_explanation') }}
+      </span>
     </div>
   </div>
 </template>
+
+<style scoped>
+.hint {
+  display: none;
+}
+.placeholder-chip {
+  width: 2.5rem;
+  background-color: var(--bs-dating-light);
+  opacity: 0.4;
+}
+.profile-thumbnail {
+  width: 2.5rem !important;
+  height: 2.5rem !important;
+}
+</style>

--- a/apps/frontend/src/features/interaction/components/AnonymousToggle.vue
+++ b/apps/frontend/src/features/interaction/components/AnonymousToggle.vue
@@ -1,9 +1,9 @@
 <script lang="ts" setup>
 import { inject, ref, type Ref } from 'vue'
 import type { OwnerProfile } from '@zod/profile/profile.dto'
-import ProfileImage from '@/features/images/components/ProfileImage.vue'
 
-import IconAnonymousUser from '@/assets/icons/interface/user.svg'
+import RevealedLikeCard from './RevealedLikeCard.vue'
+import AnonymousLikeCard from './AnonymousLikeCard.vue'
 
 const props = defineProps<{
   selectedAnonymous: boolean | null
@@ -32,18 +32,14 @@ const handleRevealedClick = () => {
     <div class="d-flex justify-content-center gap-2">
       <div>
         <BButton
-          size="lg"
+          variant="outline-dating-light"
           class="btn-anon-choice mb-1"
           @click="handleAnonymousClick"
           @mouseover="hintAnonymous = true"
           @mouseout="hintAnonymous = null"
           :pressed="props.selectedAnonymous === true"
         >
-          <div class="placeholder-chip ratio ratio-1x1 dating-eligible-highlight">
-            <div class="d-flex align-items-center justify-content-center w-100 h-100">
-              <IconAnonymousUser class="svg-icon text-dating" />
-            </div>
-          </div>
+          <AnonymousLikeCard />
         </BButton>
         <div class="text-center">{{ $t('interactions.anonymous_toggle_anonymous') }}</div>
       </div>
@@ -52,18 +48,17 @@ const handleRevealedClick = () => {
         <BButton
           size="lg"
           class="btn-anon-choice mb-1"
+          variant="outline-dating-light"
           @click="handleRevealedClick"
           @mouseover="hintAnonymous = false"
           @mouseout="hintAnonymous = null"
           :pressed="props.selectedAnonymous === false"
         >
-          <span class="profile-thumbnail d-inline-flex">
-            <ProfileImage
-              v-if="viewerProfile"
-              :profile="viewerProfile"
-              variant="thumb"
-            />
-          </span>
+          <RevealedLikeCard
+            v-if="viewerProfile"
+            :profile="viewerProfile"
+            class="w-100"
+          />
         </BButton>
         <div class="text-center">{{ $t('interactions.anonymous_toggle_reveal') }}</div>
       </div>

--- a/apps/frontend/src/features/interaction/components/AnonymousToggle.vue
+++ b/apps/frontend/src/features/interaction/components/AnonymousToggle.vue
@@ -28,7 +28,7 @@ const handleRevealedClick = () => {
 
 <template>
   <div>
-    <h6 class="text-center">{{ $t('interactions.anonymous_toggle_question') }}</h6>
+    <h6 class="text-center text-secondary">{{ $t('interactions.anonymous_toggle_question') }}</h6>
     <div class="d-flex justify-content-center gap-2">
       <div class="anon-choice">
         <BButton
@@ -40,7 +40,7 @@ const handleRevealedClick = () => {
           @mouseout="hintAnonymous = null"
           :pressed="props.selectedAnonymous === true"
         >
-          <AnonymousProfileChip  />
+          <AnonymousProfileChip :gender="viewerProfile?.gender ?? undefined" />
         </BButton>
         <div class="text-center">{{ $t('interactions.anonymous_toggle_anonymous') }}</div>
       </div>
@@ -64,7 +64,7 @@ const handleRevealedClick = () => {
       </div>
     </div>
     <div
-      class="form-hint mb-2 text-muted"
+      class="form-hint mb-2 text-muted px-2 mt-1"
       style="min-height: 2rem"
     >
       <span

--- a/apps/frontend/src/features/interaction/components/AnonymousToggle.vue
+++ b/apps/frontend/src/features/interaction/components/AnonymousToggle.vue
@@ -3,7 +3,7 @@ import { inject, ref, type Ref } from 'vue'
 import type { OwnerProfile } from '@zod/profile/profile.dto'
 
 import RevealedLikeCard from './RevealedLikeCard.vue'
-import AnonymousLikeCard from './AnonymousLikeCard.vue'
+import AnonymousProfileChip from './AnonymousProfileChip.vue'
 
 const props = defineProps<{
   selectedAnonymous: boolean | null
@@ -30,25 +30,26 @@ const handleRevealedClick = () => {
   <div>
     <h6 class="text-center">{{ $t('interactions.anonymous_toggle_question') }}</h6>
     <div class="d-flex justify-content-center gap-2">
-      <div>
+      <div class="anon-choice">
         <BButton
           variant="outline-dating-light"
-          class="btn-anon-choice mb-1"
+          size="lg"
+          class="d-flex align-items-center justify-content-center mb-1 p-2 "
           @click="handleAnonymousClick"
           @mouseover="hintAnonymous = true"
           @mouseout="hintAnonymous = null"
           :pressed="props.selectedAnonymous === true"
         >
-          <AnonymousLikeCard />
+          <AnonymousProfileChip  />
         </BButton>
         <div class="text-center">{{ $t('interactions.anonymous_toggle_anonymous') }}</div>
       </div>
 
-      <div>
+      <div class="anon-choice">
         <BButton
-          size="lg"
-          class="btn-anon-choice mb-1"
           variant="outline-dating-light"
+          size="lg"
+          class="d-flex align-items-center justify-content-center mb-1 p-2 "
           @click="handleRevealedClick"
           @mouseover="hintAnonymous = false"
           @mouseout="hintAnonymous = null"
@@ -57,7 +58,6 @@ const handleRevealedClick = () => {
           <RevealedLikeCard
             v-if="viewerProfile"
             :profile="viewerProfile"
-            class="w-100"
           />
         </BButton>
         <div class="text-center">{{ $t('interactions.anonymous_toggle_reveal') }}</div>
@@ -65,7 +65,7 @@ const handleRevealedClick = () => {
     </div>
     <div
       class="form-hint mb-2 text-muted"
-      style="height: 1rem"
+      style="min-height: 2rem"
     >
       <span
         class="hint"
@@ -82,6 +82,16 @@ const handleRevealedClick = () => {
 </template>
 
 <style scoped>
+/* Two side-by-side toggle choices with equal square dimensions; the
+   wrapping div fixes the BButton's box so its content (chip / card) can
+   shrink-fit and center without dragging the button height with it. */
+.anon-choice {
+  width: 6rem;
+  /* height: 6rem; */
+  display: flex;
+  flex-direction: column;
+}
+
 .hint {
   display: none;
 }

--- a/apps/frontend/src/features/interaction/components/AnonymousToggle.vue
+++ b/apps/frontend/src/features/interaction/components/AnonymousToggle.vue
@@ -32,9 +32,8 @@ const handleRevealedClick = () => {
     <div class="d-flex justify-content-center gap-2">
       <div>
         <BButton
-          variant="outline-dating-light"
           size="lg"
-          class="d-flex align-items-center mb-1 p-4"
+          class="btn-anon-choice mb-1"
           @click="handleAnonymousClick"
           @mouseover="hintAnonymous = true"
           @mouseout="hintAnonymous = null"
@@ -51,9 +50,8 @@ const handleRevealedClick = () => {
 
       <div>
         <BButton
-          variant="outline-dating-light"
           size="lg"
-          class="d-flex align-items-center mb-1 p-4"
+          class="btn-anon-choice mb-1"
           @click="handleRevealedClick"
           @mouseover="hintAnonymous = false"
           @mouseout="hintAnonymous = null"

--- a/apps/frontend/src/features/interaction/components/InteractionButtons.vue
+++ b/apps/frontend/src/features/interaction/components/InteractionButtons.vue
@@ -86,6 +86,7 @@ const handleMessageClick = () => {
 </script>
 
 <template>
+  <!-- pass button/popover -->
   <div class="d-flex justify-content-center align-items-center gap-2">
     <div v-if="context.canDate && !context.isMatch && context.likedByMe">
       <BPopover
@@ -93,7 +94,6 @@ const handleMessageClick = () => {
         placement="top"
         title="Popover"
         body-class="bg-danger-subtle"
-        manual
         click
         lazy
         title-class="d-none"
@@ -101,12 +101,12 @@ const handleMessageClick = () => {
         <template #target>
           <BButton
             variant="secondary"
-            class="btn-icon-lg me-2 btn-shadow"
+            class="btn-icon-lg me-2 btn-shadow bg-secondary-subtle"
             @click="handlePassClick"
             :disabled="!context.canPass"
             :title="$t('interactions.pass_button_title')"
           >
-            <IconPass class="svg-icon-lg" />
+            <IconPass class="svg-icon-lg text-secondary" />
           </BButton>
         </template>
         <ConfirmPassDialog
@@ -125,11 +125,12 @@ const handleMessageClick = () => {
     >
       <template #target>
         <BButton
-          class="btn-icon-lg btn-info me-2 btn-shadow"
+          class="btn-icon-lg me-2 btn-shadow bg-info-subtle"
+          variant="info"
           @click="handleMessageClick"
-          :class="{ 'opacity-50': !props.context.canMessage }"
+          :disabled="!props.context.canMessage"
         >
-          <IconMessage class="svg-icon-lg p-0" />
+          <IconMessage class="svg-icon-lg p-0 text-info" />
         </BButton>
       </template>
       <span v-if="props.context.canMessage">
@@ -172,11 +173,10 @@ const handleMessageClick = () => {
       <template #title>
         <span class="d-inline-flex w-100">
           <span class="flex-grow-1">
+            <IconLike class="svg-icon text-dating" />
             {{ $t('interactions.they_liked_you') }}
           </span>
-          <span class="flex-grow-0 text-dating flex-shrink-1">
-            <IconLike class="svg-icon" />
-          </span>
+          <span class="flex-grow-0 text-dating flex-shrink-1 ms-2"> </span>
         </span>
       </template>
 
@@ -184,20 +184,13 @@ const handleMessageClick = () => {
         <BButton
           class="btn-icon-lg btn-shadow"
           variant="dating"
+          @click="handleLikeBackClick"
         >
           <IconLike class="svg-icon-lg" />
         </BButton>
       </template>
       <span class="mb-2 d-block">
-        <BButton
-          variant="outline-dating"
-          size="sm"
-          @click="handleLikeBackClick"
-        >
-          <IconLike class="svg-icon" />
-
-          {{ $t('interactions.like_them_back') }}
-        </BButton>
+        {{ $t('interactions.like_them_back') }}
       </span>
     </BPopover>
 
@@ -219,10 +212,10 @@ const handleMessageClick = () => {
       </template>
       <template #target>
         <BButton
-          class="btn-icon-lg btn-shadow"
+          class="btn-icon-lg btn-shadow bg-dating-light"
           variant="dating"
         >
-          <IconLike class="svg-icon-lg" />
+          <IconLike class="svg-icon-lg text-dating" />
         </BButton>
       </template>
       <AnonymousToggle

--- a/apps/frontend/src/features/interaction/components/InteractionButtons.vue
+++ b/apps/frontend/src/features/interaction/components/InteractionButtons.vue
@@ -150,7 +150,7 @@ const handleMessageClick = () => {
       :title="$t('interactions.you_liked_them')"
     >
       <template #target>
-        <BButton class="btn-icon-lg btn-shadow" variant="dating">
+        <BButton class="btn-like">
           <IconLike class="svg-icon-lg" />
         </BButton>
       </template>
@@ -177,16 +177,13 @@ const handleMessageClick = () => {
       </template>
 
       <template #target>
-        <BButton
-          class="btn-icon-lg btn-shadow"
-          variant="dating"
-        >
+        <BButton class="btn-like">
           <IconLike class="svg-icon-lg" />
         </BButton>
       </template>
       <span class="mb-2 d-block">
         <BButton
-          variant="outline-dating"
+          class="btn-like-back"
           size="sm"
           @click="handleLikeBackClick"
         >
@@ -214,10 +211,7 @@ const handleMessageClick = () => {
         </span>
       </template>
       <template #target>
-        <BButton
-          class="btn-icon-lg btn-shadow"
-          variant="dating"
-        >
+        <BButton class="btn-like">
           <IconLike class="svg-icon-lg" />
         </BButton>
       </template>

--- a/apps/frontend/src/features/interaction/components/InteractionButtons.vue
+++ b/apps/frontend/src/features/interaction/components/InteractionButtons.vue
@@ -150,7 +150,10 @@ const handleMessageClick = () => {
       :title="$t('interactions.you_liked_them')"
     >
       <template #target>
-        <BButton class="btn-like">
+        <BButton
+          class="btn-icon-lg btn-shadow"
+          variant="dating"
+        >
           <IconLike class="svg-icon-lg" />
         </BButton>
       </template>
@@ -177,13 +180,16 @@ const handleMessageClick = () => {
       </template>
 
       <template #target>
-        <BButton class="btn-like">
+        <BButton
+          class="btn-icon-lg btn-shadow"
+          variant="dating"
+        >
           <IconLike class="svg-icon-lg" />
         </BButton>
       </template>
       <span class="mb-2 d-block">
         <BButton
-          class="btn-like-back"
+          variant="outline-dating"
           size="sm"
           @click="handleLikeBackClick"
         >
@@ -211,7 +217,10 @@ const handleMessageClick = () => {
         </span>
       </template>
       <template #target>
-        <BButton class="btn-like">
+        <BButton
+          class="btn-icon-lg btn-shadow"
+          variant="dating"
+        >
           <IconLike class="svg-icon-lg" />
         </BButton>
       </template>

--- a/apps/frontend/src/features/interaction/components/InteractionButtons.vue
+++ b/apps/frontend/src/features/interaction/components/InteractionButtons.vue
@@ -24,7 +24,8 @@ const emit = defineEmits<{
 
 const passPopover = ref(false)
 
-// Local ref tracks the radio selection — synced from context when it changes
+// Holds the user's current anonymity preference, kept in sync with the
+// server-provided context so handleLikeBackClick can emit the latest value.
 const selectedAnonymous = ref(props.context.isAnonymous)
 watch(
   () => props.context.isAnonymous,
@@ -146,7 +147,7 @@ const handleMessageClick = () => {
       v-if="context.canDate && !context.isMatch && context.likedByMe"
       placement="top"
       style="min-width: 16rem; min-height: 14rem"
-      body-class="d-flex align-items-center flex-column justify-items-center"
+      body-class="d-flex align-items-center flex-column justify-content-center"
       :title="$t('interactions.you_liked_them')"
     >
       <template #target>

--- a/apps/frontend/src/features/interaction/components/InteractionButtons.vue
+++ b/apps/frontend/src/features/interaction/components/InteractionButtons.vue
@@ -1,13 +1,14 @@
 <script lang="ts" setup>
-import { computed, ref, watch } from 'vue'
+import { ref, watch } from 'vue'
 import { type InteractionContext } from '@zod/interaction/interactionContext.dto'
 
 import IconLike from '@/assets/icons/emojis/smiling-emoji.svg'
 import IconPass from '@/assets/icons/interface/cross.svg'
-
 import IconMessage from '@/assets/icons/interface/message.svg'
-import AnonymousToggle from './AnonymousToggle.vue'
+
 import ConfirmPassDialog from './ConfirmPassDialog.vue'
+import AnonymousToggle from './AnonymousToggle.vue'
+
 import { tracker } from '@/lib/umami'
 
 const props = defineProps<{
@@ -32,12 +33,29 @@ watch(
   }
 )
 
-const handleLikeClick = () => {
-  // If the user has already liked the profile, do nothing
+const handleUpdateAnonymous = (isAnonymous: boolean) => {
+  if (!props.context.likedByMe || isAnonymous === props.context.isAnonymous) {
+    return
+  }
+  selectedAnonymous.value = isAnonymous
+  tracker.track('interaction-update-like', { anonymous: isAnonymous })
+  emit('update:anonymous', isAnonymous)
+}
+
+const handleCreateLikeClick = (isAnonymous: boolean) => {
   if (props.context.likedByMe || !props.context.canLike) {
     return
   }
-  tracker.track('interaction-like', { anonymous: selectedAnonymous.value })
+  selectedAnonymous.value = isAnonymous
+  tracker.track('interaction-create-like', { anonymous: isAnonymous })
+  emit('like', isAnonymous)
+}
+
+const handleLikeBackClick = () => {
+  if (props.context.likedByMe || !props.context.canLike) {
+    return
+  }
+  tracker.track('interaction-like-back', { anonymous: selectedAnonymous.value })
   emit('like', selectedAnonymous.value)
 }
 
@@ -63,10 +81,6 @@ const handleMessageClick = () => {
     emit('message')
     return
   }
-}
-
-const handleAnonymousChange = (value: boolean) => {
-  emit('update:anonymous', value)
 }
 </script>
 
@@ -112,7 +126,7 @@ const handleAnonymousChange = (value: boolean) => {
         <BButton
           class="btn-icon-lg btn-info me-2 btn-shadow"
           @click="handleMessageClick"
-          :class="{'opacity-50': !props.context.canMessage}"
+          :class="{ 'opacity-50': !props.context.canMessage }"
         >
           <IconMessage class="svg-icon-lg p-0" />
         </BButton>
@@ -131,16 +145,18 @@ const handleAnonymousChange = (value: boolean) => {
     <BPopover
       v-if="context.canDate && !context.isMatch && context.likedByMe"
       placement="top"
+      style="min-width: 16rem; min-height: 14rem"
+      body-class="d-flex align-items-center flex-column justify-items-center"
       :title="$t('interactions.you_liked_them')"
     >
       <template #target>
-        <BButton class="btn-icon-lg btn-dating btn-shadow">
+        <BButton class="btn-icon-lg btn-shadow" variant="dating">
           <IconLike class="svg-icon-lg" />
         </BButton>
       </template>
       <AnonymousToggle
-        v-model="selectedAnonymous"
-        @change="handleAnonymousChange"
+        :selectedAnonymous="context.isAnonymous"
+        @change="handleUpdateAnonymous"
       />
     </BPopover>
 
@@ -162,14 +178,22 @@ const handleAnonymousChange = (value: boolean) => {
 
       <template #target>
         <BButton
-          class="btn-icon-lg btn-dating btn-shadow"
-          @click="handleLikeClick"
+          class="btn-icon-lg btn-shadow"
+          variant="dating"
         >
           <IconLike class="svg-icon-lg" />
         </BButton>
       </template>
       <span class="mb-2 d-block">
-        {{ $t('interactions.like_them_back') }}
+        <BButton
+          variant="outline-dating"
+          size="sm"
+          @click="handleLikeBackClick"
+        >
+          <IconLike class="svg-icon" />
+
+          {{ $t('interactions.like_them_back') }}
+        </BButton>
       </span>
     </BPopover>
 
@@ -177,7 +201,7 @@ const handleAnonymousChange = (value: boolean) => {
     <BPopover
       v-else-if="context.canDate && !context.isMatch"
       placement="top"
-      style="width: 16rem; height: 12rem"
+      style="min-width: 16rem; min-height: 14rem"
     >
       <template #title>
         <span class="d-inline-flex w-100">
@@ -191,13 +215,16 @@ const handleAnonymousChange = (value: boolean) => {
       </template>
       <template #target>
         <BButton
-          class="btn-icon-lg btn-dating btn-shadow"
-          @click="handleLikeClick"
+          class="btn-icon-lg btn-shadow"
+          variant="dating"
         >
           <IconLike class="svg-icon-lg" />
         </BButton>
       </template>
-      <AnonymousToggle v-model="selectedAnonymous" />
+      <AnonymousToggle
+        :selectedAnonymous="context.likedByMe ? context.isAnonymous : null"
+        @change="handleCreateLikeClick"
+      />
     </BPopover>
   </div>
 </template>

--- a/apps/frontend/src/features/interaction/components/ProfileInteractions.vue
+++ b/apps/frontend/src/features/interaction/components/ProfileInteractions.vue
@@ -41,6 +41,7 @@ const handleLike = async (isAnonymous: boolean) => {
     } else {
       emit('liked')
       emit('updated')
+      toast.info(t('interactions.you_smiled_at', { name: props.profile.publicName }))
     }
   } else {
     toast.error(t('interactions.like_error'))

--- a/apps/frontend/src/features/interaction/components/ReceivedLikesTeaser.vue
+++ b/apps/frontend/src/features/interaction/components/ReceivedLikesTeaser.vue
@@ -33,14 +33,31 @@ const displayedLikes = computed(() => receivedLikes.value.slice(0, 4))
         v-for="like in displayedLikes"
         :key="like.createdAt"
       >
-        <RevealedLikeCard
+        <div
+          class="like-card dating p-2"
           v-if="like.profile"
-          :profile="like.profile"
-          @click="emit('interaction:selected', like)"
-        />
+        >
+          <RevealedLikeCard
+            :profile="like.profile"
+            @click="emit('interaction:selected', like)"
+            class="like-card"
+          />
+        </div>
         <!-- Anonymous: popover card with hint -->
-        <AnonymousLikeCard v-else />
+        <div
+          class="like-card dating p-2"
+          v-else
+        >
+          <AnonymousLikeCard />
+        </div>
       </BCol>
     </BRow>
   </div>
 </template>
+
+<style scoped>
+.like-card:hover {
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.15);
+  border-radius: var(--bs-border-radius-lg);
+}
+</style>

--- a/apps/frontend/src/features/interaction/components/ReceivedLikesTeaser.vue
+++ b/apps/frontend/src/features/interaction/components/ReceivedLikesTeaser.vue
@@ -40,7 +40,6 @@ const displayedLikes = computed(() => receivedLikes.value.slice(0, 4))
           <RevealedLikeCard
             :profile="like.profile"
             @click="emit('interaction:selected', like)"
-            class="like-card"
           />
         </div>
         <!-- Anonymous: popover card with hint -->
@@ -56,8 +55,11 @@ const displayedLikes = computed(() => receivedLikes.value.slice(0, 4))
 </template>
 
 <style scoped>
+
 .like-card:hover {
   box-shadow: 0 1px 6px rgba(0, 0, 0, 0.15);
+}
+.like-card {
   border-radius: var(--bs-border-radius-lg);
 }
 </style>

--- a/apps/frontend/src/features/interaction/components/RevealedLikeCard.vue
+++ b/apps/frontend/src/features/interaction/components/RevealedLikeCard.vue
@@ -9,20 +9,16 @@ defineProps<{
 
 <template>
   <div
-    class="ratio ratio-1x1 clickable like-card"
-    role="button"
-    tabindex="0"
+    class="rounded-3 d-flex flex-column align-items-center justify-content-center gap-2 p-2 h-100"
   >
-    <div class="dating rounded-3 d-flex flex-column align-items-center justify-content-center p-2">
-      <ProfileThumbnail
-        v-if="profile.profileImages[0]"
-        :profile="profile"
-        class="avatar-chip dating-eligible-highlight"
-      />
-      <small class="mt-1 text-truncate w-100 text-center">
-        {{ profile.publicName }}
-      </small>
-    </div>
+    <ProfileThumbnail
+      v-if="profile.profileImages[0]"
+      :profile="profile"
+      class="avatar-chip dating-eligible-highlight"
+    />
+    <small class="publicname w-75 text-truncate text-center d-block">
+      {{ profile.publicName }}
+    </small>
   </div>
 </template>
 
@@ -40,5 +36,11 @@ defineProps<{
 .like-card:hover {
   box-shadow: 0 1px 6px rgba(0, 0, 0, 0.15);
   border-radius: var(--bs-border-radius-lg);
+}
+.publicname {
+  height: 0.75rem;
+  font-size: 0.625rem;
+  line-height: 0.75rem;
+  color: var(--bs-dating);
 }
 </style>

--- a/apps/frontend/src/features/interaction/components/RevealedLikeCard.vue
+++ b/apps/frontend/src/features/interaction/components/RevealedLikeCard.vue
@@ -33,10 +33,6 @@ defineProps<{
   cursor: pointer;
 }
 
-.like-card:hover {
-  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.15);
-  border-radius: var(--bs-border-radius-lg);
-}
 .publicname {
   height: 0.75rem;
   font-size: 0.625rem;

--- a/apps/frontend/src/features/interaction/components/__tests__/InteractionButtons.spec.ts
+++ b/apps/frontend/src/features/interaction/components/__tests__/InteractionButtons.spec.ts
@@ -79,7 +79,7 @@ describe('InteractionButtons', () => {
   it('emits update:anonymous when toggling anonymity on an already-liked profile', async () => {
     const wrapper = mount(
       InteractionButtons,
-      mountOpts({ ...baseContext, likedByMe: true, isAnonymous: true, canLike: false }),
+      mountOpts({ ...baseContext, likedByMe: true, isAnonymous: true, canLike: false })
     )
 
     // already liked: toggling to revealed should emit update:anonymous(false)
@@ -93,7 +93,7 @@ describe('InteractionButtons', () => {
   it('does not emit update:anonymous when the chosen value matches current isAnonymous', async () => {
     const wrapper = mount(
       InteractionButtons,
-      mountOpts({ ...baseContext, likedByMe: true, isAnonymous: true, canLike: false }),
+      mountOpts({ ...baseContext, likedByMe: true, isAnonymous: true, canLike: false })
     )
 
     await wrapper.find('.toggle-anon').trigger('click')
@@ -104,11 +104,14 @@ describe('InteractionButtons', () => {
   it('emits like when "like back" button is clicked (they liked me, revealed)', async () => {
     const wrapper = mount(
       InteractionButtons,
-      mountOpts({ ...baseContext, likedMeRevealed: true, isAnonymous: false }),
+      mountOpts({ ...baseContext, likedMeRevealed: true, isAnonymous: false })
     )
 
-    const likeBtn = wrapper.find('.btn-dating')
-    await likeBtn.trigger('click')
+    // The popover trigger renders with variant="dating" (.btn-dating); the
+    // actual "like back" action button inside the popover body is the only
+    // .btn-outline-dating in the tree, so it disambiguates cleanly.
+    const likeBackBtn = wrapper.find('.btn-outline-dating')
+    await likeBackBtn.trigger('click')
 
     expect(wrapper.emitted('like')).toEqual([[false]])
   })
@@ -127,7 +130,7 @@ describe('InteractionButtons', () => {
     // confirmation dialog instead of emitting 'pass' directly.
     const wrapper = mount(
       InteractionButtons,
-      mountOpts({ ...baseContext, likedByMe: true, canLike: false }),
+      mountOpts({ ...baseContext, likedByMe: true, canLike: false })
     )
 
     const passBtn = wrapper.find('[title="interactions.pass_button_title"]')

--- a/apps/frontend/src/features/interaction/components/__tests__/InteractionButtons.spec.ts
+++ b/apps/frontend/src/features/interaction/components/__tests__/InteractionButtons.spec.ts
@@ -107,10 +107,10 @@ describe('InteractionButtons', () => {
       mountOpts({ ...baseContext, likedMeRevealed: true, isAnonymous: false })
     )
 
-    // The popover trigger renders with variant="dating" (.btn-dating); the
-    // actual "like back" action button inside the popover body is the only
-    // .btn-outline-dating in the tree, so it disambiguates cleanly.
-    const likeBackBtn = wrapper.find('.btn-outline-dating')
+    // The popover trigger renders with .btn-like; the actual "like back"
+    // action button inside the popover body is the only .btn-like-back in
+    // the tree, so it disambiguates cleanly.
+    const likeBackBtn = wrapper.find('.btn-like-back')
     await likeBackBtn.trigger('click')
 
     expect(wrapper.emitted('like')).toEqual([[false]])

--- a/apps/frontend/src/features/interaction/components/__tests__/InteractionButtons.spec.ts
+++ b/apps/frontend/src/features/interaction/components/__tests__/InteractionButtons.spec.ts
@@ -107,10 +107,7 @@ describe('InteractionButtons', () => {
       mountOpts({ ...baseContext, likedMeRevealed: true, isAnonymous: false })
     )
 
-    // The popover trigger renders with variant="dating" (.btn-dating); the
-    // actual "like back" action button inside the popover body is the only
-    // .btn-outline-dating in the tree, so it disambiguates cleanly.
-    const likeBackBtn = wrapper.find('.btn-outline-dating')
+    const likeBackBtn = wrapper.find('.btn-dating')
     await likeBackBtn.trigger('click')
 
     expect(wrapper.emitted('like')).toEqual([[false]])

--- a/apps/frontend/src/features/interaction/components/__tests__/InteractionButtons.spec.ts
+++ b/apps/frontend/src/features/interaction/components/__tests__/InteractionButtons.spec.ts
@@ -1,6 +1,5 @@
 import { mount } from '@vue/test-utils'
 import { describe, it, expect, vi } from 'vitest'
-import { nextTick } from 'vue'
 
 vi.mock('@/assets/icons/emojis/smiling-emoji.svg', () => ({
   default: { template: '<span />' },
@@ -13,6 +12,20 @@ vi.mock('@/assets/icons/interface/message.svg', () => ({
 }))
 vi.mock('../ConfirmPassDialog.vue', () => ({
   default: { template: '<div />' },
+}))
+
+// Stub AnonymousToggle so tests can drive its `change` event directly
+// without depending on its internal markup or i18n.
+vi.mock('../AnonymousToggle.vue', () => ({
+  default: {
+    props: ['selectedAnonymous'],
+    emits: ['change'],
+    template:
+      '<div class="anonymous-toggle-stub">' +
+      '<button class="toggle-anon" @click="$emit(\'change\', true)" /> ' +
+      '<button class="toggle-revealed" @click="$emit(\'change\', false)" />' +
+      '</div>',
+  },
 }))
 
 import InteractionButtons from '../InteractionButtons.vue'
@@ -39,51 +52,65 @@ const mountOpts = (context: InteractionContext) => ({
 })
 
 describe('InteractionButtons', () => {
-  it('emits like with selectedAnonymous value when like button is clicked', async () => {
-    const wrapper = mount(InteractionButtons, mountOpts({ ...baseContext, isAnonymous: true }))
+  it('emits like(true) when the anonymous toggle is clicked in the create-like popover', async () => {
+    const wrapper = mount(InteractionButtons, mountOpts({ ...baseContext }))
 
-    const likeBtn = wrapper.find('.btn-dating')
-    await likeBtn.trigger('click')
+    await wrapper.find('.toggle-anon').trigger('click')
 
     expect(wrapper.emitted('like')).toEqual([[true]])
   })
 
-  it('emits like with isAnonymous=false when context starts revealed', async () => {
-    const wrapper = mount(InteractionButtons, mountOpts({ ...baseContext, isAnonymous: false }))
+  it('emits like(false) when the revealed toggle is clicked in the create-like popover', async () => {
+    const wrapper = mount(InteractionButtons, mountOpts({ ...baseContext }))
 
-    const likeBtn = wrapper.find('.btn-dating')
-    await likeBtn.trigger('click')
+    await wrapper.find('.toggle-revealed').trigger('click')
 
     expect(wrapper.emitted('like')).toEqual([[false]])
-  })
-
-  it('syncs selectedAnonymous when context.isAnonymous changes', async () => {
-    const context = { ...baseContext, isAnonymous: true }
-    const wrapper = mount(InteractionButtons, mountOpts(context))
-
-    // Click like — should emit true (anonymous)
-    const likeBtn = wrapper.find('.btn-dating')
-    await likeBtn.trigger('click')
-    expect(wrapper.emitted('like')![0]).toEqual([true])
-
-    // Update context to revealed
-    await wrapper.setProps({
-      context: { ...context, isAnonymous: false, canLike: true },
-    })
-    await nextTick()
-
-    // Click like again — should now emit false (revealed)
-    await likeBtn.trigger('click')
-    expect(wrapper.emitted('like')![1]).toEqual([false])
   })
 
   it('does not emit like when canLike is false', async () => {
     const wrapper = mount(InteractionButtons, mountOpts({ ...baseContext, canLike: false }))
 
+    await wrapper.find('.toggle-anon').trigger('click')
+
+    expect(wrapper.emitted('like')).toBeUndefined()
+  })
+
+  it('emits update:anonymous when toggling anonymity on an already-liked profile', async () => {
+    const wrapper = mount(
+      InteractionButtons,
+      mountOpts({ ...baseContext, likedByMe: true, isAnonymous: true, canLike: false }),
+    )
+
+    // already liked: toggling to revealed should emit update:anonymous(false)
+    await wrapper.find('.toggle-revealed').trigger('click')
+
+    expect(wrapper.emitted('update:anonymous')).toEqual([[false]])
+    // should NOT emit a new like
+    expect(wrapper.emitted('like')).toBeUndefined()
+  })
+
+  it('does not emit update:anonymous when the chosen value matches current isAnonymous', async () => {
+    const wrapper = mount(
+      InteractionButtons,
+      mountOpts({ ...baseContext, likedByMe: true, isAnonymous: true, canLike: false }),
+    )
+
+    await wrapper.find('.toggle-anon').trigger('click')
+
+    expect(wrapper.emitted('update:anonymous')).toBeUndefined()
+  })
+
+  it('emits like when "like back" button is clicked (they liked me, revealed)', async () => {
+    const wrapper = mount(
+      InteractionButtons,
+      mountOpts({ ...baseContext, likedMeRevealed: true, isAnonymous: false }),
+    )
+
     const likeBtn = wrapper.find('.btn-dating')
     await likeBtn.trigger('click')
 
-    expect(wrapper.emitted('like')).toBeUndefined()
+    expect(wrapper.emitted('like')).toEqual([[false]])
   })
 
   it('emits message when message button is clicked and canMessage is true', async () => {

--- a/apps/frontend/src/features/interaction/components/__tests__/InteractionButtons.spec.ts
+++ b/apps/frontend/src/features/interaction/components/__tests__/InteractionButtons.spec.ts
@@ -107,10 +107,10 @@ describe('InteractionButtons', () => {
       mountOpts({ ...baseContext, likedMeRevealed: true, isAnonymous: false })
     )
 
-    // The popover trigger renders with .btn-like; the actual "like back"
-    // action button inside the popover body is the only .btn-like-back in
-    // the tree, so it disambiguates cleanly.
-    const likeBackBtn = wrapper.find('.btn-like-back')
+    // The popover trigger renders with variant="dating" (.btn-dating); the
+    // actual "like back" action button inside the popover body is the only
+    // .btn-outline-dating in the tree, so it disambiguates cleanly.
+    const likeBackBtn = wrapper.find('.btn-outline-dating')
     await likeBackBtn.trigger('click')
 
     expect(wrapper.emitted('like')).toEqual([[false]])

--- a/apps/frontend/src/types/bootstrap-vue-next.d.ts
+++ b/apps/frontend/src/types/bootstrap-vue-next.d.ts
@@ -1,5 +1,8 @@
 import 'bootstrap-vue-next'
 
+// Per bvn docs (https://bootstrap-vue-next.github.io/bootstrap-vue-next/docs/types.html#extending-types):
+// extend BaseColorVariant with custom theme colors, and BaseButtonVariant with
+// the explicit `outline-*` counterparts (bvn doesn't auto-derive them).
 declare module 'bootstrap-vue-next' {
   export interface BaseColorVariant {
     dating: unknown
@@ -9,5 +12,22 @@ declare module 'bootstrap-vue-next' {
     muted: unknown
     highlight: unknown
     'post-it': unknown
+  }
+
+  export interface BaseButtonVariant {
+    dating: unknown
+    'dating-light': unknown
+    social: unknown
+    tag: unknown
+    muted: unknown
+    highlight: unknown
+    'post-it': unknown
+    'outline-dating': unknown
+    'outline-dating-light': unknown
+    'outline-social': unknown
+    'outline-tag': unknown
+    'outline-muted': unknown
+    'outline-highlight': unknown
+    'outline-post-it': unknown
   }
 }

--- a/apps/frontend/src/types/bootstrap-vue-next.d.ts
+++ b/apps/frontend/src/types/bootstrap-vue-next.d.ts
@@ -1,8 +1,5 @@
 import 'bootstrap-vue-next'
 
-// Per bvn docs (https://bootstrap-vue-next.github.io/bootstrap-vue-next/docs/types.html#extending-types):
-// extend BaseColorVariant with custom theme colors, and BaseButtonVariant with
-// the explicit `outline-*` counterparts (bvn doesn't auto-derive them).
 declare module 'bootstrap-vue-next' {
   export interface BaseColorVariant {
     dating: unknown
@@ -12,22 +9,5 @@ declare module 'bootstrap-vue-next' {
     muted: unknown
     highlight: unknown
     'post-it': unknown
-  }
-
-  export interface BaseButtonVariant {
-    dating: unknown
-    'dating-light': unknown
-    social: unknown
-    tag: unknown
-    muted: unknown
-    highlight: unknown
-    'post-it': unknown
-    'outline-dating': unknown
-    'outline-dating-light': unknown
-    'outline-social': unknown
-    'outline-tag': unknown
-    'outline-muted': unknown
-    'outline-highlight': unknown
-    'outline-post-it': unknown
   }
 }

--- a/apps/frontend/src/types/bootstrap-vue-next.d.ts
+++ b/apps/frontend/src/types/bootstrap-vue-next.d.ts
@@ -1,5 +1,16 @@
 import 'bootstrap-vue-next'
 
+// Per bvn docs (https://bootstrap-vue-next.github.io/bootstrap-vue-next/docs/types.html#extending-types):
+// extend BaseColorVariant with custom theme colors (auto-inherited into
+// BaseButtonVariant via `extends`); add `outline-*` counterparts to
+// BaseButtonVariant explicitly because BaseColorVariantOutline is a frozen
+// mapped type that doesn't auto-derive from augmented BaseColorVariant.
+//
+// NOTE: this file must be included by every tsconfig project that
+// type-checks .vue files using bvn components — see tsconfig.vitest.json's
+// include list. A child tsconfig's `include` replaces the parent's, so
+// vitest project must list this file explicitly even though it extends
+// tsconfig.app.json.
 declare module 'bootstrap-vue-next' {
   export interface BaseColorVariant {
     dating: unknown
@@ -9,5 +20,15 @@ declare module 'bootstrap-vue-next' {
     muted: unknown
     highlight: unknown
     'post-it': unknown
+  }
+
+  export interface BaseButtonVariant {
+    'outline-dating': unknown
+    'outline-dating-light': unknown
+    'outline-social': unknown
+    'outline-tag': unknown
+    'outline-muted': unknown
+    'outline-highlight': unknown
+    'outline-post-it': unknown
   }
 }

--- a/apps/frontend/tsconfig.vitest.json
+++ b/apps/frontend/tsconfig.vitest.json
@@ -1,6 +1,12 @@
 {
   "extends": "./tsconfig.app.json",
-  "include": ["src/**/__tests__/*", "src/**/*.vue", "src/types/env.d.ts", "src/types/svg.d.ts"],
+  "include": [
+    "src/**/__tests__/*",
+    "src/**/*.vue",
+    "src/types/env.d.ts",
+    "src/types/svg.d.ts",
+    "src/types/bootstrap-vue-next.d.ts"
+  ],
   "exclude": [],
   "compilerOptions": {
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.vitest.tsbuildinfo",

--- a/packages/shared/i18n/en.json
+++ b/packages/shared/i18n/en.json
@@ -133,12 +133,13 @@
   "interactions": {
     "anonymous_like_explanation": "They won't know who sent it until they smile back at you.",
     "anonymous_toggle_anonymous": "Stay anonymous",
-    "anonymous_toggle_reveal": "Reveal my profile",
+    "anonymous_toggle_question": "Let them see who sent it?",
+    "anonymous_toggle_reveal": "Show my name",
     "cancel_button": "Maybe later",
     "its_a_match": "It's a match!",
     "like_button_title": "Smile",
     "like_error": "Oops, this didn't work. Please try again.",
-    "like_them_back": "Smile back at them?",
+    "like_them_back": "Smile back",
     "message_confirmation": "Nice!",
     "pass_button_title": "Pass",
     "revealed_like_explanation": "They will see who sent it.",
@@ -148,7 +149,8 @@
     "they_liked_you": "They smiled at you!",
     "you_liked_them": "You smiled at them",
     "you_matched_with_them": "{name} smiled back!",
-    "you_messaged_them": "You messaged them"
+    "you_messaged_them": "You messaged them",
+    "you_smiled_at": "You smiled at {name}"
   },
   "matches": {
     "anonymous_like_hint": "They smiled at you anonymously, at least for now. You'll find out who when you smile back. You can bump into them on the map — if you see someone marked like this, your preferences match.",

--- a/packages/shared/i18n/hu.json
+++ b/packages/shared/i18n/hu.json
@@ -136,13 +136,14 @@
   },
   "interactions": {
     "anonymous_like_explanation": "Csak akkor derül ki, hogy tőled jött, ha visszamosolyog rád.",
-    "anonymous_toggle_anonymous": "Névtelenül",
-    "anonymous_toggle_reveal": "Mutasd a profilom",
+    "anonymous_toggle_anonymous": "Nem",
+    "anonymous_toggle_question": "Lássa, hogy ki küldte?",
+    "anonymous_toggle_reveal": "Igen",
     "cancel_button": "Talán később",
     "its_a_match": "Kölcsönös!",
     "like_button_title": "Rámosolygok!",
     "like_error": "Hoppá, ez nem működött. Kérjük, próbáld meg újra.",
-    "like_them_back": "Visszamosolyogsz?",
+    "like_them_back": "Visszamosolygok",
     "message_confirmation": "Elküldve!",
     "pass_button_title": "Passzolok",
     "revealed_like_explanation": "Látni fogja, hogy Te küldted.",
@@ -152,7 +153,8 @@
     "they_liked_you": "Rád mosolygott!",
     "you_liked_them": "Rámosolygok",
     "you_matched_with_them": "{name} visszamosolygott!",
-    "you_messaged_them": "Üzenetet küldtél neki"
+    "you_messaged_them": "Üzenetet küldtél neki",
+    "you_smiled_at": "Rámosolyogtál!"
   },
   "matches": {
     "anonymous_like_hint": "Egyelőre névtelenül mosolygott rád. De a Komakeresőben rátalálhatsz - ha Te is rámosolyogsz, ki fog derülni, ki küldte. Ha valakit ilyen jelöléssel látsz, könnyen lehet, hogy egymást keresitek:",


### PR DESCRIPTION
## Summary

- Redesign the like popover: replace the radio group with a paired-button toggle (anonymous icon vs. profile thumbnail) so the user picks anonymity *as part of* the like action, not before.
- Split the single \`interaction-like\` analytics event into three semantic variants: \`interaction-create-like\`, \`interaction-update-like\`, \`interaction-like-back\`.
- Add a \"You smiled at {name}\" confirmation toast on a successful non-match like.
- Wire the existing-but-unused \`update:anonymous\` event so users can flip a previously sent like between anonymous and revealed (this never worked before — the handler was gated on \`canLike\`, which is false for already-liked profiles).

## Behavioral fixes uncovered while reviewing

- \`AnonymousToggle\` is now fully *controlled*: it accepts \`selectedAnonymous: boolean | null\` and emits \`change(isAnonymous)\` with the correct semantics (clicking \"Stay anonymous\" emits \`true\`, clicking \"Show my name\" emits \`false\`). The earlier draft had inverted semantics and dropped the payload.
- \`InteractionButtons\` no longer binds \`v-model\` to the \`context\` prop (Vue refused to compile it: *\"v-model cannot be used on a prop\"*); the toggle is now bound one-way with \`:selectedAnonymous\` + \`@change\`.
- \`hintAnonymous\` ref typing fixed (\`ref<boolean | null>(null)\`).
- Removed dead commented \`<UpdateLike>\` block and unused imports.
- Replaced a hardcoded Hungarian heading with the new \`interactions.anonymous_toggle_question\` i18n key (en + hu).

## Test plan

- [x] \`pnpm --filter frontend exec vitest run InteractionButtons.spec.ts\` — 8/8 pass (rewritten to drive the new \`change\` events)
- [x] \`pnpm --filter frontend test\` — 599/599 pass
- [ ] Manual: open a profile you haven't liked, click the smile button, pick each toggle, verify the like is sent with the correct \`isAnonymous\` flag and the toast appears.
- [ ] Manual: on a profile you've already liked, open the popover and flip anonymity — verify it persists (calls \`updateLike\`, not \`like\`).
- [ ] Manual: on a profile that liked you (revealed), click the smile button — verify it emits a like-back without opening the toggle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)