### PR TITLE
chore(i18n): remove orphaned translation keys

### DIFF
--- a/.changeset/quiet-pine-sweep.md
+++ b/.changeset/quiet-pine-sweep.md
@@ -1,0 +1,7 @@
+---
+'@opencupid/frontend': patch
+'@opencupid/backend': patch
+---
+
+Remove orphaned i18n keys from `packages/shared/i18n/{en,hu}.json` that were no
+longer referenced by any `t()`/`$t()` call in the codebase.

--- a/packages/shared/i18n/en.json
+++ b/packages/shared/i18n/en.json
@@ -28,13 +28,36 @@
   "calls": {
     "accept": "Accept",
     "allow_calls_label": "Allow calls",
-    "section_title": "Calls",
     "call_button_title": "Start video call",
     "calling": "Calling...",
     "cancel_call": "Cancel",
     "decline": "Decline",
     "incoming_call_from": "Incoming call from {name}",
-    "open_to_calls_setting": "I'm open to video calls"
+    "open_to_calls_setting": "I'm open to video calls",
+    "section_title": "Calls"
+  },
+  "community": {
+    "actions": {
+      "cancel": "Nevermind",
+      "create": "Submit",
+      "save": "Save community"
+    },
+    "labels": {
+      "content": "About this community",
+      "founded_since": "Since {year}",
+      "visibility": "Show this community",
+      "year_founded": "Founded in"
+    },
+    "messages": {
+      "error_load": "Failed to load community"
+    },
+    "placeholders": {
+      "content": "Describe your community…",
+      "year_unknown": "Don't know / not sure"
+    },
+    "share": {
+      "community_text": "{publicName} runs a community — check it out"
+    }
   },
   "emails": {
     "fallback_hint": "If the button doesn't work, copy and paste this URL:",
@@ -99,29 +122,6 @@
       "event_text": "{publicName} is hosting an event — check it out"
     }
   },
-  "community": {
-    "actions": {
-      "cancel": "Nevermind",
-      "create": "Submit",
-      "save": "Save community"
-    },
-    "labels": {
-      "content": "About this community",
-      "year_founded": "Founded in",
-      "founded_since": "Since {year}",
-      "visibility": "Show this community"
-    },
-    "messages": {
-      "error_load": "Failed to load community"
-    },
-    "placeholders": {
-      "content": "Describe your community…",
-      "year_unknown": "Don't know / not sure"
-    },
-    "share": {
-      "community_text": "{publicName} runs a community — check it out"
-    }
-  },
   "gender": {
     "agender": "Agender",
     "androgynous": "Androgynous",
@@ -180,6 +180,15 @@
     "you_messaged_them": "You messaged them",
     "you_smiled_at": "You smiled at {name}"
   },
+  "map": {
+    "layer_control": {
+      "aria_label": "Map layers",
+      "communities": "Communities",
+      "events": "Events",
+      "people": "People",
+      "posts": "Posts"
+    }
+  },
   "matches": {
     "anonymous_like_hint": "They smiled at you anonymously, at least for now. You'll find out who when you smile back. You can bump into them on the map — if you see someone marked like this, your preferences match.",
     "anonymous_like_hint_cta": "Discover the community",
@@ -198,15 +207,6 @@
     "received_likes": "{count, plural, =0 {No smiles yet.} one {You have # smile.} other {You have # smiles!}}",
     "you_matched_with": "{name} smiled back!",
     "you_received_like": "Someone smiled at you!"
-  },
-  "map": {
-    "layer_control": {
-      "people": "People",
-      "posts": "Posts",
-      "events": "Events",
-      "communities": "Communities",
-      "aria_label": "Map layers"
-    }
   },
   "messaging": {
     "already_sent_waiting": "You have already sent them a message. Once they answer, you can continue the conversation.",
@@ -297,11 +297,12 @@
   "posts": {
     "actions": {
       "cancel": "Nevermind",
+      "contact": "Contact poster",
       "create": "Submit",
-      "create_cta_title": "Post something",
       "create_advert_cta_title": "Post an advert",
-      "create_event_cta_title": "Post an event",
       "create_community_cta_title": "Create a community",
+      "create_cta_title": "Post something",
+      "create_event_cta_title": "Post an event",
       "delete": "Delete",
       "edit": "Edit Post",
       "hide": "Hide (but don't delete)",
@@ -433,8 +434,8 @@
     "email_notifications_opt_in": "Email",
     "newsletter_opt_in": "Email newsletter",
     "newsletter_opt_in_hint": "Community updates, new features, that kind of stuff. You can unsubscribe any time.",
-    "notifications_opt_in": "When someone messages me, smiles at me, or matches with me...",
     "notifications_label": "Notifications",
+    "notifications_opt_in": "When someone messages me, smiles at me, or matches with me...",
     "push_notify_messages": "Popup and mobile notification",
     "title": "Settings"
   },

--- a/packages/shared/i18n/en.json
+++ b/packages/shared/i18n/en.json
@@ -10,11 +10,7 @@
     "captcha_success": "Of course!  Sorry for asking.",
     "captcha_verify": "Let's check",
     "captcha_verifying": "Hang on a sec...",
-    "email": "Email",
     "login": "Continue",
-    "login_confirm_welcome": "Welcome!",
-    "password": "Password",
-    "phone_number": "Phone number",
     "token_check_email": "We sent you a login link. Check your email and click the link to log in.",
     "token_check_messages": "Check your messages",
     "token_different_device": "It seems the login was started on a different device. Please go back and enter your email again.",
@@ -23,13 +19,10 @@
     "token_invalid": "The code is invalid. Please try again.",
     "token_invalid_feedback": "Code should be 6 digits",
     "token_invalid_link": "Hmm that link in the email didn't look right. Please enter the code in the message.",
-    "token_sent_email": "We have sent you a login link, check your inbox. If you don't see it, please check your spam folder.",
-    "token_sent_phone": "We have sent you a little code to your phone number, please enter it below.",
     "token_unknown_error": "Something went wrong. Please try again later.",
     "unknown_error": "An unexpected error occurred. Please try again later."
   },
   "authentication": {
-    "login": "Login",
     "logout": "Logout"
   },
   "calls": {
@@ -41,7 +34,6 @@
     "cancel_call": "Cancel",
     "decline": "Decline",
     "incoming_call_from": "Incoming call from {name}",
-    "missed_call_message": "Missed call",
     "open_to_calls_setting": "I'm open to video calls"
   },
   "emails": {
@@ -154,12 +146,6 @@
     "two_spirit": "Two-spirit",
     "unspecified": "I'd rather not say"
   },
-  "general": {
-    "connectiontypes": {
-      "dating": "Date",
-      "socializing": "Buddy"
-    }
-  },
   "haskids_label": {
     "no": "No kids",
     "unspecified": "I'd rather not say",
@@ -175,12 +161,6 @@
     "unspecified": "Doesn't matter",
     "yes": "Has kids"
   },
-  "home": {
-    "explore_interests": "Explore interests",
-    "meet_new_people": "New people",
-    "more_people": "Find buddies",
-    "welcome_title": "Welcome to {siteName}!"
-  },
   "interactions": {
     "anonymous_like_explanation": "They won't know who sent it until they smile back at you.",
     "anonymous_toggle_anonymous": "Stay anonymous",
@@ -188,10 +168,8 @@
     "anonymous_toggle_reveal": "Show my name",
     "cancel_button": "Maybe later",
     "its_a_match": "It's a match!",
-    "like_button_title": "Smile",
     "like_error": "Oops, this didn't work. Please try again.",
     "like_them_back": "Smile back",
-    "message_confirmation": "Nice!",
     "pass_button_title": "Pass",
     "revealed_like_explanation": "They will see who sent it.",
     "send_a_like": "Smile at them",
@@ -199,21 +177,13 @@
     "send_them_a_message": "Send {name} a message",
     "they_liked_you": "They smiled at you!",
     "you_liked_them": "You smiled at them",
-    "you_matched_with_them": "{name} smiled back!",
     "you_messaged_them": "You messaged them",
     "you_smiled_at": "You smiled at {name}"
   },
   "matches": {
     "anonymous_like_hint": "They smiled at you anonymously, at least for now. You'll find out who when you smile back. You can bump into them on the map — if you see someone marked like this, your preferences match.",
     "anonymous_like_hint_cta": "Discover the community",
-    "find_button_cta": "Go connect",
-    "no_match_have_sent_like": "They will surely smile back at you.",
-    "no_match_have_sent_like_cta": "Keep lookin'",
-    "no_match_no_sent_like": "There's gotta be someone out there worth smiling at?  ",
-    "no_match_no_sent_like_cta": "Start lookin'",
     "notifications": {
-      "and": "and",
-      "matches": "{count, plural, one {# new match} other {# new matches}}",
       "you_have_likes": "{count, plural, one {Someone smiled at you} other {# people smiled at you}}"
     },
     "pass_confirm_dialog": {
@@ -226,7 +196,6 @@
       "title": "But wait..."
     },
     "received_likes": "{count, plural, =0 {No smiles yet.} one {You have # smile.} other {You have # smiles!}}",
-    "received_likes_cta": "Find out who sent it",
     "you_matched_with": "{name} smiled back!",
     "you_received_like": "Someone smiled at you!"
   },
@@ -242,48 +211,30 @@
   "messaging": {
     "already_sent_waiting": "You have already sent them a message. Once they answer, you can continue the conversation.",
     "block_member": "Block member",
-    "block_report_unmatch": "Block/report/unmatch",
-    "block_user_ok": "Block {name}",
-    "conversation_options_title": "Conversation options",
     "loading_older_messages": "Loading older messages…",
-    "matches_list_title": "My matches ❤️",
-    "message_input_hint": "Press Enter to send",
-    "message_input_hint_click": "Click SEND to send",
     "message_input_placeholder": "Type your message here...",
     "message_sent_success": "Message sent successfully!",
     "my_conversations": "My conversations",
     "my_turn": "My turn",
-    "nevermind": "Nevermind",
-    "new_message_notification": "{sender} sent a message",
     "no_messages_cta": "Find people",
     "no_messages_placeholder": "Your conversations will take place here.",
-    "no_messages_title": "No messages yet",
     "page_title": "Messages",
-    "send_failed": "Oops, this didn't work. Please try again.",
     "send_message_button": "Send",
-    "send_message_heading": "Send Message",
     "send_message_to_user": "Send a message to {name}",
     "send_mode_click": "Click to send",
     "send_mode_press_enter": "Press enter to send",
     "their_turn": "Their turn",
     "unknown_sender": "Someone",
     "voice": {
-      "back_to_text": "Back to text",
       "cancel": "Cancel",
       "confirm_cancel_button": "Nevermind",
       "confirm_send_button": "Send",
       "confirm_send_title": "Ok to send this?",
       "max_duration": "Max {duration}s",
-      "permission_denied": "Microphone permission denied. Please allow microphone access to record voice messages.",
       "record": "Record",
       "record_again": "Record again",
-      "recording_mode": "Voice Message",
-      "record_voice_message": "Record voice message",
-      "retry_permission": "Try Again",
       "start_recording": "Leave voice message",
       "stop_recording": "Stop recording",
-      "text": "Text",
-      "unsupported_browser": "Voice recording is not supported in this browser.",
       "voice_message_notification": "sent you a voice message",
       "voice_message_preview": "Voice message"
     }
@@ -295,16 +246,8 @@
     }
   },
   "nav": {
-    "browse": "Buddies",
-    "bulletin": "Bulletin",
-    "home": "Home",
     "inbox": "Inbox",
-    "matches": "Dating",
-    "profile": "Profile",
-    "settings": "Settings"
-  },
-  "notifications": {
-    "voice_message_sent": "Sent a voice message"
+    "profile": "Profile"
   },
   "onboarding": {
     "age_subtitle": "I've been on this planet since",
@@ -313,30 +256,17 @@
     "confirmation": {
       "browse_button": "Meet people",
       "browse_hint": "See who else is on here",
-      "profile_button": "My profile",
-      "profile_hint": "See what other people see about me.",
       "title": "All set!"
     },
-    "connections_subtitle": "I feel complete but could use some company.",
-    "connections_title": "I am looking for...",
-    "country_placeholder": "Country",
-    "dating_hint_subtitle": "We'll ask you a few questions so we can find the best matches for you. This information is only visible to other people who are also looking for a relationship.",
-    "dating_hint_title": "Let's set up your dating profile",
     "dating_intro_hint": "Leave this empty if you want to fill this in later.",
     "dating_intro_placeholder": "Tell a bit about the kind of relationship you are looking for",
-    "dating_intro_subtitle": "This will be visible only to people who are looking for a relationship as well, not to those who are just looking for friends or social connections.",
     "dating_intro_title": "I would like to find:",
     "dating_mode_step_hint_active": "In the next few steps, please reveal a few additional details about yourself, and your preferences on who you would like to meet.  Those details will be visible only to other people in dating mode who match your preferences.  ",
     "dating_mode_step_hint_inactive": "You can always enable or disable dating mode later from your profile.",
     "dating_mode_step_title": "Would you also like to use dating mode?",
     "dating_mode_switch": "Dating mode ON?",
     "dating_preferences_title": "My preferences",
-    "finish_button": "Finish",
     "gender_subtitle": "I identify as...",
-    "goals": {
-      "dating": "Dating, finding a partner, and exploring romantic relationships.",
-      "socializing": "Socializing, hanging out, traveling, and meeting new people"
-    },
     "interests_hint": "Start typing to search for tags. You can add new tags if you don't find what you're looking for.",
     "interests_popular_heading": "What other people here are into:",
     "interests_title": "I'm into...",
@@ -344,10 +274,7 @@
     "languages_title": "I speak...",
     "location_hint": "Start typing your city or village, and select from the list.",
     "location_title": "I'm from...",
-    "next_button": "Next",
-    "photos_subtitle": "Add a photo of yourself so others can see you.",
     "photos_title": "I look like...",
-    "relationship_subtitle": "My family situation is",
     "relationship_title": "I am...",
     "social_intro_hint": "Leave this empty if you want to fill this in later.",
     "social_intro_placeholder": "Tell a bit about yourself",
@@ -370,9 +297,7 @@
   "posts": {
     "actions": {
       "cancel": "Nevermind",
-      "contact": "Contact poster",
       "create": "Submit",
-      "create_cta": "Create post...",
       "create_cta_title": "Post something",
       "create_advert_cta_title": "Post an advert",
       "create_event_cta_title": "Post an event",
@@ -385,47 +310,21 @@
     },
     "create_title": "Post something",
     "edit_title": "Edit post",
-    "filters": {
-      "all": "All Posts",
-      "nearby": "Nearby",
-      "offers": "Offers",
-      "recent": "Recent",
-      "requests": "Requests"
-    },
     "labels": {
       "content": "Content",
-      "location": "Location",
-      "type": "Post Type",
-      "updated": "Last updated",
       "visibility": "Visible to others"
-    },
-    "location": {
-      "enable": "Enable Location",
-      "prompt": "Enable location to see nearby posts"
     },
     "messages": {
       "confirm_delete": "Are you sure you want to delete this post?",
-      "created": "Post created successfully",
-      "deleted": "Post deleted successfully",
-      "error_create": "Failed to create post",
-      "error_delete": "Failed to delete post",
       "error_load": "Failed to load posts",
-      "error_update": "Failed to update post",
-      "no_my_posts": "You haven't created any posts yet",
-      "no_nearby": "No posts found nearby",
-      "no_posts": "No posts found",
-      "no_recent": "No recent posts found",
-      "not_visible": "This post is not visible to others",
-      "updated": "Post updated successfully"
+      "no_posts": "No posts found"
     },
-    "my_posts": "My posts",
     "placeholders": {
       "content": "Share what you're offering or looking for"
     },
     "share": {
       "post_text": "{publicName} posted something — take a look"
     },
-    "title": "Bulletin board",
     "types": {
       "OFFER": "Offer",
       "REQUEST": "Request"
@@ -439,48 +338,18 @@
       "confirmation_yes": "Yes, block them",
       "dialog_message_1": "If this person is bothering you, you can block them. This will prevent them from sending you messages or interacting with your profile. They will also not be shown to you anywhere on this site, as if they never existed.",
       "dialog_message_2": "They will not receive any notification that you have blocked them.",
-      "dialog_title": "Block {name}?",
-      "empty": "You have no blocked users.",
-      "title": "Blocked users",
-      "unblock_button": "Unblock",
-      "unblock_confirmation": "Are you sure you want to unblock this user?",
-      "unblock_confirmation_no": "No, keep blocked",
-      "unblock_confirmation_yes": "Yes, unblock"
+      "dialog_title": "Block {name}?"
     },
     "browse": {
       "filters": {
-        "age_range": "Age range:",
-        "anywhere": "Anywhere",
-        "button_update_prefs": "Update",
-        "dialog_cancel_button": "Nevermind",
-        "dialog_ok_button": "Find people",
-        "explore_tags": "Explore popular interests",
-        "filter_display_label": "Looking in:",
         "locate_button_title": "Set to my location",
-        "near_label": "Near...",
-        "search_button_title_dating": "Find people",
-        "search_button_title_social": "Find people",
-        "search_placeholder": "Search",
-        "social_title": "I 'm looking for connections...",
-        "tags_label": "Interested in..."
+        "search_placeholder": "Search"
       },
       "invite_button": "Invite",
-      "loading_more_profiles": "Loading more profiles...",
-      "no_results_cta_description": "You can help by inviting your friends to join. The more, the merrier.",
-      "no_results_cta_title": "It's a bit lonely here. Invite a friend?",
-      "social_no_results": "We haven't found anyone in {country} yet.",
-      "social_no_results_city": "Haven't found anyone in {cityName} yet.",
-      "social_no_results_tags": "Haven't found anyone with those interests.",
-      "views": {
-        "grid_view_button_title": "Grid view",
-        "map_view_button_title": "Map view"
-      }
+      "no_results_cta_title": "It's a bit lonely here. Invite a friend?"
     },
     "forms": {
       "age_range": "Age range",
-      "age_title_display": "I was born in {birthYear}",
-      "city_add_placeholder": "Add this as new city",
-      "city_deselect_label": "Remove",
       "city_search_placeholder": "Search locations",
       "city_start_typing": "Start typing to search for your city",
       "dating_mode": "Dating mode",
@@ -488,8 +357,6 @@
       "dating_mode_view": "Dating mode view",
       "dating_mode_view_hint_active": "This is what other people with whom your preferences mutually match will see.",
       "dating_profile_tab": "My profile",
-      "dictate": "Dictate",
-      "dictate_listening": "Listening…",
       "edit_button_hint": "Edit your info",
       "edit_titles": {
         "gender_identity": "Gender",
@@ -513,9 +380,7 @@
       "more_options": "More options",
       "my_dating_profile": "My dating profile",
       "my_preferences": "My preferences",
-      "my_profile": "My profile",
       "name_first_name_only": "Just your first name please",
-      "name_invalid": "Enter at least 3 letters",
       "name_label": "My first name is...",
       "preview_language": "Preview language",
       "preview_profile": "Preview my profile",
@@ -533,12 +398,9 @@
     "image_editor": {
       "delete_button_title": "Remove photo"
     },
-    "image_editor_help": "Your photo here",
     "image_upload": {
       "add_from_phone": "Add a photo from your phone",
       "errors": {
-        "IMAGE_TOO_LARGE": "The image is too large. Please choose a smaller photo (max 10MB).",
-        "IMAGE_UPLOAD_FAILED": "Failed to upload image. Please try again.",
         "unknown": "Something went wrong. Please try again."
       },
       "looks_good": "Looks good!",
@@ -548,12 +410,8 @@
       "try_another": "Choose a different photo"
     },
     "more_options_button_title": "More options",
-    "no_profile_create": "Create Profile",
-    "no_profile_title": "Please fill in your profile",
     "profile_not_found": "Profile not found",
-    "profile_photos": "{name}'s photos",
-    "pronouns_edit_label": "pronouns",
-    "send_message_button": "Message"
+    "pronouns_edit_label": "pronouns"
   },
   "pronouns": {
     "he_him": "He/him",
@@ -573,7 +431,6 @@
   "settings": {
     "calls_opt_in_hint": "You can disable this on a per-member basis as well. Uncheck this if you're not interested in using this at all.",
     "email_notifications_opt_in": "Email",
-    "language_label": "Language",
     "newsletter_opt_in": "Email newsletter",
     "newsletter_opt_in_hint": "Community updates, new features, that kind of stuff. You can unsubscribe any time.",
     "notifications_opt_in": "When someone messages me, smiles at me, or matches with me...",
@@ -590,10 +447,7 @@
     "dialog_cancel_button": "Nevermind",
     "edit_button_title": "Edit",
     "error": {
-      "cancel": "Cancel",
-      "message": "An error occurred. Please try again later.",
       "rate_limit": "Slow down partner.",
-      "retry": "Retry",
       "title": "We've hit a snag here."
     },
     "install_banner": {
@@ -606,35 +460,14 @@
     "locale_selector": {
       "help_wanted_translating": "Help wanted translating"
     },
-    "modal": {
-      "close": "Close"
-    },
     "share_dialog": {
       "button_copied": "Copied",
       "button_copy": "Copy",
-      "description": "Invite your friends to join Gaians and connect with like-minded people.",
-      "qr_hint": "Flash this at their phone",
       "share_text": "{publicName} invited you to join {siteName}",
-      "share_title": "Check out {siteName}",
-      "title": "Spread the word"
-    },
-    "spinner": {
-      "spinning": "Spinning"
+      "share_title": "Check out {siteName}"
     },
     "submitbutton": {
-      "save": "Save",
-      "submit": "Submit",
       "working": "Working..."
-    },
-    "toast": {
-      "error": {
-        "message": "An error occurred. Please try again.",
-        "title": "Error"
-      },
-      "success": {
-        "message": "Your action was successful.",
-        "title": "Success"
-      }
     },
     "update_banner": {
       "message": "An update is available.",

--- a/packages/shared/i18n/hu.json
+++ b/packages/shared/i18n/hu.json
@@ -10,11 +10,7 @@
     "captcha_success": "Hát persze. Elnézést a kérdésért.",
     "captcha_verify": "Nézzük meg",
     "captcha_verifying": "Egy pillanat...",
-    "email": "E-mail",
     "login": "Tovább",
-    "login_confirm_welcome": "Légy üdvözölve!",
-    "password": "Jelszó",
-    "phone_number": "Telefonszám",
     "token_check_email": "Küldtünk egy bejelentkezési linket. Nézd meg az emailjeidet, és kattints a linkre a belépéshez.",
     "token_check_messages": "Nézz rá az üzeneteidre",
     "token_different_device": "Úgy tűnik, a bejelentkezést egy másik eszközön kezdted el. Menj vissza, és add meg újra az email címedet.",
@@ -23,13 +19,10 @@
     "token_invalid": "A kóddal valami nem stimmel, jól írtad be?",
     "token_invalid_feedback": "A kód 6 számjegyű",
     "token_invalid_link": "Úgy tűnik, az emailben kapott link hibás. Írd be az üzenetben kapott kódot.",
-    "token_sent_email": "Emailen küldtünk egy linket, arra kattints rá (vagy írd be a kódot).  Ha nem látod az emailt, nézz rá a spam mappára is.",
-    "token_sent_phone": "A telefonodra küldtünk egy üzenetet, az abban levő kódot írd be ide.",
     "token_unknown_error": "Valami hiba történt. Kérlek, próbáld újra később.",
     "unknown_error": "Váratlan hiba történt. Kérlek, próbáld újra később."
   },
   "authentication": {
-    "login": "Belépés",
     "logout": "Kilépés"
   },
   "calls": {
@@ -41,7 +34,6 @@
     "cancel_call": "Mégse",
     "decline": "Elutasítás",
     "incoming_call_from": "Bejövő hívás: {name}",
-    "missed_call_message": "Nem fogadott hívás",
     "open_to_calls_setting": "Elérhető vagyok videóhívásra"
   },
   "emails": {
@@ -158,12 +150,6 @@
     "two_spirit": "Két szellem",
     "unspecified": "Inkább nem mondom meg"
   },
-  "general": {
-    "connectiontypes": {
-      "dating": "Társ",
-      "socializing": "Koma"
-    }
-  },
   "haskids_label": {
     "no": "Nincs gyereke",
     "unspecified": "Inkább nem mondom meg",
@@ -179,12 +165,6 @@
     "unspecified": "Mindegy",
     "yes": "Van gyereke"
   },
-  "home": {
-    "explore_interests": "Érdeklődési körök felfedezése",
-    "meet_new_people": "Nemrég csatlakoztak",
-    "more_people": "Komakereső",
-    "welcome_title": "Légy üdvözölve nálunk."
-  },
   "interactions": {
     "anonymous_like_explanation": "Csak akkor derül ki, hogy tőled jött, ha visszamosolyog rád.",
     "anonymous_toggle_anonymous": "Nem",
@@ -192,10 +172,8 @@
     "anonymous_toggle_reveal": "Igen",
     "cancel_button": "Talán később",
     "its_a_match": "Kölcsönös!",
-    "like_button_title": "Rámosolygok!",
     "like_error": "Hoppá, ez nem működött. Kérjük, próbáld meg újra.",
     "like_them_back": "Visszamosolygok",
-    "message_confirmation": "Elküldve!",
     "pass_button_title": "Passzolok",
     "revealed_like_explanation": "Látni fogja, hogy Te küldted.",
     "send_a_like": "Rámosolygok",
@@ -203,21 +181,13 @@
     "send_them_a_message": "Küldj neki egy üzenetet.",
     "they_liked_you": "Rád mosolygott!",
     "you_liked_them": "Rámosolygok",
-    "you_matched_with_them": "{name} visszamosolygott!",
     "you_messaged_them": "Üzenetet küldtél neki",
     "you_smiled_at": "Rámosolyogtál!"
   },
   "matches": {
     "anonymous_like_hint": "Egyelőre névtelenül mosolygott rád. De a Komakeresőben rátalálhatsz - ha Te is rámosolyogsz, ki fog derülni, ki küldte. Ha valakit ilyen jelöléssel látsz, könnyen lehet, hogy egymást keresitek:",
     "anonymous_like_hint_cta": "A Komakeresőhöz",
-    "find_button_cta": "Kapcsolódj",
-    "no_match_have_sent_like": "Még nem lájkolt vissza senki",
-    "no_match_have_sent_like_cta": "Keresés",
-    "no_match_no_sent_like": "Még nem lájkoltál senkit",
-    "no_match_no_sent_like_cta": "Kapcsolódj",
     "notifications": {
-      "and": "és",
-      "matches": "{count, plural, one {# új kölcsönös ❤️} other {# új kölcsönös ❤️}}",
       "you_have_likes": "{count, plural, one {Valaki rád mosolygott} other {Többen rád mosolyogtak}}"
     },
     "pass_confirm_dialog": {
@@ -230,7 +200,6 @@
       "title": "De várj..."
     },
     "received_likes": "{count, plural, =0 {Még nincs ❤️-od} one {# ❤️-ot kaptál} other {# ❤️-od van}}",
-    "received_likes_cta": "Vajon ki küldte?",
     "you_matched_with": "{name} visszamosolygott",
     "you_received_like": "Valaki rád mosolygott!"
   },
@@ -246,48 +215,30 @@
   "messaging": {
     "already_sent_waiting": "Már küldtél nekik üzenetet. Amint válaszolnak, folytathatod a beszélgetést.",
     "block_member": "Tag letiltása",
-    "block_report_unmatch": "Letiltás/jelentés",
-    "block_user_ok": "{name} letiltása",
-    "conversation_options_title": "Beszélgetés beállításai",
     "loading_older_messages": "Régebbi üzenetek betöltése…",
-    "matches_list_title": "Egymásra mosolyogtunk ❤️",
-    "message_input_hint": "Enter-rel küldheted",
-    "message_input_hint_click": "Kattints a KÜLDÉS gombra",
     "message_input_placeholder": "...",
     "message_sent_success": "Az üzeneted megérkezett a postafiókjába.",
     "my_conversations": "Beszélgetéseim",
     "my_turn": "Én jövök",
-    "nevermind": "Mégse",
-    "new_message_notification": "{sender} küldött egy üzenetet",
     "no_messages_cta": "Komakereső",
     "no_messages_placeholder": "Itt találod majd a beszélgetéseidet.",
-    "no_messages_title": "Még nincsenek üzenetek",
     "page_title": "Üzenetek",
-    "send_failed": "Hoppá, ez nem működött. Kérjük, próbáld meg újra.",
     "send_message_button": "Küldés",
-    "send_message_heading": "Üzenet küldése",
     "send_message_to_user": "Üzenet {name} részére",
     "send_mode_click": "Kattintással küldés",
     "send_mode_press_enter": "Enter-rel küldés",
     "their_turn": "Ő jön",
     "unknown_sender": "Valaki",
     "voice": {
-      "back_to_text": "Vissza a szöveghez",
       "cancel": "Mégse",
       "confirm_cancel_button": "Mégsem",
       "confirm_send_button": "Küldés",
       "confirm_send_title": "Elküldöd?",
       "max_duration": "Max. {duration}mp",
-      "permission_denied": "A mikrofon hozzáférés megtagadva. Engedélyezd a mikrofon használatát.",
       "record": "Felvétel",
       "record_again": "Újra felvétel",
-      "recording_mode": "Hangüzenet",
-      "record_voice_message": "Hangüzenet rögzítése",
-      "retry_permission": "Próbáld újra",
       "start_recording": "Hangüzenet",
       "stop_recording": "Felvétel leállítása",
-      "text": "Szöveg",
-      "unsupported_browser": "A hangrögzítés nem támogatott ebben a böngészőben.",
       "voice_message_notification": "hangüzenetet küldött",
       "voice_message_preview": "Hangüzenet"
     }
@@ -299,16 +250,8 @@
     }
   },
   "nav": {
-    "browse": "Komakereső",
-    "bulletin": "Hirdetőtábla",
-    "home": "Főoldal",
     "inbox": "Üzenetek",
-    "matches": "Pártaláló",
-    "profile": "Profilom",
-    "settings": "Beállítások"
-  },
-  "notifications": {
-    "voice_message_sent": "Hangüzenetet küldött"
+    "profile": "Profilom"
   },
   "onboarding": {
     "age_subtitle": "Ennyi ideje élek ezen a bolygón",
@@ -317,30 +260,17 @@
     "confirmation": {
       "browse_button": "Komakereső",
       "browse_hint": "Ki van még itt?",
-      "profile_button": "A profilomhoz",
-      "profile_hint": "Hogyan látnak mások?",
       "title": "Kész!"
     },
-    "connections_subtitle": "Teljes vagyok, de jól jönne egy kis társaság.",
-    "connections_title": "Kivel kapcsolódnál?",
-    "country_placeholder": "Ország",
-    "dating_hint_subtitle": "Felteszünk néhány kérdést, hogy megtaláljuk a legjobb párokat számodra. Ezek az információk csak azok számára láthatók, akik szintén kapcsolatot keresnek.",
-    "dating_hint_title": "Állítsuk be a társkereső profilodat",
     "dating_intro_hint": "Ezt csak olyanok fogják olvasni, akik szintén párt (is) keresnek.  Ha inkább későbbre hagynád ezt, hagyd üresen.",
     "dating_intro_placeholder": "Milyen kapcsolódást keresek...",
-    "dating_intro_subtitle": "Ezt csak olyanok látják, akik szintén párkapcsolatot keresnek, nem azok, akik csak barátokat vagy társaságot keresnek.",
     "dating_intro_title": "Kit keresek",
     "dating_mode_step_hint_active": "Ezzel bekapcsolod a párkereső profilt, amin keresztül kapcsolódhatsz másokkal, akik szintén hasonló céllal (is) vannak itt.  A következő lépésben adj meg egy pár adatot és állítsd be, kikkel szeretnél találkozni.  Csak azok fogják látni az adataidat, akikkel kölcsönösen megfeleltek egymás preferenciáinak.",
     "dating_mode_step_hint_inactive": "Később bármikor be- és kikapcsolhatod ezt a profil oldaladon.",
     "dating_mode_step_title": "Szeretnéd a társkereső módot is használni?",
     "dating_mode_switch": "Pártaláló mód",
     "dating_preferences_title": "Preferenciáim",
-    "finish_button": "Befejezés",
     "gender_subtitle": "Így azonosítom magam",
-    "goals": {
-      "dating": "Romantikus kapcsolatot is keresek",
-      "socializing": "Komákat szeretnék megismerni"
-    },
     "interests_hint": "Kezdj el beírni egy érdeklődési kört, majd válaszd ki a listából.  Több címkét is hozzáadhatsz.",
     "interests_popular_heading": "Mások itt ezekre kíváncsiak:",
     "interests_title": "Mi érdekel?",
@@ -348,10 +278,7 @@
     "languages_title": "Nyelvek",
     "location_hint": "Kezdd el beírni a városod vagy falvad nevét, majd válaszd ki a listából.",
     "location_title": "Hol laksz?",
-    "next_button": "Következő",
-    "photos_subtitle": "Tölts fel egy képet magadról, hogy mások is láthassanak.",
     "photos_title": "Képeim",
-    "relationship_subtitle": "A családi helyzetem:",
     "relationship_title": "Családi helyzetem",
     "social_intro_hint": "Mit érdemes rólam tudni? Kit, mit keresek? (Később is bármikor kitöltheted.)",
     "social_intro_placeholder": "Rovid bemutatkozo",
@@ -374,9 +301,7 @@
   "posts": {
     "actions": {
       "cancel": "Mégse",
-      "contact": "Kapcsolatfelvétel",
       "create": "Mehet",
-      "create_cta": "Új hirdetés...",
       "create_cta_title": "Feladok egy hirdetést",
       "create_advert_cta_title": "Hirdetést adok fel",
       "create_event_cta_title": "Eseményt szervezek",
@@ -389,47 +314,21 @@
     },
     "create_title": "Új hirdetés",
     "edit_title": "Hirdetés szerkesztése",
-    "filters": {
-      "all": "Összes hirdetés",
-      "nearby": "A közelben",
-      "offers": "Ajánlatok",
-      "recent": "Legújabb",
-      "requests": "Keresések"
-    },
     "labels": {
       "content": "Tartalom",
-      "location": "Helyszín",
-      "type": "Típus",
-      "updated": "Utoljára frissítve",
       "visibility": "Látható?"
-    },
-    "location": {
-      "enable": "Helymeghatározás engedélyezése",
-      "prompt": "Engedélyezd a helymeghatározást a közeli hirdetések megtekintéséhez"
     },
     "messages": {
       "confirm_delete": "Biztosan törölni szeretnéd ezt a hirdetést?",
-      "created": "Hirdetés sikeresen létrehozva",
-      "deleted": "Hirdetés sikeresen törölve",
-      "error_create": "Nem sikerült létrehozni a hirdetést",
-      "error_delete": "Nem sikerült törölni a hirdetést",
       "error_load": "Nem sikerült betölteni a hirdetéseket",
-      "error_update": "Nem sikerült frissíteni a hirdetést",
-      "no_my_posts": "Még nem hoztál létre hirdetést",
-      "no_nearby": "Nincsenek közeli hirdetések",
-      "no_posts": "Nincsenek hirdetések",
-      "no_recent": "Nincsenek friss hirdetések",
-      "not_visible": "Ez a hirdetés nem látható mások számára",
-      "updated": "Hirdetés sikeresen frissítve"
+      "no_posts": "Nincsenek hirdetések"
     },
-    "my_posts": "Saját hirdetéseim",
     "placeholders": {
       "content": "Írd le, mit kínálsz vagy mit keresel"
     },
     "share": {
       "post_text": "{publicName} posztolt valamit — nézd meg"
     },
-    "title": "Hirdetőtábla",
     "types": {
       "OFFER": "Kínál",
       "REQUEST": "Keres"
@@ -443,48 +342,18 @@
       "confirmation_yes": "Igen, letiltom",
       "dialog_message_1": "Ha ez a személy zavar téged, itt le tudod tiltani. Ezután nem fog tudni üzeneteket küldeni Neked, sem bármilyen interakcióba lépni a profiloddal. Sehol nem fog megjelenni neked  a továbbiakban, mintha soha nem is létezett volna.",
       "dialog_message_2": "Nem kap értesítést róla, hogy letiltottad.",
-      "dialog_title": "Profil letiltása",
-      "empty": "Nincsenek letiltott felhasználóid.",
-      "title": "Letiltott felhasználók",
-      "unblock_button": "Tiltás feloldása",
-      "unblock_confirmation": "Biztos, hogy fel akarod oldani a tiltását?",
-      "unblock_confirmation_no": "Nem, maradjon blokkolva",
-      "unblock_confirmation_yes": "Igen"
+      "dialog_title": "Profil letiltása"
     },
     "browse": {
       "filters": {
-        "age_range": "Korosztály:",
-        "anywhere": "Bárhol",
-        "button_update_prefs": "Rendben",
-        "dialog_cancel_button": "Mégse",
-        "dialog_ok_button": "Keresés",
-        "explore_tags": "Népszerű érdeklődési körök",
-        "filter_display_label": "Hely:",
         "locate_button_title": "Keress körülöttem",
-        "near_label": "Errefelé:",
-        "search_button_title_dating": "Keresés",
-        "search_button_title_social": "Keresés",
-        "search_placeholder": "Keresés",
-        "social_title": "Itt keresek...",
-        "tags_label": "Érdeklődési körök..."
+        "search_placeholder": "Keresés"
       },
       "invite_button": "Megosztás",
-      "loading_more_profiles": "Egy pillanat...",
-      "no_results_cta_description": "Segíthetsz, ha meghívod barátaidat, hogy csatlakozzanak. Minél többen vagyunk, annál jobb.",
-      "no_results_cta_title": "Ez a közösség még növekszik. Hívd meg pár barátodat a környékről?",
-      "social_no_results": "Errefelé még nem találtunk senkit.",
-      "social_no_results_city": "Errefelé még nem találtunk senkit.",
-      "social_no_results_tags": "Nem találtunk senkit, akinek ezek a dolgok érdekelnének.",
-      "views": {
-        "grid_view_button_title": "Lista nézet",
-        "map_view_button_title": "Térkép nézet"
-      }
+      "no_results_cta_title": "Ez a közösség még növekszik. Hívd meg pár barátodat a környékről?"
     },
     "forms": {
       "age_range": "Korosztály",
-      "age_title_display": "{birthYear}-ben születtem",
-      "city_add_placeholder": "Új város hozzáadása",
-      "city_deselect_label": "Eltávolítás",
       "city_search_placeholder": "Helyek keresése",
       "city_start_typing": "Kezdd el beírni a városod nevét",
       "dating_mode": "Párkereső mód",
@@ -492,8 +361,6 @@
       "dating_mode_view": "Párkereső nézet",
       "dating_mode_view_hint_active": "Ezt látják azok, akikkel kölcsönösen megfeleltek egymás preferenciáinak.",
       "dating_profile_tab": "Profilom",
-      "dictate": "Diktálj",
-      "dictate_listening": "Hallgatom...",
       "edit_button_hint": "Változtatás",
       "edit_titles": {
         "gender_identity": "Nemem",
@@ -517,11 +384,8 @@
       "more_options": "További lehetőségek...",
       "my_dating_profile": "Párkereső profilom",
       "my_preferences": "Kit keresek?",
-      "my_profile": "Adataim",
       "name_first_name_only": "Csak a keresztnevedet",
-      "name_invalid": "Adj meg legalább 3 betűt",
       "name_label": "A keresztnevem...",
-      "preference_kids_label": " ",
       "preview_language": "Előnézeti nyelv",
       "preview_profile": "Profilom előnézete",
       "preview_profile_hint": "Így látják mások a profilomat",
@@ -538,12 +402,9 @@
     "image_editor": {
       "delete_button_title": "Kép eltávolítása"
     },
-    "image_editor_help": "Itt tölts fel képet",
     "image_upload": {
       "add_from_phone": "Kép egy albumból",
       "errors": {
-        "IMAGE_TOO_LARGE": "A kép túl nagy. Kérjük, válassz kisebb fotót (max. 10MB).",
-        "IMAGE_UPLOAD_FAILED": "A kép feltöltése nem sikerült. Kérjük, próbáld újra.",
         "unknown": "Valami hiba történt. Kérjük, próbáld újra."
       },
       "looks_good": "Jól lesz, mehet",
@@ -553,12 +414,8 @@
       "try_another": "Válassz másik képet"
     },
     "more_options_button_title": "További lehetőségek",
-    "no_profile_create": "Profil létrehozása",
-    "no_profile_title": "Töltsd ki a profilodat",
     "profile_not_found": "Nincs ilyen profil",
-    "profile_photos": "{name} fotói",
-    "pronouns_edit_label": "névmások",
-    "send_message_button": "Üzenet"
+    "pronouns_edit_label": "névmások"
   },
   "pronouns": {
     "he_him": "Ő/Ő",
@@ -578,13 +435,10 @@
   "settings": {
     "calls_opt_in_hint": "Ezt minden tagnál külön is letilthatod. Ha egyáltalán nem szeretnél videóhívásokat fogadni, vedd ki a pipát.",
     "email_notifications_opt_in": "e-mail értesítést új üzenetről",
-    "enable_push": "Push értesítések engedélyezése",
-    "language_label": "Nyelv",
     "newsletter_opt_in": "Szívesen kapok alkalmi hírlevelet",
     "newsletter_opt_in_hint": "Közösségi hírek, új funkciók, ilyesmi. Bármikor leiratkozhatsz.",
     "notifications_label": "Értesítések",
     "notifications_opt_in": "Ha üzenetet, lájkot vagy találatot kapok...",
-    "push_notifications": "Push értesítések",
     "push_notify_messages": "Mobil értesítés  új üzenetről",
     "title": "Beállítások"
   },
@@ -597,10 +451,7 @@
     "dialog_cancel_button": "Bezár",
     "edit_button_title": "Szerkesztés",
     "error": {
-      "cancel": "Mégse",
-      "message": "Hiba történt. Kérjük, próbálja meg később újra.",
       "rate_limit": "Hé, lassíts egy kicsit!",
-      "retry": "Retry",
       "title": "Itt elakadtunk."
     },
     "install_banner": {
@@ -613,35 +464,14 @@
     "locale_selector": {
       "help_wanted_translating": "Segíts a fordításban"
     },
-    "modal": {
-      "close": "Zárja be a"
-    },
     "share_dialog": {
       "button_copied": "Másolva",
       "button_copy": "Másolás",
-      "description": "Hívj meg barátokat",
-      "qr_hint": "Villantsd ezt a telefonjukra",
       "share_text": "{publicName} meghívott, hogy csatlakozz a {siteName}-hez",
-      "share_title": "Nézd meg a {siteName}-t",
-      "title": "Terjeszd az igét"
-    },
-    "spinner": {
-      "spinning": "Spinning"
+      "share_title": "Nézd meg a {siteName}-t"
     },
     "submitbutton": {
-      "save": "Mentés",
-      "submit": "Mehet",
       "working": "Dolgozom..."
-    },
-    "toast": {
-      "error": {
-        "message": "Hiba történt. Kérjük, próbáld újra.",
-        "title": "Hiba"
-      },
-      "success": {
-        "message": "A művelet sikeres volt.",
-        "title": "Siker"
-      }
     },
     "update_banner": {
       "message": "Új verzió jelent meg, frissítsünk?",

--- a/packages/shared/i18n/hu.json
+++ b/packages/shared/i18n/hu.json
@@ -28,13 +28,36 @@
   "calls": {
     "accept": "Fogadás",
     "allow_calls_label": "Hívható vagyok",
-    "section_title": "Hívások",
     "call_button_title": "Videóhívás",
     "calling": "Hívás...",
     "cancel_call": "Mégse",
     "decline": "Elutasítás",
     "incoming_call_from": "Bejövő hívás: {name}",
-    "open_to_calls_setting": "Elérhető vagyok videóhívásra"
+    "open_to_calls_setting": "Elérhető vagyok videóhívásra",
+    "section_title": "Hívások"
+  },
+  "community": {
+    "actions": {
+      "cancel": "Mégse",
+      "create": "Mehet",
+      "save": "Közösség mentése"
+    },
+    "labels": {
+      "content": "A közösségről",
+      "founded_since": "{year} óta",
+      "visibility": "Mutasd ezt a közösséget",
+      "year_founded": "Alapítás éve"
+    },
+    "messages": {
+      "error_load": "Nem sikerült betölteni a közösséget"
+    },
+    "placeholders": {
+      "content": "Mesélj a közösségről…",
+      "year_unknown": "Nem tudom / nem biztos"
+    },
+    "share": {
+      "community_text": "{publicName} közösséget vezet — nézd meg"
+    }
   },
   "emails": {
     "fallback_hint": "Ha a gomb nem működik, másold ki és illeszd be ezt a címsorba:",
@@ -103,29 +126,6 @@
       "event_text": "{publicName} eseményt szervez — nézd meg"
     }
   },
-  "community": {
-    "actions": {
-      "cancel": "Mégse",
-      "create": "Mehet",
-      "save": "Közösség mentése"
-    },
-    "labels": {
-      "content": "A közösségről",
-      "year_founded": "Alapítás éve",
-      "founded_since": "{year} óta",
-      "visibility": "Mutasd ezt a közösséget"
-    },
-    "messages": {
-      "error_load": "Nem sikerült betölteni a közösséget"
-    },
-    "placeholders": {
-      "content": "Mesélj a közösségről…",
-      "year_unknown": "Nem tudom / nem biztos"
-    },
-    "share": {
-      "community_text": "{publicName} közösséget vezet — nézd meg"
-    }
-  },
   "gender": {
     "agender": "Agender",
     "androgynous": "Androgün",
@@ -184,6 +184,15 @@
     "you_messaged_them": "Üzenetet küldtél neki",
     "you_smiled_at": "Rámosolyogtál!"
   },
+  "map": {
+    "layer_control": {
+      "aria_label": "Térképrétegek",
+      "communities": "Communities",
+      "events": "Események",
+      "people": "Komák",
+      "posts": "Hirdetések"
+    }
+  },
   "matches": {
     "anonymous_like_hint": "Egyelőre névtelenül mosolygott rád. De a Komakeresőben rátalálhatsz - ha Te is rámosolyogsz, ki fog derülni, ki küldte. Ha valakit ilyen jelöléssel látsz, könnyen lehet, hogy egymást keresitek:",
     "anonymous_like_hint_cta": "A Komakeresőhöz",
@@ -202,15 +211,6 @@
     "received_likes": "{count, plural, =0 {Még nincs ❤️-od} one {# ❤️-ot kaptál} other {# ❤️-od van}}",
     "you_matched_with": "{name} visszamosolygott",
     "you_received_like": "Valaki rád mosolygott!"
-  },
-  "map": {
-    "layer_control": {
-      "people": "Komák",
-      "posts": "Hirdetések",
-      "events": "Események",
-      "communities": "Communities",
-      "aria_label": "Térképrétegek"
-    }
   },
   "messaging": {
     "already_sent_waiting": "Már küldtél nekik üzenetet. Amint válaszolnak, folytathatod a beszélgetést.",
@@ -301,11 +301,12 @@
   "posts": {
     "actions": {
       "cancel": "Mégse",
+      "contact": "Kapcsolatfelvétel",
       "create": "Mehet",
-      "create_cta_title": "Feladok egy hirdetést",
       "create_advert_cta_title": "Hirdetést adok fel",
-      "create_event_cta_title": "Eseményt szervezek",
       "create_community_cta_title": "Create a community",
+      "create_cta_title": "Feladok egy hirdetést",
+      "create_event_cta_title": "Eseményt szervezek",
       "delete": "Törlés",
       "edit": "Szerkesztés",
       "hide": "Elrejtés (törlés nélkül)",

--- a/scripts/cleanup-orphan-i18n.mjs
+++ b/scripts/cleanup-orphan-i18n.mjs
@@ -1,0 +1,126 @@
+#!/usr/bin/env node
+// Throw-away script: find i18n keys referenced in the codebase via t()/$t()
+// and remove keys from packages/shared/i18n/{en,hu}.json that are no longer used.
+//
+// Usage:
+//   node scripts/cleanup-orphan-i18n.mjs           # dry run, lists orphans
+//   node scripts/cleanup-orphan-i18n.mjs --write   # delete orphan keys
+
+import fs from 'node:fs'
+import path from 'node:path'
+import url from 'node:url'
+
+const ROOT = path.resolve(path.dirname(url.fileURLToPath(import.meta.url)), '..')
+const WRITE = process.argv.includes('--write')
+
+const SOURCE_DIRS = [
+  'apps/frontend/src',
+  'apps/admin/src',
+  'apps/backend/src',
+  'packages/shared',
+]
+
+const EXTENSIONS = new Set(['.vue', '.ts', '.tsx', '.js', '.mjs', '.cjs'])
+
+const I18N_FILES = [
+  'packages/shared/i18n/en.json',
+  'packages/shared/i18n/hu.json',
+]
+
+// Prefixes coming from template literals where the prefix is a variable
+// (e.g. useEnumOptions: t(`${prefix}.${value}`)). Keep any key under these.
+const VARIABLE_PREFIX_ALLOWLIST = [
+  'gender',
+  'gender_preferences',
+  'relationship',
+  'haskids',
+  'haskids_label',
+  'haskids_preference',
+  'pronouns',
+]
+
+const STATIC_RE = /(?<![a-zA-Z0-9_$])\$?t\(\s*(['"])([a-zA-Z0-9_.\-]+)\1/g
+const DYNAMIC_RE = /(?<![a-zA-Z0-9_$])\$?t\(\s*`([^`$]*)\$\{/g
+
+function walk(dir, files = []) {
+  for (const ent of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (ent.name === 'node_modules' || ent.name === 'dist' || ent.name === '.turbo') continue
+    const full = path.join(dir, ent.name)
+    if (ent.isDirectory()) walk(full, files)
+    else if (EXTENSIONS.has(path.extname(ent.name))) files.push(full)
+  }
+  return files
+}
+
+const staticKeys = new Set()
+const dynamicPrefixes = new Set(VARIABLE_PREFIX_ALLOWLIST)
+
+let fileCount = 0
+for (const rel of SOURCE_DIRS) {
+  const base = path.join(ROOT, rel)
+  if (!fs.existsSync(base)) continue
+  for (const file of walk(base)) {
+    fileCount++
+    const txt = fs.readFileSync(file, 'utf8')
+    for (const m of txt.matchAll(STATIC_RE)) staticKeys.add(m[2])
+    for (const m of txt.matchAll(DYNAMIC_RE)) {
+      const prefix = m[1].replace(/\.$/, '')
+      if (prefix) dynamicPrefixes.add(prefix)
+    }
+  }
+}
+
+function flatten(obj, prefix, out) {
+  for (const [k, v] of Object.entries(obj)) {
+    const key = prefix ? `${prefix}.${k}` : k
+    if (v && typeof v === 'object' && !Array.isArray(v)) flatten(v, key, out)
+    else out.push(key)
+  }
+}
+
+function isReferenced(key) {
+  if (staticKeys.has(key)) return true
+  for (const p of dynamicPrefixes) {
+    if (key === p || key.startsWith(p + '.')) return true
+  }
+  return false
+}
+
+function prune(obj, prefix) {
+  const out = {}
+  for (const [k, v] of Object.entries(obj)) {
+    const key = prefix ? `${prefix}.${k}` : k
+    if (v && typeof v === 'object' && !Array.isArray(v)) {
+      const inner = prune(v, key)
+      if (Object.keys(inner).length > 0) out[k] = inner
+    } else if (isReferenced(key)) {
+      out[k] = v
+    }
+  }
+  return out
+}
+
+console.log(`Scanned ${fileCount} source files`)
+console.log(`Found ${staticKeys.size} static t() keys`)
+console.log(`Dynamic prefixes: ${[...dynamicPrefixes].sort().join(', ')}\n`)
+
+for (const rel of I18N_FILES) {
+  const file = path.join(ROOT, rel)
+  const json = JSON.parse(fs.readFileSync(file, 'utf8'))
+  const before = []
+  flatten(json, '', before)
+  const pruned = prune(json, '')
+  const after = []
+  flatten(pruned, '', after)
+  const afterSet = new Set(after)
+  const removed = before.filter((k) => !afterSet.has(k))
+  console.log(`${rel}: ${before.length} → ${after.length} keys (${removed.length} orphans)`)
+  for (const k of removed) console.log(`  - ${k}`)
+  if (WRITE) {
+    fs.writeFileSync(file, JSON.stringify(pruned, null, 2) + '\n', 'utf8')
+    console.log(`  ✎ wrote ${rel}`)
+  }
+  console.log()
+}
+
+if (!WRITE) console.log('Dry run — pass --write to apply.')


### PR DESCRIPTION
## Summary

Throw-away script (`scripts/cleanup-orphan-i18n.mjs`) indexes every `t()` / `$t()` call across the frontend, admin and backend source trees, correlates it with `packages/shared/i18n/{en,hu}.json`, and prunes keys that no longer appear anywhere in code.

- 141 keys removed from `en.json` (481 → 340)
- 145 keys removed from `hu.json` (485 → 340, ignoring the 4 `emails.*.footer` keys that were already only present in `hu`)

### How it works

- Walks `apps/frontend/src`, `apps/admin/src`, `apps/backend/src`, `packages/shared` for `.vue`/`.ts`/`.tsx`/`.js`/`.mjs`/`.cjs` files.
- Captures **static keys** from `t('…')` / `$t("…")`.
- Captures **dynamic prefixes** from `` t(`prefix.${var}`) `` and keeps every JSON key starting with that prefix — covers cases like `emails.${emailType}.subject`, `posts.types.${type}`, `profiles.forms.edit_titles.${field}`.
- A small manual allowlist (`gender`, `relationship`, `pronouns`, `haskids*`, etc.) covers `useEnumOptions` where the prefix itself is a variable.

Run with no args for a dry run; pass `--write` to apply.

## Test plan

- [x] `pnpm --filter frontend test` — 629/629 pass
- [x] `pnpm --filter backend test` — 731/731 pass
- [x] `pnpm type-check` — green
- [x] Both JSON files parse and remain key-aligned with their pre-existing en/hu structure

https://claude.ai/code/session_019a6PLXKQ8JojaDoWfTSRLh

---
_Generated by [Claude Code](https://claude.ai/code/session_019a6PLXKQ8JojaDoWfTSRLh)_