### PR TITLE
fix(frontend): stripForPreview returns only first paragraph

### DIFF
--- a/.changeset/copper-rivers-glow.md
+++ b/.changeset/copper-rivers-glow.md
@@ -1,0 +1,5 @@
+---
+'@opencupid/frontend': patch
+---
+
+Conversation list previews now show only the first paragraph of a message.

--- a/apps/frontend/src/lib/__tests__/renderMessage.spec.ts
+++ b/apps/frontend/src/lib/__tests__/renderMessage.spec.ts
@@ -113,4 +113,12 @@ describe('stripForPreview', () => {
   it('collapses whitespace', () => {
     expect(stripForPreview('hello   \n   world')).toBe('hello world')
   })
+
+  it('returns only the first paragraph', () => {
+    expect(stripForPreview('first para\n\nsecond para')).toBe('first para')
+  })
+
+  it('treats lines separated by whitespace-only blank line as paragraph break', () => {
+    expect(stripForPreview('first\n   \nsecond')).toBe('first')
+  })
 })

--- a/apps/frontend/src/lib/renderMessage.ts
+++ b/apps/frontend/src/lib/renderMessage.ts
@@ -33,9 +33,12 @@ export function renderMessage(content: string): string {
   })
 }
 
-/** Strip markdown and HTML for plain-text previews (conversation list, etc.) */
+/** Strip markdown and HTML for plain-text previews (conversation list, etc.).
+ *  Returns only the first paragraph (text up to the first blank line). */
 export function stripForPreview(content: string): string {
-  let text = content
+  let text = content.split(/\n\s*\n/, 1)[0] ?? ''
+
+  text = text
     .replace(/\*\*(.+?)\*\*/g, '$1') // **bold**
     .replace(/\*(.+?)\*/g, '$1') // *italic*
     .replace(/__(.+?)__/g, '$1') // __bold__


### PR DESCRIPTION
## Summary
- `stripForPreview` in `apps/frontend/src/lib/renderMessage.ts` now extracts only the first paragraph (text up to the first blank line) before stripping markdown/HTML and collapsing whitespace.
- Used by the conversation list in `ConversationSummaries.vue`; previously all paragraphs were flattened into a single line via newline-to-space replacement, which produced noisy previews for multi-paragraph messages.
- Single-newline line breaks within a paragraph are still preserved as spaces (existing behavior unchanged).

## Test plan
- [x] `pnpm --filter frontend exec vitest run src/lib/__tests__/renderMessage.spec.ts` — 21 passing, including 2 new cases (`\n\n` separator and whitespace-only blank line)
- [ ] Manual: open `/inbox` with a conversation whose last message has multiple paragraphs and confirm only the first paragraph appears in the summary row

🤖 Generated with [Claude Code](https://claude.com/claude-code)