### PR TITLE
fix(frontend): guard ViewAsDropdown against null viewerProfile

### DIFF
--- a/.changeset/coral-foxes-spin.md
+++ b/.changeset/coral-foxes-spin.md
@@ -1,0 +1,5 @@
+---
+'@opencupid/frontend': patch
+---
+
+Fix TypeError in ViewAsDropdown when viewer profile not yet loaded

--- a/apps/frontend/src/features/myprofile/components/ViewAsDropdown.vue
+++ b/apps/frontend/src/features/myprofile/components/ViewAsDropdown.vue
@@ -12,7 +12,7 @@ import { type OwnerProfile } from '@zod/profile/profile.dto'
 
 const viewState = defineModel<ViewState>({ required: true })
 
-const viewerProfile = inject<Ref<OwnerProfile>>('viewerProfile')
+const viewerProfile = inject<Ref<OwnerProfile | null>>('viewerProfile')
 
 const isDatingActive = defineModel<boolean>('isDatingActive', {
   default: false, // default this to isOnboarded
@@ -21,7 +21,7 @@ const isDatingActive = defineModel<boolean>('isDatingActive', {
 const { getLanguageLabels } = useLanguages()
 
 const languagePreviewOptions = computed(() => {
-  return getLanguageLabels(viewerProfile?.value.languages || [])
+  return getLanguageLabels(viewerProfile?.value?.languages ?? [])
 })
 
 const hasPreviewLanguages = computed(() => languagePreviewOptions.value.length > 1)

--- a/apps/frontend/src/features/myprofile/components/__tests__/ViewAsDropdown.spec.ts
+++ b/apps/frontend/src/features/myprofile/components/__tests__/ViewAsDropdown.spec.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { ref } from 'vue'
+
+vi.mock('@/features/shared/composables/useLanguages', () => ({
+  useLanguages: () => ({
+    getLanguageLabels: (codes: string[]) => codes.map((c) => ({ value: c, label: c })),
+  }),
+}))
+
+vi.mock('@/assets/icons/interface/unhide.svg', () => ({ default: { template: '<span />' } }))
+vi.mock('@/assets/icons/interface/globe.svg', () => ({ default: { template: '<span />' } }))
+vi.mock('@/assets/icons/interface/menu-dots-vert.svg', () => ({
+  default: { template: '<span />' },
+}))
+vi.mock('@/features/shared/profiledisplay/LanguageIcon.vue', () => ({
+  default: { template: '<span />' },
+}))
+
+import ViewAsDropdown from '../ViewAsDropdown.vue'
+
+const globalConfig = {
+  stubs: {
+    BDropdown: { template: '<div><slot name="button-content" /><slot :hide="() => {}" /></div>' },
+    BDropdownText: { template: '<div><slot /></div>' },
+    BDropdownDivider: { template: '<div />' },
+    BDropdownItemButton: { template: '<button><slot /></button>' },
+    BDropdownGroup: { template: '<div><slot /></div>' },
+    BFormCheckbox: { template: '<input type="checkbox" />' },
+  },
+  mocks: { $t: (k: string) => k },
+}
+
+describe('ViewAsDropdown', () => {
+  it('renders without crashing when viewerProfile ref holds null', () => {
+    const wrapper = mount(ViewAsDropdown, {
+      props: {
+        modelValue: {
+          isEditable: false,
+          currentScope: 'social',
+          previewLanguage: 'en',
+          scopes: ['social'],
+        },
+        isDatingActive: false,
+      },
+      global: {
+        ...globalConfig,
+        provide: { viewerProfile: ref(null) },
+      },
+    })
+    expect(wrapper.exists()).toBe(true)
+  })
+
+  it('renders without crashing when viewerProfile is not provided', () => {
+    const wrapper = mount(ViewAsDropdown, {
+      props: {
+        modelValue: {
+          isEditable: false,
+          currentScope: 'social',
+          previewLanguage: 'en',
+          scopes: ['social'],
+        },
+        isDatingActive: false,
+      },
+      global: globalConfig,
+    })
+    expect(wrapper.exists()).toBe(true)
+  })
+
+  it('exposes language options when viewer has languages', () => {
+    const wrapper = mount(ViewAsDropdown, {
+      props: {
+        modelValue: {
+          isEditable: false,
+          currentScope: 'social',
+          previewLanguage: 'en',
+          scopes: ['social'],
+        },
+        isDatingActive: false,
+      },
+      global: {
+        ...globalConfig,
+        provide: { viewerProfile: ref({ languages: ['en', 'hu'] }) },
+      },
+    })
+    expect(wrapper.text()).toContain('en')
+    expect(wrapper.text()).toContain('hu')
+  })
+})


### PR DESCRIPTION
## Summary

Fixes the production Sentry error `TypeError: Cannot read properties of null (reading 'languages')` originating from `ViewAsDropdown.vue`.

## Root cause

`viewerProfile` is injected from `AppShellLayout`, which forwards the owner profile store's `profile` ref. That ref is `null` until the profile loads. In `ViewAsDropdown.vue`, the access was:

```ts
getLanguageLabels(viewerProfile?.value.languages || [])
```

The optional chain only guarded the case where `inject` returns `undefined` (no provider). It did not guard `viewerProfile.value` being `null`, which is the common case during the brief window between mount and the profile fetch resolving — exactly when the user navigates `/browse → /me` per the breadcrumb.

Every other consumer in the codebase (`SendMessageForm`, `ProfileContent`, `ProfileCardComponent`, etc.) types this as `Ref<OwnerProfile | null>` and chains through `.value?.`. `ViewAsDropdown` was inconsistent.

## Changes

- `viewerProfile?.value.languages` → `viewerProfile?.value?.languages`
- Inject type widened from `Ref<OwnerProfile>` to `Ref<OwnerProfile | null>` to match the actual provided value and the rest of the codebase.
- Added regression test covering `ref(null)`, missing provide, and populated viewer.

## Test plan

- [x] `pnpm --filter frontend exec vitest run src/features/myprofile/components/__tests__/ViewAsDropdown.spec.ts` — 3 passing
- [x] `pnpm --filter frontend type-check` — clean
- [ ] Manual: navigate `/browse → /me` rapidly on a fresh load; dropdown should not throw


---
_Generated by [Claude Code](https://claude.ai/code/session_01EqEKz7zJxd87mM7BUs3ynH)_