### PR TITLE
refactor(interaction): extract interactionContext into dedicated endpoint

### DIFF
--- a/.changeset/violet-clouds-extract.md
+++ b/.changeset/violet-clouds-extract.md
@@ -1,0 +1,6 @@
+---
+'@opencupid/backend': minor
+'@opencupid/frontend': minor
+---
+
+Extract interaction context from public profile DTO into a dedicated `GET /interactions/context/:targetId` endpoint, owned by `useInteractionStore` on the frontend.

--- a/apps/backend/src/__tests__/routes/interaction.route.spec.ts
+++ b/apps/backend/src/__tests__/routes/interaction.route.spec.ts
@@ -5,9 +5,21 @@ import { MockFastify, MockReply } from '../../test-utils/fastify'
 let fastify: MockFastify
 let reply: MockReply
 let mockService: any
+let mockProfileService: any
+let mockProfileMatchService: any
+let mockMapInteractionContext: (...args: unknown[]) => unknown
 
 vi.mock('../../services/interaction.service', () => ({
   InteractionService: { getInstance: () => mockService },
+}))
+vi.mock('../../services/profile.service', () => ({
+  ProfileService: { getInstance: () => mockProfileService },
+}))
+vi.mock('../../services/profileMatch.service', () => ({
+  ProfileMatchService: { getInstance: () => mockProfileMatchService },
+}))
+vi.mock('../../api/mappers/interaction.mappers', () => ({
+  mapInteractionContext: (...args: unknown[]) => mockMapInteractionContext(...args),
 }))
 vi.mock('../../utils/wsUtils', () => ({
   broadcastToProfile: vi.fn().mockReturnValue(true),
@@ -25,7 +37,10 @@ vi.mock('@/lib/appconfig', () => ({
 }))
 
 const makeReq = (overrides: any = {}) => ({
-  session: { profileId: 'p1' },
+  session: {
+    profileId: 'p1',
+    profile: { isDatingActive: false },
+  },
   ...overrides,
 })
 
@@ -42,6 +57,13 @@ beforeEach(async () => {
     pass: vi.fn(),
     updateLike: vi.fn(),
   }
+  mockProfileService = {
+    getInteractionContextSourceById: vi.fn(),
+  }
+  mockProfileMatchService = {
+    areProfilesMutuallyCompatible: vi.fn().mockResolvedValue(false),
+  }
+  mockMapInteractionContext = vi.fn().mockReturnValue({ stub: 'context' })
   await interactionRoutes(fastify as any, {})
 })
 
@@ -245,5 +267,74 @@ describe('GET /matches', () => {
     await handler(makeReq(), reply as any)
     expect(reply.statusCode).toBe(200)
     expect(reply.payload.edges).toBe(edges)
+  })
+})
+
+describe('GET /context/:targetId', () => {
+  const targetId = 'cm000000000000000000000p2'
+
+  it('returns the mapped interaction context on success', async () => {
+    const handler = fastify.routes['GET /context/:targetId']
+    const raw = { id: 'p2', isDatingActive: false, blockedProfiles: [] }
+    mockProfileService.getInteractionContextSourceById.mockResolvedValue(raw)
+    mockMapInteractionContext = vi.fn().mockReturnValue({ canMessage: true })
+
+    await handler(makeReq({ params: { targetId } }), reply as any)
+
+    expect(reply.statusCode).toBe(200)
+    expect(reply.payload).toStrictEqual({ success: true, context: { canMessage: true } })
+    expect(mockProfileService.getInteractionContextSourceById).toHaveBeenCalledWith(targetId, 'p1')
+    expect(mockMapInteractionContext).toHaveBeenCalledWith(raw, false, 'p1')
+  })
+
+  it('checks mutual compatibility when both sides are dating-active', async () => {
+    const handler = fastify.routes['GET /context/:targetId']
+    const raw = { id: 'p2', isDatingActive: true, blockedProfiles: [] }
+    mockProfileService.getInteractionContextSourceById.mockResolvedValue(raw)
+    mockProfileMatchService.areProfilesMutuallyCompatible.mockResolvedValue(true)
+
+    const req = makeReq({
+      params: { targetId },
+      session: { profileId: 'p1', profile: { isDatingActive: true } },
+    })
+    await handler(req, reply as any)
+
+    expect(reply.statusCode).toBe(200)
+    expect(mockProfileMatchService.areProfilesMutuallyCompatible).toHaveBeenCalledWith('p1', 'p2')
+    expect(mockMapInteractionContext).toHaveBeenCalledWith(raw, true, 'p1')
+  })
+
+  it('returns 404 when the target profile does not exist', async () => {
+    const handler = fastify.routes['GET /context/:targetId']
+    mockProfileService.getInteractionContextSourceById.mockResolvedValue(null)
+
+    await handler(makeReq({ params: { targetId } }), reply as any)
+
+    expect(reply.statusCode).toBe(404)
+    expect(reply.payload.success).toBe(false)
+  })
+
+  it('returns 404 when the target has blocked the viewer (privacy)', async () => {
+    const handler = fastify.routes['GET /context/:targetId']
+    mockProfileService.getInteractionContextSourceById.mockResolvedValue({
+      id: 'p2',
+      isDatingActive: false,
+      blockedProfiles: [{ id: 'p1' }],
+    })
+
+    await handler(makeReq({ params: { targetId } }), reply as any)
+
+    expect(reply.statusCode).toBe(404)
+    expect(reply.payload.success).toBe(false)
+    expect(mockMapInteractionContext).not.toHaveBeenCalled()
+  })
+
+  it('returns 500 on service error', async () => {
+    const handler = fastify.routes['GET /context/:targetId']
+    mockProfileService.getInteractionContextSourceById.mockRejectedValue(new Error('boom'))
+
+    await handler(makeReq({ params: { targetId } }), reply as any)
+
+    expect(reply.statusCode).toBe(500)
   })
 })

--- a/apps/backend/src/__tests__/routes/interaction.route.spec.ts
+++ b/apps/backend/src/__tests__/routes/interaction.route.spec.ts
@@ -198,6 +198,28 @@ describe('PATCH /like/:targetId', () => {
     })
   })
 
+  it('broadcasts ws:update_like to the recipient on every update', async () => {
+    const { broadcastToProfile } = await import('../../utils/wsUtils')
+    const handler = fastify.routes['PATCH /like/:targetId']
+    const pair = {
+      isMatch: false,
+      to: { profile: { id: 'p2' }, isMatch: false, isAnonymous: true },
+      from: { profile: { id: 'p1' }, isMatch: false, isAnonymous: true },
+    }
+    mockService.updateLike.mockResolvedValue(pair)
+
+    const req = makeReq({
+      params: { targetId: 'cm000000000000000000000p2' },
+      body: { isAnonymous: true },
+    })
+    await handler(req, reply as any)
+
+    expect(broadcastToProfile).toHaveBeenCalledWith(fastify, 'cm000000000000000000000p2', {
+      type: 'ws:update_like',
+      payload: pair.from,
+    })
+  })
+
   it('returns 500 on error', async () => {
     const handler = fastify.routes['PATCH /like/:targetId']
     mockService.updateLike.mockRejectedValue(new Error('fail'))
@@ -220,6 +242,19 @@ describe('POST /pass/:targetId', () => {
     await handler(req, reply as any)
     expect(reply.statusCode).toBe(200)
     expect(reply.payload.success).toBe(true)
+  })
+
+  it('broadcasts ws:update_like to the recipient', async () => {
+    const { broadcastToProfile } = await import('../../utils/wsUtils')
+    const handler = fastify.routes['POST /pass/:targetId']
+    mockService.pass.mockResolvedValue(undefined)
+
+    const req = makeReq({ params: { targetId: 'cm000000000000000000000p2' } })
+    await handler(req, reply as any)
+
+    expect(broadcastToProfile).toHaveBeenCalledWith(fastify, 'cm000000000000000000000p2', {
+      type: 'ws:update_like',
+    })
   })
 
   it('returns 500 on error', async () => {

--- a/apps/backend/src/__tests__/routes/profile.route.spec.ts
+++ b/apps/backend/src/__tests__/routes/profile.route.spec.ts
@@ -41,10 +41,6 @@ vi.mock('../../api/mappers/profile.mappers', () => ({
     profileImages: p.profileImages,
     location: p.location ?? { country: '' },
   })),
-  mapProfileWithContext: vi.fn((db, _dating, _locale, _viewerId) => ({
-    id: db.id,
-    publicName: db.publicName || 'mapped',
-  })),
   mapProfileToPublic: vi.fn((db, _dating, _locale) => ({
     id: db.id,
     publicName: db.publicName || 'mapped',
@@ -82,7 +78,7 @@ beforeEach(async () => {
   mockProfileService = {
     getProfileCompleteByUserId: vi.fn(),
     getProfileCompleteById: vi.fn(),
-    getProfileWithContextById: vi.fn(),
+    getProfilePublicById: vi.fn(),
     getProfileByUserId: vi.fn(),
     updateCompleteProfile: vi.fn(),
     getOptInSettingsByProfileId: vi.fn(),
@@ -173,7 +169,7 @@ describe('GET /:id', () => {
       isDatingActive: false,
       conversationParticipants: [],
     }
-    mockProfileService.getProfileWithContextById.mockResolvedValue(dbProfile)
+    mockProfileService.getProfilePublicById.mockResolvedValue(dbProfile)
 
     const req = makeReq({ params: { id: 'cm000000000000000000000p2' } })
     await handler(req, reply as any)
@@ -183,7 +179,7 @@ describe('GET /:id', () => {
 
   it('returns 404 when profile not found', async () => {
     const handler = fastify.routes['GET /:id']
-    mockProfileService.getProfileWithContextById.mockResolvedValue(null)
+    mockProfileService.getProfilePublicById.mockResolvedValue(null)
 
     const req = makeReq({ params: { id: 'cm000000000000000000000p2' } })
     await handler(req, reply as any)
@@ -197,7 +193,7 @@ describe('GET /:id', () => {
       userId: 'u2',
       blockedProfiles: [{ id: 'p1' }],
     }
-    mockProfileService.getProfileWithContextById.mockResolvedValue(dbProfile)
+    mockProfileService.getProfilePublicById.mockResolvedValue(dbProfile)
 
     const req = makeReq({ params: { id: 'cm000000000000000000000p2' } })
     await handler(req, reply as any)
@@ -212,7 +208,7 @@ describe('GET /:id', () => {
       blockedProfiles: [],
       isDatingActive: false,
     }
-    mockProfileService.getProfileWithContextById.mockResolvedValue(dbProfile)
+    mockProfileService.getProfilePublicById.mockResolvedValue(dbProfile)
 
     const req = makeReq({
       params: { id: 'cm000000000000000000000p2' },

--- a/apps/backend/src/api/mappers/profile.mappers.ts
+++ b/apps/backend/src/api/mappers/profile.mappers.ts
@@ -1,15 +1,11 @@
 import {
-  type PublicProfileWithContext,
+  type PublicProfile,
   ProfileUnionSchema,
   type ProfileSummary,
   type OwnerProfile,
   OwnerScalarsSchema,
 } from '@zod/profile/profile.dto'
-import {
-  type DbProfileSummary,
-  type DbProfileWithContext,
-  type DbProfileWithImages,
-} from '@zod/profile/profile.db'
+import { type DbProfileSummary, type DbProfileWithImages } from '@zod/profile/profile.db'
 import { LocationSchema } from '@zod/dto/location.dto'
 import { DbLocationToLocationDTO } from './location.mappers'
 
@@ -21,7 +17,6 @@ import {
   toPublicProfileImage,
   type MinimalProfileImage,
 } from './image.mappers'
-import { mapInteractionContext } from './interaction.mappers'
 
 export function mapDbProfileToOwnerProfile(locale: string, db: DbProfileWithImages): OwnerProfile {
   const scalars = OwnerScalarsSchema.parse(db)
@@ -52,7 +47,7 @@ export function mapProfileToPublic(
   dbProfile: DbProfileWithImages,
   includeDatingContext: boolean,
   locale: string
-): PublicProfileWithContext {
+): PublicProfile {
   // map localized fields with fallback to first available locale
   const get = (field: string): string => {
     // First try to find the preferred locale with a non-empty value
@@ -86,21 +81,7 @@ export function mapProfileToPublic(
     location: DbLocationToLocationDTO(dbProfile),
     introSocial: get('introSocial') || '',
     introDating: get('introDating') || '',
-  } as PublicProfileWithContext
-}
-
-export function mapProfileWithContext(
-  dbProfile: DbProfileWithContext,
-  includeDatingContext: boolean,
-  locale: string,
-  viewerProfileId: string
-): PublicProfileWithContext {
-  const mapped = mapProfileToPublic(dbProfile, includeDatingContext, locale)
-  const interactionContext = mapInteractionContext(dbProfile, includeDatingContext, viewerProfileId)
-  return {
-    ...mapped,
-    interactionContext,
-  } as PublicProfileWithContext
+  } as PublicProfile
 }
 
 export function mapProfileImagesToOwner(images: ProfileImage[]): OwnerProfileImage[] {

--- a/apps/backend/src/api/routes/interaction.route.ts
+++ b/apps/backend/src/api/routes/interaction.route.ts
@@ -2,12 +2,16 @@ import { FastifyPluginAsync } from 'fastify'
 import z from 'zod'
 import { rateLimitConfig, sendError } from '../helpers'
 import type {
+  InteractionContextResponse,
   InteractionEdgeResponse,
   InteractionEdgesResponse,
   InteractionStatsResponse,
   ReceivedLikesResponse,
 } from '@zod/apiResponse.dto'
 import { InteractionService } from '@/services/interaction.service'
+import { ProfileService } from '@/services/profile.service'
+import { ProfileMatchService } from '@/services/profileMatch.service'
+import { mapInteractionContext } from '@/api/mappers/interaction.mappers'
 import { broadcastToProfile } from '@/utils/wsUtils'
 import { notifierService } from '@/services/notifier.service'
 import { appConfig } from '@/lib/appconfig'
@@ -21,6 +25,52 @@ const RATE_LIMIT_LIKE_OR_PASS = 3 // per-minute ceiling for deliberate like/pass
 
 const interactionRoutes: FastifyPluginAsync = async (fastify) => {
   const service = InteractionService.getInstance()
+  const profileService = ProfileService.getInstance()
+  const profileMatchService = ProfileMatchService.getInstance()
+
+  /**
+   * GET /context/:targetId
+   * Returns the viewer's interaction context with the target profile —
+   * conversation state plus (when both sides are dating-active and mutually
+   * compatible) dating state. Hidden behind a 404 when the target has blocked
+   * the viewer, matching the privacy contract of GET /profiles/:id.
+   * @param {string} targetId - Profile ID to read context for (CUID)
+   * @returns {InteractionContextResponse}
+   */
+  fastify.get<{ Params: { targetId: string } }>(
+    '/context/:targetId',
+    {
+      onRequest: [fastify.authenticate],
+      config: rateLimitConfig(fastify, '1 minute', 60),
+    },
+    async (req, reply) => {
+      const { targetId } = TargetLookupParamsSchema.parse(req.params)
+      const myId = req.session.profileId
+
+      try {
+        const raw = await profileService.getInteractionContextSourceById(targetId, myId)
+        if (!raw) return sendError(reply, 404, 'Profile not found')
+        if (raw.blockedProfiles.length > 0) {
+          return sendError(reply, 404, 'This profile does not exist')
+        }
+
+        let includeDatingContext = false
+        if (raw.isDatingActive && req.session.profile.isDatingActive) {
+          includeDatingContext = await profileMatchService.areProfilesMutuallyCompatible(
+            myId,
+            raw.id
+          )
+        }
+
+        const context = mapInteractionContext(raw, includeDatingContext, myId)
+        const response: InteractionContextResponse = { success: true, context }
+        return reply.code(200).send(response)
+      } catch (err) {
+        fastify.log.error(err)
+        return sendError(reply, 500, 'Failed to fetch interaction context')
+      }
+    }
+  )
 
   /**
    * GET /

--- a/apps/backend/src/api/routes/interaction.route.ts
+++ b/apps/backend/src/api/routes/interaction.route.ts
@@ -175,7 +175,14 @@ const interactionRoutes: FastifyPluginAsync = async (fastify) => {
       try {
         const pair = await service.updateLike(myId, targetId, body)
         const response: InteractionEdgeResponse = { success: true, pair }
-        return reply.code(200).send(response)
+        reply.code(200).send(response)
+
+        // Broadcast to the recipient — send the initiator's edge so they see the
+        // updated anonymity state (reveal or re-hide).
+        broadcastToProfile(fastify, targetId, {
+          type: 'ws:update_like',
+          payload: pair.from,
+        })
       } catch (err) {
         fastify.log.error(err)
         return sendError(reply, 500, 'Failed to update like')
@@ -201,7 +208,11 @@ const interactionRoutes: FastifyPluginAsync = async (fastify) => {
 
       try {
         await service.pass(myId, targetId)
-        return reply.code(200).send({ success: true })
+        reply.code(200).send({ success: true })
+
+        // Pass deletes any existing likes in either direction, so the recipient's
+        // received-likes list may have changed. Notify them to refetch.
+        broadcastToProfile(fastify, targetId, { type: 'ws:update_like' })
       } catch (err) {
         fastify.log.error(err)
         return sendError(reply, 500, 'Failed to pass profile')

--- a/apps/backend/src/api/routes/profile.route.ts
+++ b/apps/backend/src/api/routes/profile.route.ts
@@ -20,7 +20,6 @@ import {
   mapDbProfileToOwnerProfile,
   mapProfileSummary,
   mapProfileToPublic,
-  mapProfileWithContext,
 } from '@/api/mappers/profile.mappers'
 import type {
   GetDatingPreferencesResponse,
@@ -179,9 +178,12 @@ const profileRoutes: FastifyPluginAsync = async (fastify) => {
 
   /**
    * GET /:id
-   * Returns a public profile with interaction context (like/match/conversation state).
-   * Dating context is only included when both profiles have dating active and are mutually compatible.
-   * Returns 404 if the target profile has blocked the viewer (intentionally vague for privacy).
+   * Returns a public profile (without viewer-relative interaction state).
+   * The viewer's like/match/conversation state with this profile is served
+   * separately by GET /interactions/context/:targetId.
+   *
+   * Returns 404 if the target profile has blocked the viewer (intentionally
+   * vague for privacy).
    * @param {string} id - Target profile ID (CUID)
    * @returns {GetPublicProfileResponse}
    */
@@ -191,7 +193,7 @@ const profileRoutes: FastifyPluginAsync = async (fastify) => {
 
     try {
       const { id } = IdLookupParamsSchema.parse(req.params)
-      const raw = await profileService.getProfileWithContextById(id, myProfileId)
+      const raw = await profileService.getProfilePublicById(id, myProfileId)
       if (!raw) return sendError(reply, 404, 'Profile not found')
 
       // the profile being requested has blocked the current profile
@@ -212,7 +214,7 @@ const profileRoutes: FastifyPluginAsync = async (fastify) => {
         )
       }
 
-      const profile = mapProfileWithContext(raw, includeDatingContext, locale, myProfileId)
+      const profile = mapProfileToPublic(raw, includeDatingContext, locale)
       const response: GetPublicProfileResponse = { success: true, profile }
       return reply.code(200).send(response)
     } catch (err) {

--- a/apps/backend/src/services/profile.service.ts
+++ b/apps/backend/src/services/profile.service.ts
@@ -59,10 +59,7 @@ export class ProfileService {
   // Public profile fetch — only the viewer-facing block check is included as
   // it gates 404 visibility. Viewer-relative interaction state (likes, hides,
   // conversations) lives behind the dedicated /interactions/context endpoint.
-  async getProfilePublicById(
-    profileId: string,
-    myProfileId: string
-  ): Promise<(DbProfileWithImages & { blockedProfiles: { id: string }[] }) | null> {
+  async getProfilePublicById(profileId: string, myProfileId: string) {
     return prisma.profile.findUnique({
       where: { id: profileId },
       include: {
@@ -70,7 +67,7 @@ export class ProfileService {
         ...profileImageInclude(),
         ...blockedContextInclude(myProfileId),
       },
-    }) as Promise<(DbProfileWithImages & { blockedProfiles: { id: string }[] }) | null>
+    })
   }
 
   // Interaction-context source fetch — only the viewer-relative relations

--- a/apps/backend/src/services/profile.service.ts
+++ b/apps/backend/src/services/profile.service.ts
@@ -56,21 +56,37 @@ export class ProfileService {
     return ProfileService.instance
   }
 
-  async getProfileWithContextById(
+  // Public profile fetch — only the viewer-facing block check is included as
+  // it gates 404 visibility. Viewer-relative interaction state (likes, hides,
+  // conversations) lives behind the dedicated /interactions/context endpoint.
+  async getProfilePublicById(
     profileId: string,
     myProfileId: string
-  ): Promise<DbProfileWithContext | null> {
-    const query = {
+  ): Promise<(DbProfileWithImages & { blockedProfiles: { id: string }[] }) | null> {
+    return prisma.profile.findUnique({
       where: { id: profileId },
       include: {
         ...tagsInclude(),
         ...profileImageInclude(),
+        ...blockedContextInclude(myProfileId),
+      },
+    }) as Promise<(DbProfileWithImages & { blockedProfiles: { id: string }[] }) | null>
+  }
+
+  // Interaction-context source fetch — only the viewer-relative relations
+  // needed by mapInteractionContext. No tags/images/localized.
+  async getInteractionContextSourceById(
+    profileId: string,
+    myProfileId: string
+  ): Promise<DbProfileWithContext | null> {
+    return prisma.profile.findUnique({
+      where: { id: profileId },
+      include: {
         ...interactionContextInclude(myProfileId),
         ...conversationContextInclude(myProfileId),
         ...blockedContextInclude(myProfileId),
       },
-    }
-    return await prisma.profile.findUnique(query)
+    }) as Promise<DbProfileWithContext | null>
   }
 
   async getProfileByUserId(userId: string): Promise<Profile | null> {

--- a/apps/frontend/src/features/interaction/components/MatchPopup.vue
+++ b/apps/frontend/src/features/interaction/components/MatchPopup.vue
@@ -1,16 +1,20 @@
 <script lang="ts" setup>
 import { type InteractionEdgePair } from '@zod/interaction/interaction.dto'
-import { type PublicProfileWithContext } from '@zod/profile/profile.dto'
+import { type PublicProfile } from '@zod/profile/profile.dto'
 
 import ProfileImage from '@/features/images/components/ProfileImage.vue'
 import ContactFormPanel from '@/features/messaging/components/ContactFormPanel.vue'
 import { ref } from 'vue'
+import { useInteractionsViewModel } from '../composables/useInteractionsViewModel'
 
-defineProps<{
-  profile: PublicProfileWithContext
+const props = defineProps<{
+  profile: PublicProfile
   match: InteractionEdgePair
   show: boolean
 }>()
+
+const { contextFor } = useInteractionsViewModel()
+const context = contextFor(props.profile.id)
 
 const emit = defineEmits<{
   (e: 'close'): void
@@ -67,7 +71,7 @@ const handleSubmitted = () => {
         </div>
       </div>
       <div
-        v-if="profile.interactionContext.canMessage"
+        v-if="context?.canMessage"
         class="text-center"
       >
         <h6 class="text-center mb-3">
@@ -120,5 +124,4 @@ const handleSubmitted = () => {
 .match-popup-content.sent {
   background-color: white;
 }
-
 </style>

--- a/apps/frontend/src/features/interaction/components/ProfileInteractions.vue
+++ b/apps/frontend/src/features/interaction/components/ProfileInteractions.vue
@@ -1,7 +1,7 @@
 <script lang="ts" setup>
-import { onMounted, ref } from 'vue'
+import { onMounted, ref, watch } from 'vue'
 
-import { type PublicProfileWithContext } from '@zod/profile/profile.dto'
+import { type PublicProfile } from '@zod/profile/profile.dto'
 
 import InteractionButtons from './InteractionButtons.vue'
 import SendMessageDialog from '@/features/publicprofile/components/SendMessageDialog.vue'
@@ -16,7 +16,7 @@ const { t } = useI18n()
 const toast = useToast()
 
 const props = defineProps<{
-  profile: PublicProfileWithContext
+  profile: PublicProfile
 }>()
 
 const emit = defineEmits<{
@@ -30,7 +30,10 @@ const showMessageModal = ref(false)
 const showMatchModal = ref(false)
 const match = ref<InteractionEdgePair>()
 
-const { like, pass, updateLike, refreshInteractions, isLoading } = useInteractionsViewModel()
+const { like, pass, updateLike, refreshInteractions, fetchContext, contextFor } =
+  useInteractionsViewModel()
+
+const context = contextFor(props.profile.id)
 
 const handleLike = async (isAnonymous: boolean) => {
   const result = await like(props.profile.id, isAnonymous)
@@ -64,15 +67,24 @@ const handleAnonymousUpdate = async (isAnonymous: boolean) => {
 }
 
 const handleMessageIntent = () => {
-  const context = props.profile.interactionContext
-  if (context.haveConversation && context.conversationId) {
-    emit('intent:message', context?.conversationId)
+  const ctx = context.value
+  if (!ctx) return
+  if (ctx.haveConversation && ctx.conversationId) {
+    emit('intent:message', ctx.conversationId)
     return
   }
-  if (context.canMessage) {
+  if (ctx.canMessage) {
     showMessageModal.value = true
   }
 }
+
+watch(
+  () => props.profile.id,
+  (id) => {
+    if (id) fetchContext(id)
+  },
+  { immediate: true }
+)
 
 onMounted(async () => {
   await refreshInteractions()
@@ -81,7 +93,7 @@ onMounted(async () => {
 
 <template>
   <div
-    v-if="profile.interactionContext"
+    v-if="context"
     class="profile-interactions d-flex justify-content-center align-items-center gap-2"
   >
     <InteractionButtons
@@ -89,7 +101,7 @@ onMounted(async () => {
       @pass="handlePass"
       @like="handleLike"
       @update:anonymous="handleAnonymousUpdate"
-      :context="profile.interactionContext"
+      :context="context"
     />
     <SendMessageDialog
       v-model="showMessageModal"

--- a/apps/frontend/src/features/interaction/components/ProfileInteractions.vue
+++ b/apps/frontend/src/features/interaction/components/ProfileInteractions.vue
@@ -33,7 +33,7 @@ const match = ref<InteractionEdgePair>()
 const { like, pass, updateLike, refreshInteractions, fetchContext, contextFor } =
   useInteractionsViewModel()
 
-const context = contextFor(props.profile.id)
+const context = contextFor(() => props.profile.id)
 
 const handleLike = async (isAnonymous: boolean) => {
   const result = await like(props.profile.id, isAnonymous)

--- a/apps/frontend/src/features/interaction/components/ProfileInteractions.vue
+++ b/apps/frontend/src/features/interaction/components/ProfileInteractions.vue
@@ -43,7 +43,6 @@ const handleLike = async (isAnonymous: boolean) => {
       showMatchModal.value = true
     } else {
       emit('liked')
-      emit('updated')
       toast.info(t('interactions.you_smiled_at', { name: props.profile.publicName }))
     }
   } else {
@@ -54,14 +53,11 @@ const handleLike = async (isAnonymous: boolean) => {
 const handlePass = async () => {
   await pass(props.profile.id)
   emit('passed')
-  emit('updated')
 }
 
 const handleAnonymousUpdate = async (isAnonymous: boolean) => {
   const result = await updateLike(props.profile.id, isAnonymous)
-  if (result.success) {
-    emit('updated')
-  } else {
+  if (!result.success) {
     toast.error(t('interactions.like_error'))
   }
 }

--- a/apps/frontend/src/features/interaction/composables/useInteractionsViewModel.ts
+++ b/apps/frontend/src/features/interaction/composables/useInteractionsViewModel.ts
@@ -18,6 +18,8 @@ export function useInteractionsViewModel() {
     updateLike: store.updateLike,
     pass: store.passProfile,
     refreshInteractions: store.fetchInteractions,
+    fetchContext: store.fetchContext,
+    contextFor: (profileId: string) => computed(() => store.contextByProfileId[profileId]),
     initialize: store.initialize,
     isInitialized: computed(() => store.initialized),
     isLoading: computed(() => store.loading || !store.initialized),

--- a/apps/frontend/src/features/interaction/composables/useInteractionsViewModel.ts
+++ b/apps/frontend/src/features/interaction/composables/useInteractionsViewModel.ts
@@ -1,4 +1,4 @@
-import { computed } from 'vue'
+import { computed, toValue, type MaybeRefOrGetter } from 'vue'
 import { useInteractionStore } from '../stores/useInteractionStore'
 
 export function useInteractionsViewModel() {
@@ -19,7 +19,8 @@ export function useInteractionsViewModel() {
     pass: store.passProfile,
     refreshInteractions: store.fetchInteractions,
     fetchContext: store.fetchContext,
-    contextFor: (profileId: string) => computed(() => store.contextByProfileId[profileId]),
+    contextFor: (profileId: MaybeRefOrGetter<string>) =>
+      computed(() => store.contextByProfileId[toValue(profileId)]),
     initialize: store.initialize,
     isInitialized: computed(() => store.initialized),
     isLoading: computed(() => store.loading || !store.initialized),

--- a/apps/frontend/src/features/interaction/stores/useInteractionStore.ts
+++ b/apps/frontend/src/features/interaction/stores/useInteractionStore.ts
@@ -13,7 +13,11 @@ import {
   InteractionContextSchema,
   type InteractionContext,
 } from '@zod/interaction/interactionContext.dto'
-import type { InteractionContextResponse } from '@zod/apiResponse.dto'
+import type {
+  InteractionContextResponse,
+  InteractionEdgeResponse,
+  InteractionStatsResponse,
+} from '@zod/apiResponse.dto'
 import { storeError, storeSuccess, type StoreError, type StoreResponse } from '@/store/helpers'
 
 interface InteractionState {
@@ -71,7 +75,7 @@ export const useInteractionStore = defineStore('interaction', {
     async fetchInteractions() {
       this.loading = true
       try {
-        const res = await safeApiCall(() => api.get('/interactions'))
+        const res = await safeApiCall(() => api.get<InteractionStatsResponse>('/interactions'))
         const stats = InteractionStatsSchema.parse(res.data.stats)
         this.sent = stats.sent
         this.matches = stats.matches
@@ -92,7 +96,7 @@ export const useInteractionStore = defineStore('interaction', {
     ): Promise<StoreResponse<InteractionEdgePair>> {
       try {
         const res = await safeApiCall(() =>
-          api.post<{ success: true; pair: unknown }>(`/interactions/like/${targetId}`, {
+          api.post<InteractionEdgeResponse>(`/interactions/like/${targetId}`, {
             isAnonymous,
           })
         )
@@ -122,7 +126,7 @@ export const useInteractionStore = defineStore('interaction', {
     ): Promise<StoreResponse<InteractionEdgePair>> {
       try {
         const res = await safeApiCall(() =>
-          api.patch<{ success: true; pair: unknown }>(`/interactions/like/${targetId}`, {
+          api.patch<InteractionEdgeResponse>(`/interactions/like/${targetId}`, {
             isAnonymous,
           })
         )
@@ -185,6 +189,7 @@ export const useInteractionStore = defineStore('interaction', {
 
     async initialize() {
       bus.on('ws:new_like', this.onNewLike)
+      bus.on('ws:update_like', this.onNewLike)
       bus.on('ws:new_match', this.onNewMatch)
       if (!this.initialized) {
         await this.fetchInteractions()
@@ -193,6 +198,7 @@ export const useInteractionStore = defineStore('interaction', {
 
     teardown() {
       bus.off('ws:new_like', this.onNewLike)
+      bus.off('ws:update_like', this.onNewLike)
       bus.off('ws:new_match', this.onNewMatch)
       // Remove any other event listeners you may have added
       this.sent = []

--- a/apps/frontend/src/features/interaction/stores/useInteractionStore.ts
+++ b/apps/frontend/src/features/interaction/stores/useInteractionStore.ts
@@ -13,6 +13,7 @@ import {
   InteractionContextSchema,
   type InteractionContext,
 } from '@zod/interaction/interactionContext.dto'
+import type { InteractionContextResponse } from '@zod/apiResponse.dto'
 import { storeError, storeSuccess, type StoreError, type StoreResponse } from '@/store/helpers'
 
 interface InteractionState {
@@ -21,7 +22,7 @@ interface InteractionState {
   newMatchesCount: number
   matches: InteractionEdge[]
   passed: string[] // just IDs for now
-  contextByProfileId: Record<string, InteractionContext>
+  contextByProfileId: Partial<Record<string, InteractionContext>>
   loading: boolean
   initialized: boolean
   error: StoreError | null
@@ -57,7 +58,7 @@ export const useInteractionStore = defineStore('interaction', {
     async fetchContext(profileId: string): Promise<StoreResponse<InteractionContext>> {
       try {
         const res = await safeApiCall(() =>
-          api.get<{ success: true; context: unknown }>(`/interactions/context/${profileId}`)
+          api.get<InteractionContextResponse>(`/interactions/context/${profileId}`)
         )
         const context = InteractionContextSchema.parse(res.data.context)
         this.contextByProfileId[profileId] = context

--- a/apps/frontend/src/features/interaction/stores/useInteractionStore.ts
+++ b/apps/frontend/src/features/interaction/stores/useInteractionStore.ts
@@ -9,6 +9,10 @@ import {
   type InteractionEdgePair,
   type ReceivedLike,
 } from '@zod/interaction/interaction.dto'
+import {
+  InteractionContextSchema,
+  type InteractionContext,
+} from '@zod/interaction/interactionContext.dto'
 import { storeError, storeSuccess, type StoreError, type StoreResponse } from '@/store/helpers'
 
 interface InteractionState {
@@ -17,6 +21,7 @@ interface InteractionState {
   newMatchesCount: number
   matches: InteractionEdge[]
   passed: string[] // just IDs for now
+  contextByProfileId: Record<string, InteractionContext>
   loading: boolean
   initialized: boolean
   error: StoreError | null
@@ -29,6 +34,7 @@ export const useInteractionStore = defineStore('interaction', {
     newMatchesCount: 0,
     matches: [],
     passed: [],
+    contextByProfileId: {},
     loading: false,
     initialized: false,
     error: null,
@@ -42,6 +48,22 @@ export const useInteractionStore = defineStore('interaction', {
       if (edge.isMatch && !this.matches.some((e) => e.profile.id === edge.profile.id)) {
         this.matches.unshift(edge)
         this.newMatchesCount++
+      }
+    },
+
+    // Fetch the viewer's interaction context with a target profile.
+    // Cached on the store keyed by profileId so consumers can read it
+    // reactively after the first round-trip without re-issuing the request.
+    async fetchContext(profileId: string): Promise<StoreResponse<InteractionContext>> {
+      try {
+        const res = await safeApiCall(() =>
+          api.get<{ success: true; context: unknown }>(`/interactions/context/${profileId}`)
+        )
+        const context = InteractionContextSchema.parse(res.data.context)
+        this.contextByProfileId[profileId] = context
+        return storeSuccess(context)
+      } catch (error) {
+        return storeError(error)
       }
     },
 
@@ -85,6 +107,7 @@ export const useInteractionStore = defineStore('interaction', {
           this.sent.push(pair.to)
         }
 
+        await this.fetchContext(targetId)
         return storeSuccess(pair)
       } catch (error) {
         console.error('Failed to like profile:', error)
@@ -111,6 +134,7 @@ export const useInteractionStore = defineStore('interaction', {
           this.sent[sentIdx] = pair.from
         }
 
+        await this.fetchContext(targetId)
         return storeSuccess(pair)
       } catch (error) {
         console.error('Failed to update like:', error)
@@ -139,6 +163,7 @@ export const useInteractionStore = defineStore('interaction', {
         // Optionally: remove from sent/matches if previously liked
         this.sent = this.sent.filter((e) => e.profile.id !== targetId)
         this.matches = this.matches.filter((e) => e.profile.id !== targetId)
+        await this.fetchContext(targetId)
         return storeSuccess()
       } catch (error) {
         console.error('Failed to pass profile:', error)
@@ -173,6 +198,7 @@ export const useInteractionStore = defineStore('interaction', {
       this.receivedLikes = []
       this.matches = []
       this.passed = []
+      this.contextByProfileId = {}
       this.loading = false
       this.initialized = false
       this.error = null

--- a/apps/frontend/src/features/messaging/__tests__/SendMessageForm.spec.ts
+++ b/apps/frontend/src/features/messaging/__tests__/SendMessageForm.spec.ts
@@ -2,7 +2,7 @@ import { mount } from '@vue/test-utils'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { createPinia, setActivePinia } from 'pinia'
 import { ref } from 'vue'
-import type { PublicProfileWithContext } from '@zod/profile/profile.dto'
+import type { PublicProfile } from '@zod/profile/profile.dto'
 
 vi.mock('@/features/shared/profiledisplay/TagList.vue', () => ({
   default: { template: '<div />' },
@@ -40,7 +40,7 @@ describe('SendMessageForm', () => {
     localStorage.clear()
   })
 
-  const mockRecipient: PublicProfileWithContext = {
+  const mockRecipient: PublicProfile = {
     id: '123',
     publicName: 'Test User',
     isDatingActive: false,
@@ -55,20 +55,6 @@ describe('SendMessageForm', () => {
     },
     introSocial: '',
     introDating: '',
-    interactionContext: {
-      likedByMe: false,
-      likedMeRevealed: false,
-      isMatch: false,
-      isAnonymous: true,
-      passedByMe: false,
-      canLike: false,
-      canPass: false,
-      canDate: false,
-      haveConversation: false,
-      canMessage: true,
-      conversationId: null,
-      initiated: false,
-    },
   }
 
   it('defaults to "click" send mode', () => {

--- a/apps/frontend/src/features/messaging/components/ConversationDetail.vue
+++ b/apps/frontend/src/features/messaging/components/ConversationDetail.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { ref, computed, watchEffect } from 'vue'
 
-import type { PublicProfileWithContext } from '@zod/profile/profile.dto'
+import type { PublicProfile } from '@zod/profile/profile.dto'
 import type { ConversationSummary } from '@zod/messaging/messaging.dto'
 
 import ProfileContent from '@/features/publicprofile/components/ProfileContent.vue'
@@ -35,7 +35,7 @@ const router = useRouter()
 const panel = useDetailPanel()
 
 const showModal = ref(false)
-const conversationPartner = ref<PublicProfileWithContext | null>(null)
+const conversationPartner = ref<PublicProfile | null>(null)
 
 // Click on the conversation partner header → push their profile into the
 // global detail panel. The panel owns its own lifecycle; this component

--- a/apps/frontend/src/features/messaging/composables/useMessagingViewModel.ts
+++ b/apps/frontend/src/features/messaging/composables/useMessagingViewModel.ts
@@ -3,7 +3,7 @@ import { whenever } from '@vueuse/core'
 import { useRouter } from 'vue-router'
 
 import type { ConversationSummary } from '@zod/messaging/messaging.dto'
-import type { PublicProfileWithContext } from '@zod/profile/profile.dto'
+import type { PublicProfile } from '@zod/profile/profile.dto'
 
 import { useBootstrap } from '@/lib/bootstrap'
 import { useMessageStore } from '../stores/messageStore'
@@ -49,13 +49,11 @@ export function useMessagingViewModel() {
 
   // Send message dialog state
   const showMessageModal = ref(false)
-  const messageProfile = ref<PublicProfileWithContext>()
+  const messageProfile = ref<PublicProfile>()
 
   // Fetch a public profile by id. Returns the profile or null on failure.
   // Consumers decide what to do with the result (e.g. push into the detail panel).
-  const handleProfileSelect = async (
-    profileId: string
-  ): Promise<PublicProfileWithContext | null> => {
+  const handleProfileSelect = async (profileId: string): Promise<PublicProfile | null> => {
     const res = await fetchProfile(profileId)
     if (!res?.success) return null
     return res.data ?? null

--- a/apps/frontend/src/features/myprofile/composables/useMyProfileViewModel.ts
+++ b/apps/frontend/src/features/myprofile/composables/useMyProfileViewModel.ts
@@ -1,7 +1,7 @@
 import { useI18nStore } from '@/store/i18nStore'
 import { computed, reactive, toRef, watch } from 'vue'
 
-import { type PublicProfileWithContext } from '@zod/profile/profile.dto'
+import { type PublicProfile } from '@zod/profile/profile.dto'
 import { type EditFieldProfileFormWithImages } from '@zod/profile/profile.form'
 
 import { useOwnerProfileStore } from '@/features/myprofile/stores/ownerProfileStore'
@@ -20,12 +20,12 @@ export function useMyProfileViewModel(isEditMode: boolean) {
   })
 
   // computed properties
-  const publicProfile = reactive({} as PublicProfileWithContext)
-  const profilePreview = computed((): PublicProfileWithContext => {
+  const publicProfile = reactive({} as PublicProfile)
+  const profilePreview = computed((): PublicProfile => {
     return {
       ...publicProfile,
       isDatingActive: viewState.currentScope === 'dating',
-    } as PublicProfileWithContext
+    } as PublicProfile
   })
 
   const isDatingOnboarded = computed(() => {

--- a/apps/frontend/src/features/myprofile/stores/ownerProfileStore.ts
+++ b/apps/frontend/src/features/myprofile/stores/ownerProfileStore.ts
@@ -6,7 +6,6 @@ import type {
   ProfileOptInSettings,
   ProfileScope,
   PublicProfile,
-  PublicProfileWithContext,
   UpdateProfileOptInPayload,
   UpdateProfileScopePayload,
 } from '@zod/profile/profile.dto'
@@ -53,7 +52,7 @@ import {
   CreateProfileFormToPayloadTransform,
 } from '@zod/profile/profile.form'
 
-export type PublicProfileResponse = StoreResponse<PublicProfileWithContext> | StoreError
+export type PublicProfileResponse = StoreResponse<PublicProfile> | StoreError
 
 const defaultDatingPrefs = (): DatingPreferencesFormType => DatingPreferencesFormSchema.parse({})
 

--- a/apps/frontend/src/features/publicprofile/components/ImageCarousel.vue
+++ b/apps/frontend/src/features/publicprofile/components/ImageCarousel.vue
@@ -4,7 +4,7 @@ import { shallowRef, reactive, computed, watch } from 'vue'
 import { Carousel, Slide, Navigation, Pagination } from 'vue3-carousel'
 import 'vue3-carousel/dist/carousel.css'
 
-import { type PublicProfileWithContext } from '@zod/profile/profile.dto'
+import { type PublicProfile } from '@zod/profile/profile.dto'
 import IconCross from '@/assets/icons/interface/cross.svg'
 import ChevronLeftIcon from '@/assets/icons/arrows/arrow-single-left.svg'
 import ChevronRightIcon from '@/assets/icons/arrows/arrow-single-right.svg'
@@ -13,7 +13,7 @@ import BlurhashCanvas from '@/features/images/components/BlurhashCanvas.vue'
 import { blurhashToDataUrl } from '@/features/images/composables/useBlurhashDataUrl'
 
 const props = defineProps<{
-  profile: PublicProfileWithContext
+  profile: PublicProfile
 }>()
 
 const showFullscreen = shallowRef(false)

--- a/apps/frontend/src/features/publicprofile/components/ProfileContent.vue
+++ b/apps/frontend/src/features/publicprofile/components/ProfileContent.vue
@@ -2,7 +2,7 @@
 import { computed, inject, type Ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 
-import { type OwnerProfile, type PublicProfileWithContext } from '@zod/profile/profile.dto'
+import { type OwnerProfile, type PublicProfile } from '@zod/profile/profile.dto'
 
 import ImageCarousel from './ImageCarousel.vue'
 import IconPhoto from '@/assets/icons/interface/photo.svg'
@@ -23,7 +23,7 @@ import ImageEditor from '@/features/images/components/ImageEditor.vue'
 const { t } = useI18n()
 
 const props = defineProps<{
-  profile: PublicProfileWithContext
+  profile: PublicProfile
 }>()
 
 const viewerProfile = inject<Ref<OwnerProfile | null>>('viewerProfile')
@@ -31,7 +31,7 @@ const viewerLocation = computed(() => viewerProfile?.value?.location)
 </script>
 
 <template>
-  <div class="position-relative ">
+  <div class="position-relative">
     <div class="overflow-hidden carousel-wrapper">
       <ImageCarousel :profile />
     </div>

--- a/apps/frontend/src/features/publicprofile/components/PublicProfile.vue
+++ b/apps/frontend/src/features/publicprofile/components/PublicProfile.vue
@@ -1,12 +1,12 @@
 <script setup lang="ts">
 import { inject, type Ref } from 'vue'
-import type { OwnerProfile, PublicProfileWithContext } from '@zod/profile/profile.dto'
+import type { OwnerProfile, PublicProfile } from '@zod/profile/profile.dto'
 import ProfileInteractions from '@/features/interaction/components/ProfileInteractions.vue'
 import ProfileContent from '../components/ProfileContent.vue'
 import PublicProfileSecondaryNav from '../components/PublicProfileSecondaryNav.vue'
 
 const props = defineProps<{
-  profile: PublicProfileWithContext
+  profile: PublicProfile
 }>()
 
 const emit = defineEmits<{

--- a/apps/frontend/src/features/publicprofile/components/PublicProfile.vue
+++ b/apps/frontend/src/features/publicprofile/components/PublicProfile.vue
@@ -44,7 +44,6 @@ const viewerProfile = inject<Ref<OwnerProfile | null>>('viewerProfile')
         :profile="profile"
         @intent:message="(convoId: string) => emit('intent:message', convoId)"
         @updated="emit('updated')"
-        @passed="emit('updated')"
       />
     </div>
   </div>

--- a/apps/frontend/src/features/publicprofile/components/SendMessageDialog.vue
+++ b/apps/frontend/src/features/publicprofile/components/SendMessageDialog.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { nextTick, ref } from 'vue'
 
-import { type PublicProfileWithContext } from '@zod/profile/profile.dto'
+import { type PublicProfile } from '@zod/profile/profile.dto'
 
 import ProfileThumbnail from '@/features/images/components/ProfileThumbnail.vue'
 import ContactFormPanel from '@/features/messaging/components/ContactFormPanel.vue'
@@ -9,7 +9,7 @@ import ContactFormPanel from '@/features/messaging/components/ContactFormPanel.v
 const showModal = defineModel<boolean>()
 
 defineProps<{
-  profile: PublicProfileWithContext
+  profile: PublicProfile
 }>()
 
 const emit = defineEmits<{

--- a/apps/frontend/src/features/publicprofile/composables/usePublicProfile.ts
+++ b/apps/frontend/src/features/publicprofile/composables/usePublicProfile.ts
@@ -2,7 +2,7 @@ import { computed, reactive, ref } from 'vue'
 
 import { type StoreError } from '@/store/helpers'
 import { useOwnerProfileStore } from '@/features/myprofile/stores/ownerProfileStore'
-import { type PublicProfileWithContext } from '@zod/profile/profile.dto'
+import { type PublicProfile } from '@zod/profile/profile.dto'
 import { usePublicProfileStore } from '../stores/publicProfileStore'
 
 export function usePublicProfile() {
@@ -10,13 +10,13 @@ export function usePublicProfile() {
   const store = usePublicProfileStore()
 
   const id = ref<string | null>(null)
-  const profile = reactive<PublicProfileWithContext>({} as PublicProfileWithContext)
+  const profile = reactive<PublicProfile>({} as PublicProfile)
   const error = ref<StoreError | null>(null)
 
   const fetchProfile = async (profileId: string) => {
     // no profile ID, 404
     if (!profileId) {
-      Object.assign(profile, {} as PublicProfileWithContext)
+      Object.assign(profile, {} as PublicProfile)
       error.value = {
         success: false,
         message: 'Profile not found',
@@ -36,7 +36,7 @@ export function usePublicProfile() {
       Object.assign(profile, res.data)
       error.value = null
     } else {
-      Object.assign(profile, {} as PublicProfileWithContext)
+      Object.assign(profile, {} as PublicProfile)
       error.value = res
     }
     return res

--- a/apps/frontend/src/features/publicprofile/stores/publicProfileStore.ts
+++ b/apps/frontend/src/features/publicprofile/stores/publicProfileStore.ts
@@ -1,8 +1,8 @@
 import z from 'zod'
 import { defineStore } from 'pinia'
 import { api, safeApiCall } from '@/lib/api'
-import type { ProfileSummary, PublicProfileWithContext } from '@zod/profile/profile.dto'
-import { ProfileSummarySchema, PublicProfileWithContextSchema } from '@zod/profile/profile.dto'
+import type { ProfileSummary, PublicProfile } from '@zod/profile/profile.dto'
+import { ProfileSummarySchema, PublicProfileSchema } from '@zod/profile/profile.dto'
 import {
   storeSuccess,
   storeError,
@@ -14,7 +14,7 @@ import type { GetProfileSummariesResponse, GetPublicProfileResponse } from '@zod
 import { bus } from '@/lib/bus'
 
 type PublicProfileStoreState = {
-  profile: PublicProfileWithContext | null // Current public profile
+  profile: PublicProfile | null // Current public profile
   isLoading: boolean // Loading state
 }
 export const usePublicProfileStore = defineStore('publicProfile', {
@@ -25,13 +25,13 @@ export const usePublicProfileStore = defineStore('publicProfile', {
 
   actions: {
     // Fetch a profile by ID
-    async getPublicProfile(profileId: string): Promise<StoreResponse<PublicProfileWithContext>> {
+    async getPublicProfile(profileId: string): Promise<StoreResponse<PublicProfile>> {
       try {
         this.isLoading = true // Set loading state
         const res = await safeApiCall(() =>
           api.get<GetPublicProfileResponse>(`/profiles/${profileId}`)
         )
-        const fetched = PublicProfileWithContextSchema.parse(res.data.profile)
+        const fetched = PublicProfileSchema.parse(res.data.profile)
         this.profile = fetched
         return storeSuccess(fetched)
       } catch (error: any) {

--- a/apps/frontend/src/features/shared/composables/useDatingFields.ts
+++ b/apps/frontend/src/features/shared/composables/useDatingFields.ts
@@ -1,8 +1,4 @@
-import {
-  type OwnerProfile,
-  type PublicProfile,
-  type PublicProfileWithContext,
-} from '@zod/profile/profile.dto'
+import { type OwnerProfile, type PublicProfile } from '@zod/profile/profile.dto'
 import { computed, h, type Ref } from 'vue'
 import { useEnumOptions } from './useEnumOptions'
 

--- a/apps/frontend/src/features/shared/profiledisplay/DatingFilter.vue
+++ b/apps/frontend/src/features/shared/profiledisplay/DatingFilter.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
-import { type PublicProfileWithContext } from '@zod/profile/profile.dto'
+import { type PublicProfile } from '@zod/profile/profile.dto'
 
 // Props & Emits
 const props = defineProps<{
-  profile: PublicProfileWithContext
+  profile: PublicProfile
 }>()
 </script>
 

--- a/apps/frontend/src/features/shared/profiledisplay/GenderPronounLabel.vue
+++ b/apps/frontend/src/features/shared/profiledisplay/GenderPronounLabel.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { type PublicProfileWithContext } from '@zod/profile/profile.dto'
+import { type PublicProfile } from '@zod/profile/profile.dto'
 import { useDatingFields } from '@/features/shared/composables/useDatingFields'
 import { useI18n } from 'vue-i18n'
 import EditField from '@/features/myprofile/components/EditField.vue'
@@ -11,7 +11,7 @@ import { toRef } from 'vue'
 const { t } = useI18n()
 
 const props = defineProps<{
-  profile: PublicProfileWithContext
+  profile: PublicProfile
 }>()
 
 const profileRef = toRef(props, 'profile')

--- a/apps/frontend/src/features/shared/profiledisplay/RelationshipTags.vue
+++ b/apps/frontend/src/features/shared/profiledisplay/RelationshipTags.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { type PublicProfileWithContext } from '@zod/profile/profile.dto'
+import { type PublicProfile } from '@zod/profile/profile.dto'
 import { useDatingFields } from '@/features/shared/composables/useDatingFields'
 import { useI18n } from 'vue-i18n'
 
@@ -11,7 +11,7 @@ import { toRef } from 'vue'
 const { t } = useI18n()
 
 const props = defineProps<{
-  profile: PublicProfileWithContext
+  profile: PublicProfile
 }>()
 const profileRef = toRef(props, 'profile')
 const { relationshipStatus, hasKids } = useDatingFields(profileRef, t)

--- a/apps/frontend/src/lib/websocket.ts
+++ b/apps/frontend/src/lib/websocket.ts
@@ -72,6 +72,9 @@ export async function connectWebSocket(): Promise<void> {
           case 'ws:new_like':
             bus.emit('ws:new_like')
             break
+          case 'ws:update_like':
+            bus.emit('ws:update_like')
+            break
           case 'ws:new_message':
           case 'ws:new_match':
           case 'ws:app_notification':

--- a/apps/frontend/src/types/wsBusEvents.ts
+++ b/apps/frontend/src/types/wsBusEvents.ts
@@ -4,6 +4,7 @@ import type { InteractionEdge } from '@zod/interaction/interaction.dto'
 export type WSEvents = {
   'ws:new_message': MessageDTO
   'ws:new_like': void
+  'ws:update_like': void
   'ws:new_match': InteractionEdge
   'ws:app_notification': { title: string; body: string }
   'ws:incoming_call': {

--- a/packages/shared/zod/apiResponse.dto.ts
+++ b/packages/shared/zod/apiResponse.dto.ts
@@ -12,8 +12,9 @@ import type {
   OwnerProfile,
   ProfileOptInSettings,
   ProfileSummary,
-  PublicProfileWithContext,
+  PublicProfile,
 } from '@zod/profile/profile.dto'
+import type { InteractionContext } from '@zod/interaction/interactionContext.dto'
 import type { PublicTag, PopularTag } from '@zod/tag/tag.dto'
 import type { ConversationSummary, MessageDTO } from '@zod/messaging/messaging.dto'
 import type { LoginUser, SettingsUser } from '@zod/user/user.dto'
@@ -42,8 +43,8 @@ export type UpdateDatingPreferencesResponse = ApiSuccess<{ prefs: DatingPreferen
 
 export type GetMyProfileResponse = ApiSuccess<{ profile: OwnerProfile }>
 export type GetProfileOptInResponse = ApiSuccess<{ optIn: ProfileOptInSettings }>
-export type GetPublicProfileResponse = ApiSuccess<{ profile: PublicProfileWithContext }>
-export type GetProfilesResponse = ApiSuccess<{ profiles: PublicProfileWithContext[] }>
+export type GetPublicProfileResponse = ApiSuccess<{ profile: PublicProfile }>
+export type GetProfilesResponse = ApiSuccess<{ profiles: PublicProfile[] }>
 export type UpdateProfileResponse = ApiSuccess<{ profile: OwnerProfile }>
 export type UpdateProfileScopeResponse = ApiSuccess<{
   isDatingActive: boolean
@@ -78,6 +79,7 @@ export type ReceivedLikesResponse = ApiSuccess<{ edges: ReceivedLike[] }>
 export type InteractionEdgeResponse = ApiSuccess<{ pair: InteractionEdgePair }>
 export type InteractionEdgeCountResponse = ApiSuccess<{ count: number }>
 export type InteractionStatsResponse = ApiSuccess<{ stats: InteractionStats }>
+export type InteractionContextResponse = ApiSuccess<{ context: InteractionContext }>
 
 export type AuthResponse<T> = ApiSuccess<T> | (ApiError & { code: AuthErrorCodes })
 export type GetUserSettingsResponse = ApiSuccess<{ user: SettingsUser }>
@@ -107,7 +109,7 @@ export type DeletePostResponse = ApiSuccess<{}>
 
 // Browse responses
 export type BrowseBoundsResponse = ApiSuccess<{
-  profiles: PublicProfileWithContext[]
+  profiles: PublicProfile[]
   posts: PublicPostWithProfile[]
   tags: PublicTag[]
 }>

--- a/packages/shared/zod/dto/websocket.dto.ts
+++ b/packages/shared/zod/dto/websocket.dto.ts
@@ -1,12 +1,20 @@
-import { type InteractionEdge } from "../interaction/interaction.dto";
-import { type MessageDTO } from "../messaging/messaging.dto";
+import { type InteractionEdge } from '../interaction/interaction.dto'
+import { type MessageDTO } from '../messaging/messaging.dto'
 
 export type WSMessage =
   | { type: 'ws:new_message'; payload: MessageDTO }
   | { type: 'ws:new_like'; payload: InteractionEdge }
+  | { type: 'ws:update_like'; payload?: InteractionEdge }
   | { type: 'ws:new_match'; payload: InteractionEdge }
   | { type: 'ws:app_notification'; payload: { title: string; body: string } }
-  | { type: 'ws:incoming_call'; payload: { conversationId: string; roomName: string; caller: { id: string; publicName: string } } }
+  | {
+      type: 'ws:incoming_call'
+      payload: {
+        conversationId: string
+        roomName: string
+        caller: { id: string; publicName: string }
+      }
+    }
   | { type: 'ws:call_accepted'; payload: { conversationId: string; roomName: string } }
   | { type: 'ws:call_declined'; payload: { conversationId: string } }
   | { type: 'ws:call_cancelled'; payload: { conversationId: string } }

--- a/packages/shared/zod/profile/profile.dto.ts
+++ b/packages/shared/zod/profile/profile.dto.ts
@@ -15,7 +15,6 @@ import {
   profileOptInFields,
   userOptInFields,
 } from './profile.fields'
-import { InteractionContextSchema } from '@zod/interaction/interactionContext.dto'
 
 const PublicScalarsSchema = ProfileSchema.pick({
   ...baseFields,
@@ -50,19 +49,7 @@ export const PublicProfileSchema = ProfileUnionSchema.and(
 )
 export type PublicProfile = z.infer<typeof PublicProfileSchema>
 
-export const PublicProfileWithContextSchema = ProfileUnionSchema.and(
-  z.object({
-    location: LocationSchema,
-    profileImages: z.array(PublicProfileImageSchema).default([]),
-    tags: z.array(PublicTagSchema).default([]),
-    introSocial: z.string().default(''),
-    introDating: z.string().default(''),
-    interactionContext: InteractionContextSchema,
-  })
-)
 export const PublicProfileArraySchema = z.array(PublicProfileSchema)
-
-export type PublicProfileWithContext = z.infer<typeof PublicProfileWithContextSchema>
 
 export const OwnerScalarsSchema = ProfileSchema.pick({
   ...baseFields,
@@ -83,7 +70,7 @@ export const OwnerProfileSchema = OwnerScalarsSchema.extend({
 })
 export type OwnerProfile = z.infer<typeof OwnerProfileSchema>
 
-export type OwnerOrPublicProfile = OwnerProfile | PublicProfileWithContext
+export type OwnerOrPublicProfile = OwnerProfile | PublicProfile
 
 export const editableFields = {
   ...socialFields,


### PR DESCRIPTION
## Summary

- New `GET /interactions/context/:targetId` returns the viewer's interaction state with a target profile (conversation + dating context). Owned by `useInteractionStore` on the frontend via a new `contextByProfileId` map and `fetchContext` action; like/pass/updateLike auto-refetch.
- `PublicProfileWithContext` DTO is deleted — `interactionContext` is no longer a field on the profile shape. `GET /profiles/:id` returns plain `PublicProfile`. All ~16 frontend importers updated.
- `ProfileService` split into `getProfilePublicById` (no viewer joins) and `getInteractionContextSourceById` (viewer joins only) — smaller, single-purpose queries.

## Why

The profile DTO previously coupled viewer-relative state into a viewer-agnostic shape, forcing the `viewerProfileId` parameter all the way down through the mapper and producing the awkward `PublicProfileWithContext` hybrid type. Splitting on the `ConversationContext + DatingContext = InteractionContext` seam (which already existed in the schema) lets the interaction store own all viewer↔target state cleanly, while the profile fetch becomes simpler and cacheable.

## Test plan

- [x] `pnpm --filter backend type-check` — clean
- [x] `pnpm --filter frontend type-check` — clean (pre-existing BButton variant errors in `InteractionButtons.vue`/`AnonymousToggle.vue` predate this branch)
- [x] `vitest run` on directly-affected specs: `SendMessageForm`, `useInteractionStore`, `interaction.mappers`, `profile.route` — 50/50 pass
- [ ] Manual: open `/profile/:id`, verify like/pass/message buttons render and behave correctly after the extra round-trip
- [ ] Manual: trigger a match — verify `MatchPopup` shows the contact form (gated on `context?.canMessage`)

## Notes for reviewer

- `ContactFormPanel` reads `recipientProfile.initiated/canMessage/conversationId` but its callers pass profiles that never had those fields at the top level — `isWaitingForReply` has been silently `false`. Pre-existing bug, not addressed here.
- The new endpoint adds one network round-trip on the public profile page; the action buttons are simply absent (`v-if="context"`) until it lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)