### PR TITLE
Redesign admin dashboard with uniform KPI cards and mini charts

### DIFF
--- a/.changeset/admin-dashboard-redesign.md
+++ b/.changeset/admin-dashboard-redesign.md
@@ -1,0 +1,9 @@
+---
+'@opencupid/admin': minor
+'@opencupid/backend': minor
+---
+
+Redesign admin dashboard with uniform KPI + mini-chart cards. Removes the
+unused Total Users / Total Profiles tiles and folds the standalone Daily
+Signups / Daily Active bar charts into the KPI cards. Adds daily series for
+blocked users and reported profiles to `/admin/stats/daily`.

--- a/apps/admin/src/components/KpiCard.vue
+++ b/apps/admin/src/components/KpiCard.vue
@@ -38,15 +38,17 @@ const bars = computed(() => {
 
 <template>
   <div class="card kpi-card h-100">
-    <div class="card-body d-flex flex-column">
-      <h6 class="card-title mb-1">{{ title }}</h6>
-      <h6 class="card-subtitle mb-2 text-body-secondary small">
-        {{ subtitle || '\xa0' }}
-      </h6>
-      <div class="kpi-value">{{ value }}</div>
+    <div class="card-body kpi-body">
+      <div class="kpi-text">
+        <h6 class="card-title mb-0">{{ title }}</h6>
+        <div class="kpi-subtitle text-body-secondary">
+          {{ subtitle || '\xa0' }}
+        </div>
+        <div class="kpi-value">{{ value }}</div>
+      </div>
       <div
         v-if="series.length"
-        class="kpi-spark mt-auto"
+        class="kpi-spark"
       >
         <svg
           :viewBox="`0 0 ${VIEW_W} ${VIEW_H}`"
@@ -71,19 +73,34 @@ const bars = computed(() => {
 </template>
 
 <style scoped>
-.kpi-card {
-  min-height: 8rem;
+.kpi-body {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  align-items: end;
+  gap: 0.75rem;
+  padding: 0.75rem 1rem;
+}
+
+.kpi-text {
+  min-width: 0;
+}
+
+.kpi-subtitle {
+  font-size: 0.75rem;
+  line-height: 1.2;
+  margin-bottom: 0.25rem;
 }
 
 .kpi-value {
-  font-size: 1.75rem;
+  font-size: 1.5rem;
   font-weight: 700;
-  line-height: 1.2;
+  line-height: 1.1;
 }
 
 .kpi-spark {
-  height: 2.5rem;
+  height: 2.25rem;
   width: 100%;
+  justify-self: end;
 }
 
 .kpi-spark svg {

--- a/apps/admin/src/components/KpiCard.vue
+++ b/apps/admin/src/components/KpiCard.vue
@@ -1,0 +1,94 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+
+interface Props {
+  title: string
+  subtitle?: string
+  value: number | string
+  series?: number[]
+  color?: string
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  subtitle: '',
+  series: () => [],
+  color: '#0d6efd',
+})
+
+const VIEW_W = 100
+const VIEW_H = 32
+const GAP_RATIO = 0.25
+
+const bars = computed(() => {
+  if (!props.series.length) return []
+  const max = Math.max(1, ...props.series)
+  const slot = VIEW_W / props.series.length
+  const barW = slot * (1 - GAP_RATIO)
+  return props.series.map((v, i) => {
+    const h = (v / max) * VIEW_H
+    return {
+      x: i * slot + (slot - barW) / 2,
+      y: VIEW_H - h,
+      width: barW,
+      height: h,
+    }
+  })
+})
+</script>
+
+<template>
+  <div class="card kpi-card h-100">
+    <div class="card-body d-flex flex-column">
+      <h6 class="card-title mb-1">{{ title }}</h6>
+      <h6 class="card-subtitle mb-2 text-body-secondary small">
+        {{ subtitle || '\xa0' }}
+      </h6>
+      <div class="kpi-value">{{ value }}</div>
+      <div
+        v-if="series.length"
+        class="kpi-spark mt-auto"
+      >
+        <svg
+          :viewBox="`0 0 ${VIEW_W} ${VIEW_H}`"
+          preserveAspectRatio="none"
+          aria-hidden="true"
+          role="presentation"
+        >
+          <rect
+            v-for="(bar, i) in bars"
+            :key="i"
+            :x="bar.x"
+            :y="bar.y"
+            :width="bar.width"
+            :height="bar.height"
+            :fill="color"
+            rx="0.5"
+          />
+        </svg>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.kpi-card {
+  min-height: 8rem;
+}
+
+.kpi-value {
+  font-size: 1.75rem;
+  font-weight: 700;
+  line-height: 1.2;
+}
+
+.kpi-spark {
+  height: 2.5rem;
+  width: 100%;
+}
+
+.kpi-spark svg {
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+</style>

--- a/apps/admin/src/components/KpiCard.vue
+++ b/apps/admin/src/components/KpiCard.vue
@@ -37,10 +37,10 @@ const bars = computed(() => {
 </script>
 
 <template>
-  <div class="card kpi-card h-100">
+  <div class="card kpi-card h-100 pt-3">
     <div class="card-body kpi-body">
-      <div class="kpi-text">
-        <h6 class="card-title mb-0">{{ title }}</h6>
+      <div class="kpi-text w-100">
+        <h6 class="card-title mb-1 ">{{ title }}</h6>
         <div class="kpi-subtitle text-body-secondary">
           {{ subtitle || '\xa0' }}
         </div>
@@ -73,16 +73,17 @@ const bars = computed(() => {
 </template>
 
 <style scoped>
-.kpi-body {
+.card-body.kpi-body {
   display: grid;
   grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
   align-items: end;
   gap: 0.75rem;
-  padding: 0.75rem 1rem;
+  padding: 0;
 }
 
 .kpi-text {
   min-width: 0;
+  margin: 0 0.5rem 0.5rem 1rem;
 }
 
 .kpi-subtitle {
@@ -98,9 +99,10 @@ const bars = computed(() => {
 }
 
 .kpi-spark {
-  height: 2.25rem;
+  height: 80%;
   width: 100%;
   justify-self: end;
+  background: var(--bs-secondary-light);
 }
 
 .kpi-spark svg {

--- a/apps/admin/src/pages/DashboardPage.vue
+++ b/apps/admin/src/pages/DashboardPage.vue
@@ -143,7 +143,7 @@ onMounted(async () => {
         color="#dc3545"
       />
       <KpiCard
-        title="Reported Profiles"
+        title="Reported"
         subtitle="Total"
         :value="stats.reportedProfiles"
         :series="series(dailyStats?.dailyReportedProfiles)"

--- a/apps/admin/src/pages/DashboardPage.vue
+++ b/apps/admin/src/pages/DashboardPage.vue
@@ -170,18 +170,23 @@ onMounted(async () => {
         :series="series(dailyStats?.dailyMessages)"
         color="#fd7e14"
       />
-      <div
-        v-if="stats.segmentCounts?.length"
-        class="card h-100"
-      >
-        <div class="card-body d-flex flex-column">
-          <h6 class="card-title mb-1">Activity Segments</h6>
-          <h6 class="card-subtitle mb-2 text-body-secondary small">Current</h6>
-          <div class="segment-chart flex-grow-1">
-            <Pie
-              :data="segmentPieData"
-              :options="pieOptions"
-            />
+    </div>
+
+    <div
+      v-if="stats?.segmentCounts?.length"
+      class="row g-3 mt-3"
+    >
+      <div class="col-md-6 col-lg-4">
+        <div class="card">
+          <div class="card-body">
+            <h6 class="card-title mb-1">Activity Segments</h6>
+            <h6 class="card-subtitle mb-2 text-body-secondary small">Current</h6>
+            <div class="segment-chart">
+              <Pie
+                :data="segmentPieData"
+                :options="pieOptions"
+              />
+            </div>
           </div>
         </div>
       </div>
@@ -193,8 +198,7 @@ onMounted(async () => {
 .kpi-grid {
   display: grid;
   grid-template-columns: 1fr;
-  grid-auto-rows: 1fr;
-  gap: 1rem;
+  gap: 0.75rem;
 }
 
 @media (min-width: 576px) {
@@ -210,6 +214,6 @@ onMounted(async () => {
 }
 
 .segment-chart {
-  min-height: 10rem;
+  height: 14rem;
 }
 </style>

--- a/apps/admin/src/pages/DashboardPage.vue
+++ b/apps/admin/src/pages/DashboardPage.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
-import { ref, onMounted } from 'vue'
+import { computed, ref, onMounted } from 'vue'
 import { useApi } from '../composables/useApi'
-import { Bar, Pie } from 'vue-chartjs'
+import { Pie } from 'vue-chartjs'
 import {
   Chart as ChartJS,
   BarElement,
@@ -11,6 +11,7 @@ import {
   Legend,
   ArcElement,
 } from 'chart.js'
+import KpiCard from '../components/KpiCard.vue'
 
 ChartJS.register(BarElement, CategoryScale, LinearScale, Tooltip, Legend, ArcElement)
 
@@ -20,8 +21,6 @@ interface SegmentCount {
 }
 
 interface Stats {
-  totalUsers: number
-  totalProfiles: number
   activeProfiles: number
   recentSignups: number
   blockedUsers: number
@@ -38,6 +37,8 @@ interface DailyStats {
   success: boolean
   dailySignups: DailyEntry[]
   dailyLastSeen: DailyEntry[]
+  dailyBlockedUsers: DailyEntry[]
+  dailyReportedProfiles: DailyEntry[]
   dailyInteractions: DailyEntry[]
   dailyMatches: DailyEntry[]
   dailyMessages: DailyEntry[]
@@ -47,27 +48,20 @@ const { call, loading, error } = useApi()
 const stats = ref<Stats | null>(null)
 const dailyStats = ref<DailyStats | null>(null)
 
-const chartOptions = {
-  responsive: true,
-  maintainAspectRatio: false,
-  plugins: { legend: { display: false } },
-  scales: {
-    y: { beginAtZero: true, ticks: { stepSize: 1 } },
-  },
-}
+const series = (rows: DailyEntry[] | undefined) => (rows ? rows.map((r) => r.count) : [])
 
-function buildChartData(entries: DailyEntry[], color: string) {
-  return {
-    labels: entries.map((e) => e.date.slice(5)), // "MM-DD"
-    datasets: [
-      {
-        data: entries.map((e) => e.count),
-        backgroundColor: color,
-        borderRadius: 4,
-      },
-    ],
-  }
-}
+const dailyActiveTotal = computed(() =>
+  (dailyStats.value?.dailyLastSeen ?? []).reduce((sum, r) => sum + r.count, 0)
+)
+const interactionsTotal = computed(() =>
+  (dailyStats.value?.dailyInteractions ?? []).reduce((sum, r) => sum + r.count, 0)
+)
+const matchesTotal = computed(() =>
+  (dailyStats.value?.dailyMatches ?? []).reduce((sum, r) => sum + r.count, 0)
+)
+const messagesTotal = computed(() =>
+  (dailyStats.value?.dailyMessages ?? []).reduce((sum, r) => sum + r.count, 0)
+)
 
 const segmentColorMap: Record<string, string> = {
   new: '#0d6efd',
@@ -82,7 +76,8 @@ const pieOptions = {
   plugins: { legend: { position: 'bottom' as const } },
 }
 
-function buildSegmentPieData(counts: SegmentCount[]) {
+const segmentPieData = computed(() => {
+  const counts = stats.value?.segmentCounts ?? []
   return {
     labels: counts.map((c) => c.segment),
     datasets: [
@@ -92,7 +87,7 @@ function buildSegmentPieData(counts: SegmentCount[]) {
       },
     ],
   }
-}
+})
 
 onMounted(async () => {
   const [statsRes, dailyRes] = await Promise.all([
@@ -126,144 +121,67 @@ onMounted(async () => {
       v-if="stats"
       class="kpi-grid"
     >
-      <div class="card kpi-card">
-        <div class="card-body">
-          <h6 class="card-title">Total Users</h6>
-          <h6 class="card-subtitle mb-2 text-body-secondary">&nbsp;</h6>
-          <div class="kpi-value">{{ stats.totalUsers }}</div>
-        </div>
-      </div>
-      <div class="card kpi-card">
-        <div class="card-body">
-          <h6 class="card-title">Total Profiles</h6>
-          <h6 class="card-subtitle mb-2 text-body-secondary">&nbsp;</h6>
-          <div class="kpi-value">{{ stats.totalProfiles }}</div>
-        </div>
-      </div>
-      <div class="card kpi-card">
-        <div class="card-body">
-          <h6 class="card-title">Active Profiles</h6>
-          <h6 class="card-subtitle mb-2 text-body-secondary">&nbsp;</h6>
-          <div class="kpi-value">{{ stats.activeProfiles }}</div>
-        </div>
-      </div>
-      <div class="card kpi-card">
-        <div class="card-body">
-          <h6 class="card-title">Signups</h6>
-          <h6 class="card-subtitle mb-2 text-body-secondary">Last 7 Days</h6>
-          <div class="kpi-value">{{ stats.recentSignups }}</div>
-        </div>
-      </div>
-      <div class="card kpi-card">
-        <div class="card-body">
-          <h6 class="card-title">Blocked Users</h6>
-          <h6 class="card-subtitle mb-2 text-body-secondary">&nbsp;</h6>
-          <div class="kpi-value">{{ stats.blockedUsers }}</div>
-        </div>
-      </div>
-      <div class="card kpi-card">
-        <div class="card-body">
-          <h6 class="card-title">Reported Profiles</h6>
-          <h6 class="card-subtitle mb-2 text-body-secondary">&nbsp;</h6>
-          <div class="kpi-value">{{ stats.reportedProfiles }}</div>
-        </div>
-      </div>
-    </div>
-
-    <div
-      v-if="dailyStats || stats?.segmentCounts?.length"
-      class="row g-3 mt-2"
-    >
+      <KpiCard
+        title="Signups"
+        subtitle="Last 7 Days"
+        :value="stats.recentSignups"
+        :series="series(dailyStats?.dailySignups)"
+        color="#0d6efd"
+      />
+      <KpiCard
+        title="Daily Active"
+        subtitle="Last 7 Days"
+        :value="dailyActiveTotal"
+        :series="series(dailyStats?.dailyLastSeen)"
+        color="#198754"
+      />
+      <KpiCard
+        title="Blocked Users"
+        subtitle="Total"
+        :value="stats.blockedUsers"
+        :series="series(dailyStats?.dailyBlockedUsers)"
+        color="#dc3545"
+      />
+      <KpiCard
+        title="Reported Profiles"
+        subtitle="Total"
+        :value="stats.reportedProfiles"
+        :series="series(dailyStats?.dailyReportedProfiles)"
+        color="#fd7e14"
+      />
+      <KpiCard
+        title="Interactions"
+        subtitle="Last 7 Days"
+        :value="interactionsTotal"
+        :series="series(dailyStats?.dailyInteractions)"
+        color="#6f42c1"
+      />
+      <KpiCard
+        title="Matches"
+        subtitle="Last 7 Days"
+        :value="matchesTotal"
+        :series="series(dailyStats?.dailyMatches)"
+        color="#d63384"
+      />
+      <KpiCard
+        title="Messages"
+        subtitle="Last 7 Days"
+        :value="messagesTotal"
+        :series="series(dailyStats?.dailyMessages)"
+        color="#fd7e14"
+      />
       <div
-        v-if="dailyStats"
-        class="col-md-4"
+        v-if="stats.segmentCounts?.length"
+        class="card h-100"
       >
-        <div class="card h-100">
-          <div class="card-body">
-            <h6 class="card-title mb-3">Daily Signups (Last 7 Days)</h6>
-            <div style="height: 250px">
-              <Bar
-                :data="buildChartData(dailyStats.dailySignups, '#0d6efd')"
-                :options="chartOptions"
-              />
-            </div>
-          </div>
-        </div>
-      </div>
-      <div
-        v-if="dailyStats"
-        class="col-md-4"
-      >
-        <div class="card h-100">
-          <div class="card-body">
-            <h6 class="card-title mb-3">Daily Active (Last 7 Days)</h6>
-            <div style="height: 250px">
-              <Bar
-                :data="buildChartData(dailyStats.dailyLastSeen, '#198754')"
-                :options="chartOptions"
-              />
-            </div>
-          </div>
-        </div>
-      </div>
-      <div
-        v-if="stats?.segmentCounts?.length"
-        class="col-md-4"
-      >
-        <div class="card h-100">
-          <div class="card-body">
-            <h6 class="card-title mb-3">Activity Segments</h6>
-            <div style="height: 250px">
-              <Pie
-                :data="buildSegmentPieData(stats.segmentCounts)"
-                :options="pieOptions"
-              />
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-
-    <div
-      v-if="dailyStats"
-      class="row g-3 mt-2"
-    >
-      <div class="col-md-4">
-        <div class="card h-100">
-          <div class="card-body">
-            <h6 class="card-title mb-3">Interactions (Last 7 Days)</h6>
-            <div style="height: 250px">
-              <Bar
-                :data="buildChartData(dailyStats.dailyInteractions, '#6f42c1')"
-                :options="chartOptions"
-              />
-            </div>
-          </div>
-        </div>
-      </div>
-      <div class="col-md-4">
-        <div class="card h-100">
-          <div class="card-body">
-            <h6 class="card-title mb-3">Matches (Last 7 Days)</h6>
-            <div style="height: 250px">
-              <Bar
-                :data="buildChartData(dailyStats.dailyMatches, '#d63384')"
-                :options="chartOptions"
-              />
-            </div>
-          </div>
-        </div>
-      </div>
-      <div class="col-md-4">
-        <div class="card h-100">
-          <div class="card-body">
-            <h6 class="card-title mb-3">Messages (Last 7 Days)</h6>
-            <div style="height: 250px">
-              <Bar
-                :data="buildChartData(dailyStats.dailyMessages, '#fd7e14')"
-                :options="chartOptions"
-              />
-            </div>
+        <div class="card-body d-flex flex-column">
+          <h6 class="card-title mb-1">Activity Segments</h6>
+          <h6 class="card-subtitle mb-2 text-body-secondary small">Current</h6>
+          <div class="segment-chart flex-grow-1">
+            <Pie
+              :data="segmentPieData"
+              :options="pieOptions"
+            />
           </div>
         </div>
       </div>
@@ -274,14 +192,24 @@ onMounted(async () => {
 <style scoped>
 .kpi-grid {
   display: grid;
-  grid-template-columns: repeat(2, 1fr);
+  grid-template-columns: 1fr;
   grid-auto-rows: 1fr;
   gap: 1rem;
 }
 
+@media (min-width: 576px) {
+  .kpi-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
 @media (min-width: 992px) {
   .kpi-grid {
-    grid-template-columns: repeat(3, 1fr);
+    grid-template-columns: repeat(4, 1fr);
   }
+}
+
+.segment-chart {
+  min-height: 10rem;
 }
 </style>

--- a/apps/admin/src/pages/__tests__/DashboardPage.spec.ts
+++ b/apps/admin/src/pages/__tests__/DashboardPage.spec.ts
@@ -1,0 +1,113 @@
+import { mount, flushPromises } from '@vue/test-utils'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { ref } from 'vue'
+
+const useApiCall = vi.fn()
+vi.mock('../../composables/useApi', () => ({
+  useApi: () => ({
+    call: useApiCall,
+    loading: ref(false),
+    error: ref<string | null>(null),
+  }),
+}))
+
+// vue-chartjs renders a <canvas> via Chart.js which jsdom can't paint.
+// Stub the Pie wrapper so the component tree mounts without canvas calls.
+vi.mock('vue-chartjs', () => ({
+  Pie: { name: 'Pie', template: '<div data-test="pie-chart" />' },
+}))
+
+import DashboardPage from '../DashboardPage.vue'
+
+const stats = {
+  activeProfiles: 80,
+  recentSignups: 5,
+  blockedUsers: 2,
+  reportedProfiles: 3,
+  segmentCounts: [
+    { segment: 'new', count: 10 },
+    { segment: 'returning', count: 30 },
+  ],
+}
+
+const dailyStats = {
+  success: true,
+  dailySignups: [
+    { date: '2026-04-29', count: 1 },
+    { date: '2026-04-30', count: 3 },
+    { date: '2026-05-01', count: 2 },
+  ],
+  dailyLastSeen: [
+    { date: '2026-04-29', count: 1 },
+    { date: '2026-04-30', count: 3 },
+    { date: '2026-05-01', count: 5 },
+  ],
+  dailyBlockedUsers: [{ date: '2026-04-30', count: 1 }],
+  dailyReportedProfiles: [{ date: '2026-04-30', count: 1 }],
+  dailyInteractions: [{ date: '2026-04-30', count: 4 }],
+  dailyMatches: [{ date: '2026-04-30', count: 2 }],
+  dailyMessages: [
+    { date: '2026-04-30', count: 7 },
+    { date: '2026-05-01', count: 8 },
+  ],
+}
+
+describe('DashboardPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    useApiCall.mockImplementation((path: string) => {
+      if (path === '/admin/stats') return Promise.resolve({ success: true, stats })
+      if (path === '/admin/stats/daily') return Promise.resolve(dailyStats)
+      return Promise.resolve(null)
+    })
+  })
+
+  it('renders uniform KPI cards (no Total Users / Total Profiles)', async () => {
+    const wrapper = mount(DashboardPage)
+    await flushPromises()
+
+    const text = wrapper.text()
+    expect(text).not.toContain('Total Users')
+    expect(text).not.toContain('Total Profiles')
+
+    for (const title of [
+      'Signups',
+      'Daily Active',
+      'Blocked Users',
+      'Reported Profiles',
+      'Interactions',
+      'Matches',
+      'Messages',
+      'Activity Segments',
+    ]) {
+      expect(text).toContain(title)
+    }
+  })
+
+  it('shows the 7-day total as the KPI value for activity series', async () => {
+    const wrapper = mount(DashboardPage)
+    await flushPromises()
+
+    const html = wrapper.html()
+    // Daily Active KPI = 1 + 3 + 5 = 9
+    expect(html).toMatch(/Daily Active[\s\S]*?>\s*9\s*</)
+    // Messages KPI = 7 + 8 = 15
+    expect(html).toMatch(/Messages[\s\S]*?>\s*15\s*</)
+  })
+
+  it('renders an SVG mini bar chart for each KPI series', async () => {
+    const wrapper = mount(DashboardPage)
+    await flushPromises()
+
+    // 7 KPI cards × 1 svg each
+    const svgs = wrapper.findAll('.kpi-spark svg')
+    expect(svgs.length).toBe(7)
+  })
+
+  it('renders the activity segments pie chart', async () => {
+    const wrapper = mount(DashboardPage)
+    await flushPromises()
+
+    expect(wrapper.find('[data-test="pie-chart"]').exists()).toBe(true)
+  })
+})

--- a/apps/backend/src/__tests__/routes/admin.route.spec.ts
+++ b/apps/backend/src/__tests__/routes/admin.route.spec.ts
@@ -168,11 +168,9 @@ afterEach(() => {
 describe('GET /stats', () => {
   it('returns dashboard stats', async () => {
     mockPrisma.user.count
-      .mockResolvedValueOnce(100) // totalUsers
       .mockResolvedValueOnce(5) // recentSignups
       .mockResolvedValueOnce(2) // blockedUsers
     mockPrisma.profile.count
-      .mockResolvedValueOnce(90) // totalProfiles
       .mockResolvedValueOnce(80) // activeProfiles
       .mockResolvedValueOnce(3) // reportedProfiles
     mockPrisma.profileActivitySummary.groupBy.mockResolvedValueOnce([
@@ -188,8 +186,6 @@ describe('GET /stats', () => {
     expect(reply.statusCode).toBe(200)
     expect(reply.payload.success).toBe(true)
     expect(reply.payload.stats).toEqual({
-      totalUsers: 100,
-      totalProfiles: 90,
       activeProfiles: 80,
       recentSignups: 5,
       blockedUsers: 2,
@@ -215,13 +211,15 @@ describe('GET /stats', () => {
 })
 
 describe('GET /stats/daily', () => {
-  it('returns daily signups and last-seen counts with zero-filled days', async () => {
+  it('returns daily series with zero-filled days', async () => {
     mockPrisma.$queryRaw
       .mockResolvedValueOnce([{ date: '2026-02-20', count: BigInt(3) }]) // signups
       .mockResolvedValueOnce([
         { date: '2026-02-19', count: BigInt(7) },
         { date: '2026-02-21', count: BigInt(2) },
       ]) // last seen
+      .mockResolvedValueOnce([{ date: '2026-02-22', count: BigInt(1) }]) // blocked users
+      .mockResolvedValueOnce([{ date: '2026-02-23', count: BigInt(2) }]) // reported profiles
       .mockResolvedValueOnce([{ date: '2026-03-29', count: BigInt(5) }]) // interactions
       .mockResolvedValueOnce([{ date: '2026-03-30', count: BigInt(2) }]) // matches
       .mockResolvedValueOnce([{ date: '2026-03-28', count: BigInt(10) }]) // messages
@@ -233,12 +231,19 @@ describe('GET /stats/daily', () => {
     expect(reply.payload.success).toBe(true)
     expect(reply.payload.dailySignups).toHaveLength(7)
     expect(reply.payload.dailyLastSeen).toHaveLength(7)
+    expect(reply.payload.dailyBlockedUsers).toHaveLength(7)
+    expect(reply.payload.dailyReportedProfiles).toHaveLength(7)
     expect(reply.payload.dailyInteractions).toHaveLength(7)
     expect(reply.payload.dailyMatches).toHaveLength(7)
     expect(reply.payload.dailyMessages).toHaveLength(7)
 
     // Verify zero-fill: each entry has date and count
     for (const entry of reply.payload.dailySignups) {
+      expect(entry).toHaveProperty('date')
+      expect(entry).toHaveProperty('count')
+      expect(typeof entry.count).toBe('number')
+    }
+    for (const entry of reply.payload.dailyBlockedUsers) {
       expect(entry).toHaveProperty('date')
       expect(entry).toHaveProperty('count')
       expect(typeof entry.count).toBe('number')
@@ -254,6 +259,8 @@ describe('GET /stats/daily', () => {
     mockPrisma.$queryRaw
       .mockResolvedValueOnce([]) // signups
       .mockResolvedValueOnce([]) // last seen
+      .mockResolvedValueOnce([]) // blocked users
+      .mockResolvedValueOnce([]) // reported profiles
       .mockResolvedValueOnce([]) // interactions
       .mockResolvedValueOnce([]) // matches
       .mockResolvedValueOnce([]) // messages
@@ -264,6 +271,8 @@ describe('GET /stats/daily', () => {
     expect(reply.statusCode).toBe(200)
     expect(reply.payload.dailySignups.every((d: any) => d.count === 0)).toBe(true)
     expect(reply.payload.dailyLastSeen.every((d: any) => d.count === 0)).toBe(true)
+    expect(reply.payload.dailyBlockedUsers.every((d: any) => d.count === 0)).toBe(true)
+    expect(reply.payload.dailyReportedProfiles.every((d: any) => d.count === 0)).toBe(true)
     expect(reply.payload.dailyInteractions.every((d: any) => d.count === 0)).toBe(true)
     expect(reply.payload.dailyMatches.every((d: any) => d.count === 0)).toBe(true)
     expect(reply.payload.dailyMessages.every((d: any) => d.count === 0)).toBe(true)

--- a/apps/backend/src/api/routes/admin.route.ts
+++ b/apps/backend/src/api/routes/admin.route.ts
@@ -29,66 +29,92 @@ const adminRoutes: FastifyPluginAsync = async (fastify) => {
 
   /**
    * GET /stats/daily
-   * Returns daily signup and last-seen counts for the last 7 days.
-   * @returns {{ success, dailySignups, dailyLastSeen }}
+   * Returns daily counts for the last 7 days for each KPI rendered on the
+   * admin dashboard. Each series is zero-filled so the frontend can render
+   * uniform 7-day mini charts without gap handling.
    */
   fastify.get('/stats/daily', async (_req, reply) => {
     try {
       const days = getLast7Days()
       const since = days[0]
 
-      const [signupRows, lastSeenRows, interactionRows, matchRows, messageRows] = await Promise.all(
-        [
-          prisma.$queryRaw<{ date: string; count: bigint }[]>`
-            SELECT DATE("createdAt")::text AS date, COUNT(*)::bigint AS count
-            FROM "User"
-            WHERE "createdAt" >= ${since}::date
-            GROUP BY DATE("createdAt")
-            ORDER BY date
-          `,
-          prisma.$queryRaw<{ date: string; count: bigint }[]>`
-            SELECT DATE("lastSeenAt")::text AS date, COUNT(*)::bigint AS count
-            FROM "ProfileActivitySummary"
-            WHERE "lastSeenAt" >= ${since}::date
-            GROUP BY DATE("lastSeenAt")
-            ORDER BY date
-          `,
-          prisma.$queryRaw<{ date: string; count: bigint }[]>`
-            SELECT DATE(first_at)::text AS date, COUNT(*)::bigint AS count
-            FROM (
-              SELECT LEAST("fromId","toId") AS a, GREATEST("fromId","toId") AS b,
-                     MIN("createdAt") AS first_at
-              FROM "LikedProfile"
-              GROUP BY a, b
-            ) pairs
-            WHERE first_at >= ${since}::date
-            GROUP BY DATE(first_at)
-            ORDER BY date
-          `,
-          prisma.$queryRaw<{ date: string; count: bigint }[]>`
-            SELECT DATE(GREATEST(a."createdAt", b."createdAt"))::text AS date,
-                   COUNT(*)::bigint AS count
-            FROM "LikedProfile" a
-            JOIN "LikedProfile" b ON a."fromId" = b."toId" AND a."toId" = b."fromId"
-            WHERE a."fromId" < a."toId"
-              AND GREATEST(a."createdAt", b."createdAt") >= ${since}::date
-            GROUP BY DATE(GREATEST(a."createdAt", b."createdAt"))
-            ORDER BY date
-          `,
-          prisma.$queryRaw<{ date: string; count: bigint }[]>`
-            SELECT DATE("createdAt")::text AS date, COUNT(*)::bigint AS count
-            FROM "Message"
-            WHERE "createdAt" >= ${since}::date
-            GROUP BY DATE("createdAt")
-            ORDER BY date
-          `,
-        ]
-      )
+      const [
+        signupRows,
+        lastSeenRows,
+        blockedRows,
+        reportedRows,
+        interactionRows,
+        matchRows,
+        messageRows,
+      ] = await Promise.all([
+        prisma.$queryRaw<{ date: string; count: bigint }[]>`
+          SELECT DATE("createdAt")::text AS date, COUNT(*)::bigint AS count
+          FROM "User"
+          WHERE "createdAt" >= ${since}::date
+          GROUP BY DATE("createdAt")
+          ORDER BY date
+        `,
+        prisma.$queryRaw<{ date: string; count: bigint }[]>`
+          SELECT DATE("lastSeenAt")::text AS date, COUNT(*)::bigint AS count
+          FROM "ProfileActivitySummary"
+          WHERE "lastSeenAt" >= ${since}::date
+          GROUP BY DATE("lastSeenAt")
+          ORDER BY date
+        `,
+        // Approximation: User has no blockedAt timestamp, so use updatedAt
+        // for currently-blocked users as the latest-block proxy.
+        prisma.$queryRaw<{ date: string; count: bigint }[]>`
+          SELECT DATE("updatedAt")::text AS date, COUNT(*)::bigint AS count
+          FROM "User"
+          WHERE "isBlocked" = true AND "updatedAt" >= ${since}::date
+          GROUP BY DATE("updatedAt")
+          ORDER BY date
+        `,
+        // Same approximation for reported profiles.
+        prisma.$queryRaw<{ date: string; count: bigint }[]>`
+          SELECT DATE("updatedAt")::text AS date, COUNT(*)::bigint AS count
+          FROM "Profile"
+          WHERE "isReported" = true AND "updatedAt" >= ${since}::date
+          GROUP BY DATE("updatedAt")
+          ORDER BY date
+        `,
+        prisma.$queryRaw<{ date: string; count: bigint }[]>`
+          SELECT DATE(first_at)::text AS date, COUNT(*)::bigint AS count
+          FROM (
+            SELECT LEAST("fromId","toId") AS a, GREATEST("fromId","toId") AS b,
+                   MIN("createdAt") AS first_at
+            FROM "LikedProfile"
+            GROUP BY a, b
+          ) pairs
+          WHERE first_at >= ${since}::date
+          GROUP BY DATE(first_at)
+          ORDER BY date
+        `,
+        prisma.$queryRaw<{ date: string; count: bigint }[]>`
+          SELECT DATE(GREATEST(a."createdAt", b."createdAt"))::text AS date,
+                 COUNT(*)::bigint AS count
+          FROM "LikedProfile" a
+          JOIN "LikedProfile" b ON a."fromId" = b."toId" AND a."toId" = b."fromId"
+          WHERE a."fromId" < a."toId"
+            AND GREATEST(a."createdAt", b."createdAt") >= ${since}::date
+          GROUP BY DATE(GREATEST(a."createdAt", b."createdAt"))
+          ORDER BY date
+        `,
+        prisma.$queryRaw<{ date: string; count: bigint }[]>`
+          SELECT DATE("createdAt")::text AS date, COUNT(*)::bigint AS count
+          FROM "Message"
+          WHERE "createdAt" >= ${since}::date
+          GROUP BY DATE("createdAt")
+          ORDER BY date
+        `,
+      ])
 
       return reply.code(200).send({
         success: true,
         dailySignups: fillZeroDays(signupRows, days),
         dailyLastSeen: fillZeroDays(lastSeenRows, days),
+        dailyBlockedUsers: fillZeroDays(blockedRows, days),
+        dailyReportedProfiles: fillZeroDays(reportedRows, days),
         dailyInteractions: fillZeroDays(interactionRows, days),
         dailyMatches: fillZeroDays(matchRows, days),
         dailyMessages: fillZeroDays(messageRows, days),
@@ -101,35 +127,25 @@ const adminRoutes: FastifyPluginAsync = async (fastify) => {
 
   /**
    * GET /stats
-   * Returns dashboard KPIs: total users, active profiles, recent signups, blocked/reported counts,
-   * and activity segment distribution.
-   * @returns {{ success, stats }}
+   * Returns dashboard KPIs: active profiles, recent signups, blocked/reported
+   * counts, and activity segment distribution.
    */
   fastify.get('/stats', async (_req, reply) => {
     try {
       const now = new Date()
       const sevenDaysAgo = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000)
 
-      const [
-        totalUsers,
-        totalProfiles,
-        activeProfiles,
-        recentSignups,
-        blockedUsers,
-        reportedProfiles,
-        segmentGroups,
-      ] = await Promise.all([
-        prisma.user.count(),
-        prisma.profile.count(),
-        prisma.profile.count({ where: { isActive: true } }),
-        prisma.user.count({ where: { createdAt: { gte: sevenDaysAgo } } }),
-        prisma.user.count({ where: { isBlocked: true } }),
-        prisma.profile.count({ where: { isReported: true } }),
-        prisma.profileActivitySummary.groupBy({
-          by: ['segment'],
-          _count: { segment: true },
-        }),
-      ])
+      const [activeProfiles, recentSignups, blockedUsers, reportedProfiles, segmentGroups] =
+        await Promise.all([
+          prisma.profile.count({ where: { isActive: true } }),
+          prisma.user.count({ where: { createdAt: { gte: sevenDaysAgo } } }),
+          prisma.user.count({ where: { isBlocked: true } }),
+          prisma.profile.count({ where: { isReported: true } }),
+          prisma.profileActivitySummary.groupBy({
+            by: ['segment'],
+            _count: { segment: true },
+          }),
+        ])
 
       const segmentCounts = segmentGroups.map((g) => ({
         segment: g.segment,
@@ -139,8 +155,6 @@ const adminRoutes: FastifyPluginAsync = async (fastify) => {
       return reply.code(200).send({
         success: true,
         stats: {
-          totalUsers,
-          totalProfiles,
           activeProfiles,
           recentSignups,
           blockedUsers,


### PR DESCRIPTION
## Summary
Refactors the admin dashboard to use a unified KPI card component with integrated mini-charts, removing redundant tiles and simplifying the layout. The dashboard now displays 7 consistent KPI cards (Signups, Daily Active, Blocked Users, Reported Profiles, Interactions, Matches, Messages) plus an Activity Segments pie chart.

## Key Changes

**Frontend (DashboardPage.vue)**
- Removed `totalUsers` and `totalProfiles` from the stats interface and display
- Replaced individual bar chart components with a new reusable `KpiCard` component
- Converted chart building logic to computed properties that calculate 7-day totals
- Simplified layout from multiple rows of charts to a single responsive grid of KPI cards
- Updated grid layout: 1 column on mobile, 2 columns on tablets, 4 columns on desktop
- Removed unused `Bar` chart import and chart configuration functions

**New KpiCard Component**
- Displays title, subtitle, large value, and optional inline mini-chart
- Renders SVG-based sparkline bars (no Chart.js dependency) for compact visualization
- Accepts configurable color, series data, and responsive sizing
- Provides consistent styling and spacing across all KPI tiles

**Backend API Changes**
- `/admin/stats` endpoint: Removed `totalUsers` and `totalProfiles` queries
- `/admin/stats/daily` endpoint: Added two new daily series:
  - `dailyBlockedUsers`: Daily count of blocked users (approximated via `User.updatedAt`)
  - `dailyReportedProfiles`: Daily count of reported profiles (approximated via `Profile.updatedAt`)
- Updated response documentation to clarify zero-filled 7-day series for uniform frontend rendering

**Testing**
- Added comprehensive test suite for DashboardPage verifying:
  - Removal of Total Users/Profiles tiles
  - Correct 7-day totals displayed in KPI values
  - SVG mini-charts rendered for each series
  - Activity segments pie chart present

## Implementation Details
- KPI values for activity series (Daily Active, Interactions, Matches, Messages) now show the sum of the 7-day series rather than a single snapshot metric
- Mini-charts use SVG with responsive viewBox for lightweight rendering without Chart.js overhead
- Daily blocked/reported counts use `updatedAt` as a proxy since the schema lacks specific timestamp fields for these state changes
- All daily series are zero-filled to ensure consistent 7-day spans for frontend rendering

https://claude.ai/code/session_011KGnGAdv37eZZzwL4WWheV