### PR TITLE
refactor(images): drop ProfileImage.userId, collapse upload to single transaction

### DIFF
--- a/.changeset/silver-images-anchor.md
+++ b/.changeset/silver-images-anchor.md
@@ -1,0 +1,5 @@
+---
+'@opencupid/backend': minor
+---
+
+Drop `ProfileImage.userId` column; images are owned solely by `profileId`. Upload route collapses to a single atomic write that creates the row and syncs `Profile.hasFace` in one transaction.

--- a/.changeset/silver-images-anchor.md
+++ b/.changeset/silver-images-anchor.md
@@ -1,5 +1,6 @@
 ---
 '@opencupid/backend': minor
+'@opencupid/shared': patch
 ---
 
 Drop `ProfileImage.userId` column; images are owned solely by `profileId`. Upload route collapses to a single atomic write that creates the row and syncs `Profile.hasFace` in one transaction.

--- a/apps/backend/prisma/migrations/20260515000000_drop_profileimage_userid/migration.sql
+++ b/apps/backend/prisma/migrations/20260515000000_drop_profileimage_userid/migration.sql
@@ -1,0 +1,9 @@
+-- DropForeignKey
+ALTER TABLE "ProfileImage" DROP CONSTRAINT "ProfileImage_userId_fkey";
+
+-- DropIndex
+DROP INDEX "ProfileImage_userId_idx";
+
+-- AlterTable
+ALTER TABLE "ProfileImage" ALTER COLUMN "profileId" SET NOT NULL;
+ALTER TABLE "ProfileImage" DROP COLUMN "userId";

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -158,8 +158,7 @@ model User {
   roles                   UserRole[] @default([user])
 
   // relations
-  profile      Profile?       @relation
-  ProfileImage ProfileImage[]
+  profile Profile? @relation
 
   requestsSent     ConnectionRequest[] @relation("RequestsSent")
   requestsReceived ConnectionRequest[] @relation("RequestsReceived")
@@ -254,11 +253,9 @@ model LocalizedProfileField {
 }
 
 model ProfileImage {
-  id        String   @id @default(cuid())
-  userId    String
-  user      User     @relation(fields: [userId], references: [id])
-  profileId String?
-  profile   Profile? @relation("ProfileImages", fields: [profileId], references: [id], onDelete: Cascade)
+  id        String  @id @default(cuid())
+  profileId String
+  profile   Profile @relation("ProfileImages", fields: [profileId], references: [id], onDelete: Cascade)
 
   position    Int     @default(0) // order of images, 0 is the primary profile image
   altText     String  @default("")
@@ -277,7 +274,6 @@ model ProfileImage {
   isFlagged   Boolean @default(false)
   hasFace     Boolean @default(false)
 
-  @@index([userId])
   @@index([profileId, position])
 }
 

--- a/apps/backend/src/__tests__/services/image.service.spec.ts
+++ b/apps/backend/src/__tests__/services/image.service.spec.ts
@@ -8,10 +8,11 @@ vi.mock('../../lib/prisma', () => ({
   },
 }))
 
+const mockMakeImageLocation = vi.fn()
 vi.mock('@/lib/media', () => ({
   getMediaRoot: () => '/media',
   imageBasePath: (storagePath: string) => `images/${storagePath}`,
-  makeImageLocation: vi.fn(),
+  makeImageLocation: mockMakeImageLocation,
   mediaUrl: (p: string) => `/media/${p}`,
 }))
 
@@ -27,8 +28,9 @@ vi.mock('../../services/imageprocessor', () => ({
   },
 }))
 
+const mockGenerateContentHash = vi.fn()
 vi.mock('@/utils/hash', () => ({
-  generateContentHash: vi.fn(),
+  generateContentHash: mockGenerateContentHash,
 }))
 
 vi.mock('sharp', () => {
@@ -167,5 +169,58 @@ describe('ImageService.reorderImages', () => {
     await expect(service.reorderImages('p1', items)).rejects.toThrow('Invalid image ID')
     expect(mockPrisma.$transaction).not.toHaveBeenCalled()
     expect(mockPrisma.profileImage.update).not.toHaveBeenCalled()
+  })
+})
+
+describe('ImageService.storeImage', () => {
+  it('creates the row scoped to profileId and syncs Profile.hasFace in one transaction', async () => {
+    mockMakeImageLocation.mockResolvedValue({
+      base: 'abc',
+      relPath: 'p1',
+      absPath: '/media/images/p1',
+    })
+    mockGenerateContentHash.mockResolvedValue('hash-xyz')
+    const processSpy = vi.spyOn(service, 'processImage').mockResolvedValue({
+      mime: 'image/jpeg',
+      variants: { original: '/media/images/p1/abc-original.jpg' },
+      blurhash: 'LK',
+      hasFace: true,
+    } as any)
+    mockPrisma.profileImage.count.mockResolvedValue(2)
+    mockPrisma.profileImage.create.mockResolvedValue({
+      id: 'newimg',
+      profileId: 'p1',
+      position: 2,
+      hasFace: true,
+    })
+    mockPrisma.profileImage.findFirst.mockResolvedValue({ hasFace: true })
+
+    const result = await service.storeImage('p1', '/tmp/upload.jpg', 'caption')
+
+    expect(mockMakeImageLocation).toHaveBeenCalledWith('p1')
+    expect(mockPrisma.$transaction).toHaveBeenCalled()
+    expect(mockPrisma.profileImage.count).toHaveBeenCalledWith({ where: { profileId: 'p1' } })
+    expect(mockPrisma.profileImage.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        profileId: 'p1',
+        position: 2,
+        hasFace: true,
+        contentHash: 'hash-xyz',
+        storagePath: 'p1/abc',
+        altText: 'caption',
+      }),
+    })
+    // syncProfileHasFace runs inside the same transaction.
+    expect(mockPrisma.profileImage.findFirst).toHaveBeenCalledWith({
+      where: { profileId: 'p1', position: 0 },
+      select: { hasFace: true },
+    })
+    expect(mockPrisma.profile.update).toHaveBeenCalledWith({
+      where: { id: 'p1' },
+      data: { hasFace: true },
+    })
+    expect(result).toMatchObject({ id: 'newimg', profileId: 'p1' })
+
+    processSpy.mockRestore()
   })
 })

--- a/apps/backend/src/__tests__/services/profile.service.spec.ts
+++ b/apps/backend/src/__tests__/services/profile.service.spec.ts
@@ -162,50 +162,6 @@ describe('ProfileService.updateProfileScalars', () => {
   })
 })
 
-describe('ProfileService.addProfileImage', () => {
-  it('connects image, syncs Profile.hasFace from position-0 image, and returns updated images', async () => {
-    mockPrisma.profile.update.mockResolvedValue({})
-    mockPrisma.profileImage.findFirst.mockResolvedValue({ hasFace: true })
-    mockPrisma.profile.findUniqueOrThrow.mockResolvedValue({
-      profileImages: [{ id: 'img1' }],
-    })
-
-    const result = await service.addProfileImage('p1', 'img1')
-
-    expect(mockPrisma.$transaction).toHaveBeenCalled()
-    expect(mockPrisma.profile.update).toHaveBeenCalledWith({
-      where: { id: 'p1' },
-      data: { profileImages: { connect: { id: 'img1' } } },
-    })
-    expect(mockPrisma.profileImage.findFirst).toHaveBeenCalledWith({
-      where: { profileId: 'p1', position: 0 },
-      select: { hasFace: true },
-    })
-    expect(mockPrisma.profile.update).toHaveBeenCalledWith({
-      where: { id: 'p1' },
-      data: { hasFace: true },
-    })
-    expect(mockPrisma.profile.findUniqueOrThrow).toHaveBeenCalledWith({
-      where: { id: 'p1' },
-      select: { profileImages: true },
-    })
-    expect(result.profileImages).toHaveLength(1)
-  })
-
-  it('writes hasFace=false when no position-0 image exists', async () => {
-    mockPrisma.profile.update.mockResolvedValue({})
-    mockPrisma.profileImage.findFirst.mockResolvedValue(null)
-    mockPrisma.profile.findUniqueOrThrow.mockResolvedValue({ profileImages: [] })
-
-    await service.addProfileImage('p1', 'img1')
-
-    expect(mockPrisma.profile.update).toHaveBeenCalledWith({
-      where: { id: 'p1' },
-      data: { hasFace: false },
-    })
-  })
-})
-
 describe('ProfileService.addProfileTag / removeProfileTag', () => {
   it('connects a tag', async () => {
     mockPrisma.profile.update.mockResolvedValue({})

--- a/apps/backend/src/api/routes/image.route.ts
+++ b/apps/backend/src/api/routes/image.route.ts
@@ -2,10 +2,9 @@ import { z } from 'zod'
 import { FastifyPluginAsync } from 'fastify'
 import multipart, { MultipartValue } from '@fastify/multipart'
 
-import { ProfileService } from '@/services/profile.service'
 import { ImageService } from '@/services/image.service'
 import { uploadTmpDir } from '@/lib/media'
-import { rateLimitConfig, sendError, sendForbiddenError } from '../helpers'
+import { rateLimitConfig, sendError } from '../helpers'
 import { mapProfileImagesToOwner } from '@/api/mappers/profile.mappers'
 import { ReorderProfileImagesPayloadSchema } from '@zod/profile/profileimage.dto'
 import { appConfig } from '@/lib/appconfig'
@@ -30,8 +29,6 @@ const imageRoutes: FastifyPluginAsync = async (fastify) => {
     attachFieldsToBody: false,
   })
 
-  // instantiate services
-  const profileService = ProfileService.getInstance()
   const imageService = ImageService.getInstance()
 
   /**
@@ -41,7 +38,7 @@ const imageRoutes: FastifyPluginAsync = async (fastify) => {
    */
   fastify.get('/me', { onRequest: [fastify.authenticate] }, async (req, reply) => {
     try {
-      const rawImages = await imageService.listImages(req.user.userId)
+      const rawImages = await imageService.listImages(req.session.profileId)
       const images = mapProfileImagesToOwner(rawImages)
       const response: ImageApiResponse = { success: true, images }
       return reply.code(200).send(response)
@@ -98,22 +95,17 @@ const imageRoutes: FastifyPluginAsync = async (fastify) => {
           : fileUpload.fields.captionText) as MultipartValue
       ).value ?? '') as string
 
-      const profile = await profileService.getProfileByUserId(req.user.userId)
-      if (!profile) {
-        return sendError(reply, 404, 'No user profile to link the image to')
-      }
-
       try {
         const stored = await imageService.storeImage(
-          req.user.userId,
+          req.session.profileId,
           fileUpload.filepath,
           captionText
         )
         if (!stored) {
           return sendError(reply, 500, 'Failed to store image')
         }
-        const updated = await profileService.addProfileImage(profile.id, stored.id)
-        const images = mapProfileImagesToOwner(updated.profileImages)
+        const updated = await imageService.listImages(req.session.profileId)
+        const images = mapProfileImagesToOwner(updated)
         const response: ImageApiResponse = { success: true, images }
         return reply.code(200).send(response)
       } catch (err) {
@@ -137,10 +129,7 @@ const imageRoutes: FastifyPluginAsync = async (fastify) => {
       if (!ok) {
         return sendError(reply, 500, 'Failed to delete image')
       }
-      const updated = await imageService.listImages(req.user.userId)
-      if (!updated) {
-        return sendError(reply, 400, 'No user profile found to update after image deletion')
-      }
+      const updated = await imageService.listImages(req.session.profileId)
       const images = mapProfileImagesToOwner(updated)
       const response: ImageApiResponse = { success: true, images }
       return reply.code(200).send(response)

--- a/apps/backend/src/api/routes/image.route.ts
+++ b/apps/backend/src/api/routes/image.route.ts
@@ -96,14 +96,7 @@ const imageRoutes: FastifyPluginAsync = async (fastify) => {
       ).value ?? '') as string
 
       try {
-        const stored = await imageService.storeImage(
-          req.session.profileId,
-          fileUpload.filepath,
-          captionText
-        )
-        if (!stored) {
-          return sendError(reply, 500, 'Failed to store image')
-        }
+        await imageService.storeImage(req.session.profileId, fileUpload.filepath, captionText)
         const updated = await imageService.listImages(req.session.profileId)
         const images = mapProfileImagesToOwner(updated)
         const response: ImageApiResponse = { success: true, images }

--- a/apps/backend/src/services/image.service.ts
+++ b/apps/backend/src/services/image.service.ts
@@ -45,18 +45,11 @@ export class ImageService {
   }
 
   /**
-   * Get a single image by ID for the authenticated user
+   * List all images for a profile, ordered by position
    */
-  async getImage(id: string, userId: string): Promise<ProfileImage | null> {
-    return prisma.profileImage.findFirst({ where: { id, userId } })
-  }
-
-  /**
-   * List all images for a given user, most recent last
-   */
-  async listImages(userId: string): Promise<ProfileImage[]> {
+  async listImages(profileId: string): Promise<ProfileImage[]> {
     return prisma.profileImage.findMany({
-      where: { userId },
+      where: { profileId },
       orderBy: { position: 'asc' },
     })
   }
@@ -75,52 +68,49 @@ export class ImageService {
   }
 
   /**
-   * Store an image uploaded by the user
-   * @param userId - ID of the user uploading the image
-   * @param fileUpload - The uploaded file object
-   * @param captionText - Optional caption or alt text for the image
-   * Returns the created ProfileImage record
+   * Store an image uploaded for a profile.
+   * Creates the ProfileImage row and re-syncs Profile.hasFace in one transaction,
+   * so the invariant Profile.hasFace == position-0 image's hasFace always holds.
    */
   async storeImage(
-    userId: string,
+    profileId: string,
     tmpImagePath: string,
     captionText: string
   ): Promise<ProfileImage> {
     let imageLocation
 
-    // create image subdir, generate basename
     try {
-      imageLocation = await makeImageLocation(userId)
+      imageLocation = await makeImageLocation(profileId)
     } catch (err: any) {
       console.error('Failed to create dest dir', err)
       throw new Error('Failed to create dest dir')
     }
 
     try {
-      // Process the image and save resized variants
       const processed = await this.processImage(
         tmpImagePath,
         imageLocation.absPath,
         imageLocation.base
       )
-      // compute the content hash of the original
       const contentHash = await generateContentHash(processed.variants.original)
-      // set position to be the last position
-      const position = await prisma.profileImage.count({ where: { userId } })
 
-      // Create a new ProfileImage record
-      return await prisma.profileImage.create({
-        data: {
-          userId: userId,
-          mimeType: processed.mime,
-          altText: captionText,
-          storagePath: path.join(imageLocation.relPath, imageLocation.base),
-          isModerated: false,
-          contentHash: contentHash,
-          blurhash: processed.blurhash,
-          hasFace: processed.hasFace,
-          position: position,
-        },
+      return await prisma.$transaction(async (tx) => {
+        const position = await tx.profileImage.count({ where: { profileId } })
+        const created = await tx.profileImage.create({
+          data: {
+            profileId,
+            mimeType: processed.mime,
+            altText: captionText,
+            storagePath: path.join(imageLocation.relPath, imageLocation.base),
+            isModerated: false,
+            contentHash,
+            blurhash: processed.blurhash,
+            hasFace: processed.hasFace,
+            position,
+          },
+        })
+        await syncProfileHasFace(tx, profileId)
+        return created
       })
     } catch (err: any) {
       console.error('Failed to process image', err)

--- a/apps/backend/src/services/profile.service.ts
+++ b/apps/backend/src/services/profile.service.ts
@@ -385,25 +385,6 @@ export class ProfileService {
     }
   }
 
-  public async addProfileImage(
-    profileId: string,
-    imageId: string
-  ): Promise<{
-    profileImages: ProfileImage[]
-  }> {
-    return prisma.$transaction(async (tx) => {
-      await tx.profile.update({
-        where: { id: profileId },
-        data: { profileImages: { connect: { id: imageId } } },
-      })
-      await syncProfileHasFace(tx, profileId)
-      return tx.profile.findUniqueOrThrow({
-        where: { id: profileId },
-        select: { profileImages: true },
-      })
-    })
-  }
-
   async addProfileTag(profileId: string, tagId: string): Promise<void> {
     await prisma.profile.update({
       where: { id: profileId },

--- a/packages/shared/zod/generated/inputTypeSchemas/ProfileImageScalarFieldEnumSchema.ts
+++ b/packages/shared/zod/generated/inputTypeSchemas/ProfileImageScalarFieldEnumSchema.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
 
-export const ProfileImageScalarFieldEnumSchema = z.enum(['id','userId','profileId','position','altText','storagePath','url','width','height','mimeType','createdAt','updatedAt','contentHash','blurhash','isModerated','isFlagged','hasFace']);
+export const ProfileImageScalarFieldEnumSchema = z.enum(['id','profileId','position','altText','storagePath','url','width','height','mimeType','createdAt','updatedAt','contentHash','blurhash','isModerated','isFlagged','hasFace']);
 
 export default ProfileImageScalarFieldEnumSchema;

--- a/packages/shared/zod/generated/modelSchema/ProfileImageSchema.ts
+++ b/packages/shared/zod/generated/modelSchema/ProfileImageSchema.ts
@@ -6,8 +6,7 @@ import { z } from 'zod';
 
 export const ProfileImageSchema = z.object({
   id: z.cuid(),
-  userId: z.string(),
-  profileId: z.string().nullable(),
+  profileId: z.string(),
   position: z.number().int(),
   altText: z.string(),
   storagePath: z.string(),


### PR DESCRIPTION
## Summary

- `ProfileImage.userId` column dropped — images are owned solely by `profileId`. `profileId` is now `NOT NULL` with a single FK back to `Profile` (`ON DELETE CASCADE`).
- `storeImage(profileId, …)` is now a single Prisma `$transaction` that inserts the row and runs `syncProfileHasFace` atomically. The previous two-step path (create with userId in service A, connect to profile in service B) is gone.
- `image.route.ts` uses `req.session.profileId` for all routes; the per-request `getProfileByUserId` lookup is removed (one less DB roundtrip per upload).
- Dead methods deleted: `profileService.addProfileImage` and `imageService.getImage`. Their tests removed.

## Migration

`20260515000000_drop_profileimage_userid` — 4 statements: drop FK, drop index, set `profileId NOT NULL`, drop `userId` column. Verified safe against prod (`SELECT count(*) FROM "ProfileImage" WHERE "profileId" IS NULL` returns 0 — no backfill or orphan cleanup needed).

## Why now

The orphan window between the two writes (row exists with userId but no profileId) was a latent crash hazard. Collapsing into one transaction removes the state-machine fork; making `profileId` non-nullable enforces the invariant at the schema level. Also closes the inconsistency where `ProfileImage` was the only model in the schema carrying both `userId` and `profileId` — every other content-bearing model already uses `profileId` alone.

## Test plan

- [x] Backend test suite passes (748/748) — includes new `storeImage` test exercising the collapsed transaction and `hasFace` invariant
- [x] Frontend test suite passes (659/659) — no contract change for the client
- [x] `pnpm type-check` green across admin, backend, frontend
- [x] Migration applies cleanly against a prod-restored dev DB
- [ ] CI green
- [ ] Smoke test: upload a profile image in dev, verify `Profile.hasFace` flips when the position-0 image has a face

🤖 Generated with [Claude Code](https://claude.com/claude-code)