### PR TITLE
fix(myprofile): remove duplicate profile fetches when opening owner drawer

### DIFF
--- a/.changeset/violet-meadow-spins.md
+++ b/.changeset/violet-meadow-spins.md
@@ -1,0 +1,5 @@
+---
+'@opencupid/frontend': patch
+---
+
+Eliminate duplicate profile preview and dating-prefs fetches when opening the owner drawer.

--- a/apps/frontend/src/features/myprofile/components/ProfilePanel.vue
+++ b/apps/frontend/src/features/myprofile/components/ProfilePanel.vue
@@ -1,9 +1,8 @@
 <script setup lang="ts">
-import { provide, toRef } from 'vue'
+import { provide } from 'vue'
 import { useRouter } from 'vue-router'
 
 import { useOwnerProfileStore } from '../stores/ownerProfileStore'
-import { useMyProfileViewModel } from '../composables/useMyProfileViewModel'
 import { useMyProfileRouteState } from '../composables/useMyProfileRouteState'
 
 import MyProfile from './MyProfile.vue'
@@ -23,10 +22,8 @@ const router = useRouter()
 const { subView } = useMyProfileRouteState()
 
 const ownerProfileStore = useOwnerProfileStore()
-const { formData } = useMyProfileViewModel(false)
 
 provide('isOwner', true)
-provide('viewerProfile', toRef(formData))
 
 function handleClose() {
   router.replace({ name: 'Browse' })
@@ -99,7 +96,10 @@ function handleClose() {
     v-if="subView === 'myprofile' || subView === 'myposts'"
     class="flex-shrink-0 flex-grow-0 d-flex align-items-center justify-content-center"
   >
-    <ul class="nav nav-tabs flex-grow-0 flex-shrink-0 w-100 d-flex justify-content-center" role="tablist">
+    <ul
+      class="nav nav-tabs flex-grow-0 flex-shrink-0 w-100 d-flex justify-content-center"
+      role="tablist"
+    >
       <li class="nav-item">
         <button
           class="nav-link"


### PR DESCRIPTION
## Summary

Opening the owner drawer fired two parallel pairs of XHRs — both the public profile preview (`/profiles/preview/:locale/:profileId`) and `/profiles/me/dating-prefs` were requested twice every time the drawer mounted.

**Root cause:** `ProfilePanel.vue` was calling `useMyProfileViewModel(false)` purely to feed a `provide('viewerProfile', toRef(formData))`. But `AppShellLayout.vue` already provides `viewerProfile` higher in the tree, sourced directly from the Pinia owner profile store. The composable installs a `watch(profileStore.profile, …, { immediate: true })` that fires `getProfilePreview()` + `fetchDatingPrefs()` — and `MyProfile.vue` (rendered as a child of `ProfilePanel`) calls the same composable, installing its own copy of that watcher. Two instances → two parallel fetch pairs.

The redundant `provide` was also providing the wrong shape (the editor's `formData` reactive form object) instead of the canonical store-backed `Ref<OwnerProfile | null>` that `AppShellLayout` provides — so removing it actually corrects the type seen by descendants.

## Changes

- Drop the `useMyProfileViewModel(false)` call and the redundant `provide('viewerProfile', …)` from `ProfilePanel.vue`. `MyProfile.vue` remains the single fetcher; descendants continue to receive `viewerProfile` from `AppShellLayout`.

## Test plan

- [x] `pnpm --filter frontend exec vitest run src/features/myprofile` (21/21 passing)
- [x] `pnpm --filter frontend exec vue-tsc --noEmit` (clean)
- [ ] Manual: open the owner drawer, confirm only one `cmovknr...` (profile preview) and one `dating-prefs` request fire in the network panel
- [ ] Manual: confirm `viewerProfile` injection still works in descendants (e.g. `ProfileContent`, `AnonymousLikeCard`, `SendMessageForm`, `ProfileMapCard`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)