### PR TITLE
test(messaging): silence onBeforeUnmount warnings in VM composable specs

### DIFF
--- a/.changeset/quiet-tests-bloom.md
+++ b/.changeset/quiet-tests-bloom.md
@@ -1,0 +1,5 @@
+---
+'@opencupid/frontend': patch
+---
+
+Silence Vue lifecycle warnings in messaging view-model specs by mounting a host component before invoking the composables (#1448)

--- a/apps/frontend/src/features/messaging/composables/__tests__/useConversationDetailViewModel.spec.ts
+++ b/apps/frontend/src/features/messaging/composables/__tests__/useConversationDetailViewModel.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { createPinia, setActivePinia } from 'pinia'
 import { defineComponent, h, ref } from 'vue'
 import { mount, type VueWrapper } from '@vue/test-utils'
@@ -124,11 +124,14 @@ function makeDraftSummary(partnerId = 'partner-1'): ConversationDraftSummary {
   }
 }
 
-beforeEach(() => {
+afterEach(() => {
   if (activeWrapper) {
     activeWrapper.unmount()
     activeWrapper = null
   }
+})
+
+beforeEach(() => {
   setActivePinia(createPinia())
   vi.clearAllMocks()
   mockMessageStore.activeConversation = null

--- a/apps/frontend/src/features/messaging/composables/__tests__/useConversationDetailViewModel.spec.ts
+++ b/apps/frontend/src/features/messaging/composables/__tests__/useConversationDetailViewModel.spec.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { createPinia, setActivePinia } from 'pinia'
 import { defineComponent, h, ref } from 'vue'
-import { mount } from '@vue/test-utils'
+import { mount, type VueWrapper } from '@vue/test-utils'
 
 import type { ConversationDraftSummary, ConversationSummary } from '@zod/messaging/messaging.dto'
 
@@ -62,6 +62,22 @@ vi.mock('@/features/videocall/api/calls.api', () => ({
 
 import { useConversationDetailViewModel } from '../useConversationDetailViewModel'
 
+type Vm = ReturnType<typeof useConversationDetailViewModel>
+
+let activeWrapper: VueWrapper | null = null
+
+function mountVm(): Vm {
+  let vm!: Vm
+  const Host = defineComponent({
+    setup() {
+      vm = useConversationDetailViewModel()
+      return () => h('div')
+    },
+  })
+  activeWrapper = mount(Host)
+  return vm
+}
+
 function makePersistedSummary(
   conversationId: string,
   partnerId = 'partner-1'
@@ -109,6 +125,10 @@ function makeDraftSummary(partnerId = 'partner-1'): ConversationDraftSummary {
 }
 
 beforeEach(() => {
+  if (activeWrapper) {
+    activeWrapper.unmount()
+    activeWrapper = null
+  }
   setActivePinia(createPinia())
   vi.clearAllMocks()
   mockMessageStore.activeConversation = null
@@ -130,7 +150,7 @@ describe('useConversationDetailViewModel — detail mode', () => {
     const partner = { id: 'p1', publicName: 'Partner' }
     mockProfileStore.getPublicProfile.mockResolvedValue({ success: true, data: partner })
 
-    const vm = useConversationDetailViewModel()
+    const vm = mountVm()
     // Flush watchers (immediate: true triggers synchronously, but the async
     // body needs the microtask queue to drain).
     await vi.waitFor(() => {
@@ -155,7 +175,7 @@ describe('useConversationDetailViewModel — draft mode', () => {
     const partner = { id: 'p2', publicName: 'Partner' }
     mockProfileStore.getPublicProfile.mockResolvedValue({ success: true, data: partner })
 
-    const vm = useConversationDetailViewModel()
+    const vm = mountVm()
 
     await vi.waitFor(() =>
       expect(mockMessageStore.resolveConversationByProfile).toHaveBeenCalledWith('p2')
@@ -176,7 +196,7 @@ describe('useConversationDetailViewModel — draft mode', () => {
       data: draft,
     })
 
-    const vm = useConversationDetailViewModel()
+    const vm = mountVm()
     await vi.waitFor(() => expect(vm.isDraft.value).toBe(true))
     expect(vm.myIsCallable.value).toBe(false)
   })
@@ -191,7 +211,7 @@ describe('useConversationDetailViewModel — draft mode', () => {
       data: persisted,
     })
 
-    useConversationDetailViewModel()
+    mountVm()
 
     await vi.waitFor(() =>
       expect(mockMessageStore.setActiveConversation).toHaveBeenCalledWith(persisted)
@@ -213,7 +233,7 @@ describe('useConversationDetailViewModel — onMessageSent draft swap', () => {
       data: draft,
     })
 
-    const vm = useConversationDetailViewModel()
+    const vm = mountVm()
     await vi.waitFor(() => expect(vm.isDraft.value).toBe(true))
 
     // Simulate the store having received the persisted summary from the send response.
@@ -235,7 +255,7 @@ describe('useConversationDetailViewModel — onMessageSent draft swap', () => {
     mockRouteParams.value = { conversationId: 'c1' }
     mockMessageStore.activeConversation = makePersistedSummary('c1')
 
-    const vm = useConversationDetailViewModel()
+    const vm = mountVm()
     await vm.onMessageSent()
     expect(mockRouterReplace).not.toHaveBeenCalled()
   })

--- a/apps/frontend/src/features/messaging/composables/__tests__/useMessagingViewModel.spec.ts
+++ b/apps/frontend/src/features/messaging/composables/__tests__/useMessagingViewModel.spec.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { createPinia, setActivePinia } from 'pinia'
+import { defineComponent, h } from 'vue'
+import { mount, type VueWrapper } from '@vue/test-utils'
 
 const mockFetchProfile = vi.fn()
 const mockRouterPush = vi.fn()
@@ -39,8 +41,28 @@ vi.mock('@/features/publicprofile/composables/usePublicProfile', () => ({
 
 import { useMessagingViewModel } from '../useMessagingViewModel'
 
+type Vm = ReturnType<typeof useMessagingViewModel>
+
+let activeWrapper: VueWrapper | null = null
+
+function mountVm(): Vm {
+  let vm!: Vm
+  const Host = defineComponent({
+    setup() {
+      vm = useMessagingViewModel()
+      return () => h('div')
+    },
+  })
+  activeWrapper = mount(Host)
+  return vm
+}
+
 describe('useMessagingViewModel – handleProfileSelect', () => {
   beforeEach(() => {
+    if (activeWrapper) {
+      activeWrapper.unmount()
+      activeWrapper = null
+    }
     setActivePinia(createPinia())
     mockFetchProfile.mockReset()
     mockRouterPush.mockReset()
@@ -50,7 +72,7 @@ describe('useMessagingViewModel – handleProfileSelect', () => {
     const profile = { id: 'prof-1', publicName: 'Alice' }
     mockFetchProfile.mockResolvedValue({ success: true, data: profile })
 
-    const { handleProfileSelect } = useMessagingViewModel()
+    const { handleProfileSelect } = mountVm()
 
     const result = await handleProfileSelect('prof-1')
 
@@ -61,7 +83,7 @@ describe('useMessagingViewModel – handleProfileSelect', () => {
   it('returns null when fetchProfile fails', async () => {
     mockFetchProfile.mockResolvedValue({ success: false })
 
-    const { handleProfileSelect } = useMessagingViewModel()
+    const { handleProfileSelect } = mountVm()
     const result = await handleProfileSelect('prof-x')
 
     expect(result).toBeNull()
@@ -70,13 +92,17 @@ describe('useMessagingViewModel – handleProfileSelect', () => {
 
 describe('useMessagingViewModel – handleMatchSelect', () => {
   beforeEach(() => {
+    if (activeWrapper) {
+      activeWrapper.unmount()
+      activeWrapper = null
+    }
     setActivePinia(createPinia())
     mockFetchProfile.mockReset()
     mockRouterPush.mockReset()
   })
 
   it('navigates to ConversationNew route with the partner profileId', () => {
-    const { handleMatchSelect } = useMessagingViewModel()
+    const { handleMatchSelect } = mountVm()
 
     handleMatchSelect('prof-7')
 

--- a/apps/frontend/src/features/messaging/composables/__tests__/useMessagingViewModel.spec.ts
+++ b/apps/frontend/src/features/messaging/composables/__tests__/useMessagingViewModel.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { createPinia, setActivePinia } from 'pinia'
 import { defineComponent, h } from 'vue'
 import { mount, type VueWrapper } from '@vue/test-utils'
@@ -57,12 +57,15 @@ function mountVm(): Vm {
   return vm
 }
 
+afterEach(() => {
+  if (activeWrapper) {
+    activeWrapper.unmount()
+    activeWrapper = null
+  }
+})
+
 describe('useMessagingViewModel – handleProfileSelect', () => {
   beforeEach(() => {
-    if (activeWrapper) {
-      activeWrapper.unmount()
-      activeWrapper = null
-    }
     setActivePinia(createPinia())
     mockFetchProfile.mockReset()
     mockRouterPush.mockReset()
@@ -92,10 +95,6 @@ describe('useMessagingViewModel – handleProfileSelect', () => {
 
 describe('useMessagingViewModel – handleMatchSelect', () => {
   beforeEach(() => {
-    if (activeWrapper) {
-      activeWrapper.unmount()
-      activeWrapper = null
-    }
     setActivePinia(createPinia())
     mockFetchProfile.mockReset()
     mockRouterPush.mockReset()


### PR DESCRIPTION
## Summary

- `useConversationDetailViewModel.spec.ts` and `useMessagingViewModel.spec.ts` invoked their composables directly at the test-body level. Both register lifecycle hooks (`onBeforeUnmount` / `onUnmounted`), which Vue requires to run inside a component `setup()`, producing the warning `[Vue warn]: onBeforeUnmount is called when there is no active component instance...` on every test (the user reported it surfacing on the "does nothing when not in draft mode" case).
- Wrapped the bare calls in a small `mountVm()` helper that mounts a host `defineComponent` and exposes the returned VM, matching the pattern already used by the existing unmount-cleanup regression test in the same file.
- The host wrapper is unmounted in `beforeEach` so each test starts clean.

## Test plan

- [x] `pnpm --filter frontend exec vitest run useConversationDetailViewModel.spec.ts useMessagingViewModel.spec.ts` — 10/10 passing, no Vue warnings emitted.

https://claude.ai/code/session_01RZZjQbXNVDEHZSja3DofSS

---
_Generated by [Claude Code](https://claude.ai/code/session_01RZZjQbXNVDEHZSja3DofSS)_