### PR TITLE
fix(messaging): SPAM_BURST is non-destructive and 24h-windowed

### DIFF
--- a/.changeset/spam-burst-non-destructive-windowed.md
+++ b/.changeset/spam-burst-non-destructive-windowed.md
@@ -1,0 +1,5 @@
+---
+'@opencupid/backend': patch
+---
+
+Fix SPAM_BURST: hold messages instead of destroying them, and scope the threshold to a 24h window. Held messages are now released to recipients when the flag clears, and old unanswered intros no longer count toward the burst threshold.

--- a/apps/backend/src/__tests__/routes/messaging.route.spec.ts
+++ b/apps/backend/src/__tests__/routes/messaging.route.spec.ts
@@ -134,6 +134,7 @@ beforeEach(async () => {
   reply = new MockReply()
   mockTrustService = {
     hasTrustFlag: vi.fn().mockResolvedValue(false),
+    reconcileSpamBurst: vi.fn().mockResolvedValue(undefined),
   }
   mockMessageService = {
     listMessagesForConversation: vi.fn(),
@@ -1166,11 +1167,9 @@ describe('profile-trust integration', () => {
   })
 
   // PENDING outcome: quarantined sender writes a new convo → PENDING, no recipient side effects.
-  it('quarantined sender: PENDING outcome suppresses notifications, enqueues reconcile', async () => {
+  it('quarantined sender: PENDING outcome suppresses notifications, runs reconcile', async () => {
     const { broadcastToProfile } = await import('../../utils/wsUtils')
-    const { profileTrustQueue } = await import('@/queues/profileTrustQueue')
     ;(broadcastToProfile as any).mockClear()
-    const spy = vi.spyOn(profileTrustQueue, 'add').mockResolvedValue({} as any)
 
     mockTrustService.hasTrustFlag.mockResolvedValue(true)
     mockMessageService.resolveConversation.mockResolvedValue({
@@ -1196,12 +1195,8 @@ describe('profile-trust integration', () => {
     )
     expect(newMessageCalls).toHaveLength(0)
     expect(mockNotifierService.notifyProfile).not.toHaveBeenCalled()
-    // But reconcile WAS enqueued.
-    expect(spy).toHaveBeenCalledWith(
-      'reconcile-one',
-      { kind: 'reconcile-one', profileId: senderProfileId },
-      expect.objectContaining({ jobId: `trust-${senderProfileId}` })
-    )
+    // But reconcile WAS run.
+    expect(mockTrustService.reconcileSpamBurst).toHaveBeenCalledWith(senderProfileId)
     // resolveConversation received createAsPending: true
     expect(mockMessageService.resolveConversation).toHaveBeenCalledWith(
       fastify.prisma,
@@ -1209,15 +1204,10 @@ describe('profile-trust integration', () => {
       'ck1234567890abcd12345678',
       { createAsPending: true }
     )
-
-    spy.mockRestore()
   })
 
   // accept_and_promote_pending: recipient (not quarantined) replies into sender's PENDING.
-  it('accept_and_promote_pending: promote + accept, notify, no enqueue', async () => {
-    const { profileTrustQueue } = await import('@/queues/profileTrustQueue')
-    const spy = vi.spyOn(profileTrustQueue, 'add').mockResolvedValue({} as any)
-
+  it('accept_and_promote_pending: promote + accept, notify, no reconcile', async () => {
     // Bob (p1) is sending into a PENDING initiated by Alice ('other-user').
     mockTrustService.hasTrustFlag.mockResolvedValue(false)
     mockMessageService.resolveConversation.mockResolvedValue({
@@ -1246,53 +1236,36 @@ describe('profile-trust integration', () => {
       'conv1'
     )
     expect(mockNotifierService.notifyProfile).toHaveBeenCalled()
-    // Sender did NOT add a new row to their own count — no enqueue.
-    expect(spy).not.toHaveBeenCalled()
-
-    spy.mockRestore()
+    // Sender did NOT add a new row to their own count — no reconcile.
+    expect(mockTrustService.reconcileSpamBurst).not.toHaveBeenCalled()
   })
 
-  // Test B — enqueue called on new_conversation
-  it('enqueues reconcile-one job when outcome is new_conversation', async () => {
-    const { profileTrustQueue } = await import('@/queues/profileTrustQueue')
-    const spy = vi.spyOn(profileTrustQueue, 'add').mockResolvedValue({} as any)
-
+  // Test B — reconcile called on new_conversation
+  it('runs reconcileSpamBurst when outcome is new_conversation', async () => {
     const handler = fastify.routes['POST /message']
     mockNewConversationSend()
 
     await handler({ session: { profileId: senderProfileId }, body: validBody } as any, reply as any)
 
     expect(reply.statusCode).toBe(200)
-    expect(spy).toHaveBeenCalledTimes(1)
-    expect(spy).toHaveBeenCalledWith(
-      'reconcile-one',
-      { kind: 'reconcile-one', profileId: senderProfileId },
-      expect.objectContaining({ jobId: `trust-${senderProfileId}` })
-    )
-
-    spy.mockRestore()
+    expect(mockTrustService.reconcileSpamBurst).toHaveBeenCalledTimes(1)
+    expect(mockTrustService.reconcileSpamBurst).toHaveBeenCalledWith(senderProfileId)
   })
 
-  // Test C — enqueue NOT called on other outcomes (reply)
-  it('does not enqueue when outcome is reply', async () => {
-    const { profileTrustQueue } = await import('@/queues/profileTrustQueue')
-    const spy = vi.spyOn(profileTrustQueue, 'add').mockResolvedValue({} as any)
-
+  // Test C — reconcile NOT called on other outcomes (reply)
+  it('does not run reconcileSpamBurst when outcome is reply', async () => {
     const handler = fastify.routes['POST /message']
     mockReplySend()
 
     await handler({ session: { profileId: senderProfileId }, body: validBody } as any, reply as any)
 
     expect(reply.statusCode).toBe(200)
-    expect(spy).not.toHaveBeenCalled()
-
-    spy.mockRestore()
+    expect(mockTrustService.reconcileSpamBurst).not.toHaveBeenCalled()
   })
 
-  // Test D — send succeeds even when enqueue rejects
-  it('returns 200 even when enqueue throws (fire-and-forget)', async () => {
-    const { profileTrustQueue } = await import('@/queues/profileTrustQueue')
-    const spy = vi.spyOn(profileTrustQueue, 'add').mockRejectedValue(new Error('redis down'))
+  // Test D — send succeeds even when reconcile rejects (best-effort)
+  it('returns 200 even when reconcileSpamBurst throws (best-effort)', async () => {
+    mockTrustService.reconcileSpamBurst.mockRejectedValue(new Error('db down'))
 
     const handler = fastify.routes['POST /message']
     mockNewConversationSend()
@@ -1300,8 +1273,6 @@ describe('profile-trust integration', () => {
     await handler({ session: { profileId: senderProfileId }, body: validBody } as any, reply as any)
 
     expect(reply.statusCode).toBe(200)
-
-    spy.mockRestore()
   })
 })
 

--- a/apps/backend/src/__tests__/services/messaging.service.spec.ts
+++ b/apps/backend/src/__tests__/services/messaging.service.spec.ts
@@ -491,8 +491,8 @@ describe('MessageService.promoteConversation', () => {
 
   it('is a silent no-op when count===0 (peer-promoted, DISCARDED, BLOCKED, or absent)', async () => {
     // The status filter on PENDING absorbs every concurrent transition without
-    // a probe: peer-promoter, SPAM_BURST → DISCARDED, recipient → BLOCKED, or
-    // a row that no longer exists all collapse to count===0 → return without
+    // a probe: peer-promoter, recipient → BLOCKED, an admin/moderation DISCARD,
+    // or a row that no longer exists all collapse to count===0 → return without
     // inserting the participant (the prior promoter inserted it, or the row
     // shouldn't be revived).
     const updateMany = vi.fn().mockResolvedValue({ count: 0 })

--- a/apps/backend/src/__tests__/services/profileTrust.service.spec.ts
+++ b/apps/backend/src/__tests__/services/profileTrust.service.spec.ts
@@ -24,7 +24,7 @@ vi.mock('@/services/messaging.service', () => ({
 }))
 
 import { prisma } from '../../lib/prisma'
-import { ProfileTrustService } from '../../services/profileTrust.service'
+import { ProfileTrustService, SPAM_BURST_WINDOW_MS } from '../../services/profileTrust.service'
 
 const mockedFindFirst = vi.mocked(prisma.profileTrustFlag.findFirst)
 
@@ -204,7 +204,7 @@ describe('ProfileTrustService', () => {
         mockedFindFirst.mockResolvedValue(null)
         await svc.reconcileSpamBurst('profile-1')
 
-        const expectedSince = new Date(FROZEN_NOW.getTime() - 24 * 60 * 60 * 1000)
+        const expectedSince = new Date(FROZEN_NOW.getTime() - SPAM_BURST_WINDOW_MS)
         const call = conversationCount.mock.calls[0][0] as any
         expect((call.where.createdAt as { gte: Date }).gte.toISOString()).toBe(
           expectedSince.toISOString()
@@ -226,7 +226,7 @@ describe('ProfileTrustService', () => {
         mockedFindFirst.mockResolvedValue(null)
         await svc.reconcileSpamBurst('profile-1')
 
-        const expectedSince = new Date(FROZEN_NOW.getTime() - 24 * 60 * 60 * 1000)
+        const expectedSince = new Date(FROZEN_NOW.getTime() - SPAM_BURST_WINDOW_MS)
         const countCall = conversationCount.mock.calls[0][0] as any
         const updateCall = conversationUpdateMany.mock.calls[0][0] as any
         expect((countCall.where.createdAt as { gte: Date }).gte.toISOString()).toBe(

--- a/apps/backend/src/__tests__/services/profileTrust.service.spec.ts
+++ b/apps/backend/src/__tests__/services/profileTrust.service.spec.ts
@@ -102,7 +102,7 @@ describe('ProfileTrustService', () => {
       queueAdd.mockReset()
     })
 
-    it('writes flag AND DISCARDs active (INITIATED+PENDING) when threshold reached and not already flagged', async () => {
+    it('writes flag AND demotes in-window INITIATED → PENDING when threshold reached and not already flagged', async () => {
       conversationCount.mockResolvedValue(3)
       mockedFindFirst.mockResolvedValue(null) // hasTrustFlag returns false
 
@@ -119,16 +119,17 @@ describe('ProfileTrustService', () => {
       expect(conversationUpdateMany).toHaveBeenCalledWith({
         where: {
           initiatorProfileId: 'profile-1',
-          status: { in: ['INITIATED', 'PENDING'] },
+          status: 'INITIATED',
+          createdAt: { gte: expect.any(Date) },
         },
-        data: { status: 'DISCARDED' },
+        data: { status: 'PENDING' },
       })
     })
 
-    it('DISCARDs race-survivors when at threshold and already flagged (convergence)', async () => {
+    it('demotes race-survivors when at threshold and already flagged (convergence)', async () => {
       // Models the race: a send crossed the route's pre-tx hasTrustFlag check BEFORE
       // the flag landed, so when reconcile runs next, it sees count >= threshold AND
-      // alreadyFlagged. The just-created INITIATED must still be DISCARDed.
+      // alreadyFlagged. The just-created INITIATED must still be demoted to PENDING.
       conversationCount.mockResolvedValue(3)
       mockedFindFirst.mockResolvedValue({ id: 'flag-1' } as any) // already flagged
 
@@ -136,13 +137,14 @@ describe('ProfileTrustService', () => {
 
       // No new flag written — idempotent.
       expect(profileTrustFlagCreate).not.toHaveBeenCalled()
-      // But active-row DISCARD DOES run — this is the convergence guarantee.
+      // But in-window INITIATED demotion DOES run — this is the convergence guarantee.
       expect(conversationUpdateMany).toHaveBeenCalledWith({
         where: {
           initiatorProfileId: 'profile-1',
-          status: { in: ['INITIATED', 'PENDING'] },
+          status: 'INITIATED',
+          createdAt: { gte: expect.any(Date) },
         },
-        data: { status: 'DISCARDED' },
+        data: { status: 'PENDING' },
       })
       // Not in the clear branch.
       expect(profileTrustFlagUpdateMany).not.toHaveBeenCalled()
@@ -179,13 +181,90 @@ describe('ProfileTrustService', () => {
       expect(queueAdd).not.toHaveBeenCalled()
     })
 
-    it('threshold-counting query includes both INITIATED and PENDING', async () => {
+    it('threshold-counting query includes both INITIATED and PENDING and a createdAt window', async () => {
       conversationCount.mockResolvedValue(0)
       mockedFindFirst.mockResolvedValue(null)
       await svc.reconcileSpamBurst('profile-1')
       expect(conversationCount).toHaveBeenCalledWith({
-        where: { initiatorProfileId: 'profile-1', status: { in: ['INITIATED', 'PENDING'] } },
+        where: {
+          initiatorProfileId: 'profile-1',
+          status: { in: ['INITIATED', 'PENDING'] },
+          createdAt: { gte: expect.any(Date) },
+        },
       })
+    })
+
+    it('threshold window is 24 hours back from now', async () => {
+      // Freeze time so we can assert the exact `gte` boundary.
+      const FROZEN_NOW = new Date('2026-05-15T09:13:23.161Z')
+      vi.useFakeTimers()
+      vi.setSystemTime(FROZEN_NOW)
+      try {
+        conversationCount.mockResolvedValue(0)
+        mockedFindFirst.mockResolvedValue(null)
+        await svc.reconcileSpamBurst('profile-1')
+
+        const expectedSince = new Date(FROZEN_NOW.getTime() - 24 * 60 * 60 * 1000)
+        const call = conversationCount.mock.calls[0][0] as any
+        expect((call.where.createdAt as { gte: Date }).gte.toISOString()).toBe(
+          expectedSince.toISOString()
+        )
+      } finally {
+        vi.useRealTimers()
+      }
+    })
+
+    it('demotion updateMany shares the same window as the count', async () => {
+      // The window must apply to both predicates: counting ancients gives false-positive
+      // flag-clear oscillation; demoting ancients hides messages recipients have had
+      // for weeks. Both must be windowed identically.
+      const FROZEN_NOW = new Date('2026-05-15T09:13:23.161Z')
+      vi.useFakeTimers()
+      vi.setSystemTime(FROZEN_NOW)
+      try {
+        conversationCount.mockResolvedValue(3)
+        mockedFindFirst.mockResolvedValue(null)
+        await svc.reconcileSpamBurst('profile-1')
+
+        const expectedSince = new Date(FROZEN_NOW.getTime() - 24 * 60 * 60 * 1000)
+        const countCall = conversationCount.mock.calls[0][0] as any
+        const updateCall = conversationUpdateMany.mock.calls[0][0] as any
+        expect((countCall.where.createdAt as { gte: Date }).gte.toISOString()).toBe(
+          expectedSince.toISOString()
+        )
+        expect((updateCall.where.createdAt as { gte: Date }).gte.toISOString()).toBe(
+          expectedSince.toISOString()
+        )
+      } finally {
+        vi.useRealTimers()
+      }
+    })
+
+    it('does not demote PENDING rows (they are already held)', async () => {
+      // The updateMany predicate targets only INITIATED, not PENDING. PENDING rows are
+      // already in the held state — re-writing them would be a no-op and would
+      // misleadingly bump updatedAt.
+      conversationCount.mockResolvedValue(5)
+      mockedFindFirst.mockResolvedValue(null)
+      await svc.reconcileSpamBurst('profile-1')
+      const call = conversationUpdateMany.mock.calls[0][0] as any
+      expect(call.where.status).toBe('INITIATED')
+    })
+
+    it('regression: never writes status=DISCARDED on any code path', async () => {
+      // Guards against accidental reintroduction of the destructive enforcement. The
+      // pre-fix code wrote DISCARDED in both threshold-reached branches; under the
+      // structural fix, no reconcile path writes DISCARDED — that state is reserved
+      // for moderation / partial-unique-index tombstoning, not flag enforcement.
+      mockedFindFirst.mockResolvedValue(null)
+      for (const count of [0, 1, 2, 3, 5, 50]) {
+        conversationUpdateMany.mockReset()
+        conversationCount.mockResolvedValue(count)
+        await svc.reconcileSpamBurst('profile-1')
+        for (const call of conversationUpdateMany.mock.calls) {
+          expect((call[0] as any).data.status).not.toBe('DISCARDED')
+        }
+      }
     })
   })
 

--- a/apps/backend/src/__tests__/services/profileTrust.service.spec.ts
+++ b/apps/backend/src/__tests__/services/profileTrust.service.spec.ts
@@ -102,7 +102,7 @@ describe('ProfileTrustService', () => {
       queueAdd.mockReset()
     })
 
-    it('writes flag AND demotes in-window INITIATED → PENDING when threshold reached and not already flagged', async () => {
+    it('writes flag when threshold reached and not already flagged', async () => {
       conversationCount.mockResolvedValue(3)
       mockedFindFirst.mockResolvedValue(null) // hasTrustFlag returns false
 
@@ -116,37 +116,19 @@ describe('ProfileTrustService', () => {
           flaggedBy: 'heuristic:spam_burst',
         }),
       })
-      expect(conversationUpdateMany).toHaveBeenCalledWith({
-        where: {
-          initiatorProfileId: 'profile-1',
-          status: 'INITIATED',
-          createdAt: { gte: expect.any(Date) },
-        },
-        data: { status: 'PENDING' },
-      })
+      // Existing rows are not touched — flag-and-gate, not flag-and-converge.
+      expect(conversationUpdateMany).not.toHaveBeenCalled()
     })
 
-    it('demotes race-survivors when at threshold and already flagged (convergence)', async () => {
-      // Models the race: a send crossed the route's pre-tx hasTrustFlag check BEFORE
-      // the flag landed, so when reconcile runs next, it sees count >= threshold AND
-      // alreadyFlagged. The just-created INITIATED must still be demoted to PENDING.
+    it('is a no-op when at threshold and already flagged (idempotent)', async () => {
       conversationCount.mockResolvedValue(3)
       mockedFindFirst.mockResolvedValue({ id: 'flag-1' } as any) // already flagged
 
       await svc.reconcileSpamBurst('profile-1')
 
-      // No new flag written — idempotent.
+      // No second flag, no row-status writes, not in the clear branch.
       expect(profileTrustFlagCreate).not.toHaveBeenCalled()
-      // But in-window INITIATED demotion DOES run — this is the convergence guarantee.
-      expect(conversationUpdateMany).toHaveBeenCalledWith({
-        where: {
-          initiatorProfileId: 'profile-1',
-          status: 'INITIATED',
-          createdAt: { gte: expect.any(Date) },
-        },
-        data: { status: 'PENDING' },
-      })
-      // Not in the clear branch.
+      expect(conversationUpdateMany).not.toHaveBeenCalled()
       expect(profileTrustFlagUpdateMany).not.toHaveBeenCalled()
       expect(queueAdd).not.toHaveBeenCalled()
     })
@@ -214,56 +196,30 @@ describe('ProfileTrustService', () => {
       }
     })
 
-    it('demotion updateMany shares the same window as the count', async () => {
-      // The window must apply to both predicates: counting ancients gives false-positive
-      // flag-clear oscillation; demoting ancients hides messages recipients have had
-      // for weeks. Both must be windowed identically.
-      const FROZEN_NOW = new Date('2026-05-15T09:13:23.161Z')
-      vi.useFakeTimers()
-      vi.setSystemTime(FROZEN_NOW)
-      try {
-        conversationCount.mockResolvedValue(3)
-        mockedFindFirst.mockResolvedValue(null)
-        await svc.reconcileSpamBurst('profile-1')
-
-        const expectedSince = new Date(FROZEN_NOW.getTime() - SPAM_BURST_WINDOW_MS)
-        const countCall = conversationCount.mock.calls[0][0] as any
-        const updateCall = conversationUpdateMany.mock.calls[0][0] as any
-        expect((countCall.where.createdAt as { gte: Date }).gte.toISOString()).toBe(
-          expectedSince.toISOString()
-        )
-        expect((updateCall.where.createdAt as { gte: Date }).gte.toISOString()).toBe(
-          expectedSince.toISOString()
-        )
-      } finally {
-        vi.useRealTimers()
-      }
-    })
-
-    it('does not demote PENDING rows (they are already held)', async () => {
-      // The updateMany predicate targets only INITIATED, not PENDING. PENDING rows are
-      // already in the held state — re-writing them would be a no-op and would
-      // misleadingly bump updatedAt.
-      conversationCount.mockResolvedValue(5)
-      mockedFindFirst.mockResolvedValue(null)
-      await svc.reconcileSpamBurst('profile-1')
-      const call = conversationUpdateMany.mock.calls[0][0] as any
-      expect(call.where.status).toBe('INITIATED')
-    })
-
-    it('regression: never writes status=DISCARDED on any code path', async () => {
-      // Guards against accidental reintroduction of the destructive enforcement. The
-      // pre-fix code wrote DISCARDED in both threshold-reached branches; under the
-      // structural fix, no reconcile path writes DISCARDED — that state is reserved
-      // for moderation / partial-unique-index tombstoning, not flag enforcement.
-      mockedFindFirst.mockResolvedValue(null)
-      for (const count of [0, 1, 2, 3, 5, 50]) {
+    it('regression: never writes any conversation-row change on any code path', async () => {
+      // Guards against accidental reintroduction of row-touching enforcement. Under
+      // the flag-and-gate policy, reconcileSpamBurst maintains the SPAM_BURST flag
+      // only — existing conversation rows are never modified by this function.
+      // Sweeps the full case matrix (below/at/over threshold × flagged/not).
+      for (const [count, flagged] of [
+        [0, false],
+        [1, false],
+        [2, false],
+        [3, false],
+        [5, false],
+        [50, false],
+        [0, true],
+        [1, true],
+        [2, true],
+        [3, true],
+        [5, true],
+        [50, true],
+      ] as const) {
         conversationUpdateMany.mockReset()
         conversationCount.mockResolvedValue(count)
+        mockedFindFirst.mockResolvedValue(flagged ? ({ id: 'flag-1' } as any) : null)
         await svc.reconcileSpamBurst('profile-1')
-        for (const call of conversationUpdateMany.mock.calls) {
-          expect((call[0] as any).data.status).not.toBe('DISCARDED')
-        }
+        expect(conversationUpdateMany).not.toHaveBeenCalled()
       }
     })
   })

--- a/apps/backend/src/__tests__/workers/profileTrustWorker.spec.ts
+++ b/apps/backend/src/__tests__/workers/profileTrustWorker.spec.ts
@@ -37,16 +37,6 @@ beforeEach(() => {
 })
 
 describe('processProfileTrustJob', () => {
-  describe('reconcile-one', () => {
-    it('calls reconcileSpamBurst with the payload profileId', async () => {
-      await processProfileTrustJob(
-        mockJob<ProfileTrustJobData>({ kind: 'reconcile-one', profileId: 'p1' })
-      )
-      expect(reconcileSpamBurst).toHaveBeenCalledTimes(1)
-      expect(reconcileSpamBurst).toHaveBeenCalledWith('p1')
-    })
-  })
-
   describe('promote-pendings', () => {
     it('calls promotePendingsIfClear with the payload profileId', async () => {
       await processProfileTrustJob(

--- a/apps/backend/src/__tests__/workers/profileTrustWorker.spec.ts
+++ b/apps/backend/src/__tests__/workers/profileTrustWorker.spec.ts
@@ -5,7 +5,7 @@ vi.mock('../../lib/prisma', () => ({
   prisma: {
     profileTrustFlag: {
       findMany: vi.fn(),
-      update: vi.fn(),
+      updateMany: vi.fn(),
     },
     profile: {
       findMany: vi.fn(),
@@ -54,11 +54,11 @@ describe('processProfileTrustJob', () => {
         { id: 'f2', profileId: 'p2' },
       ] as any)
       vi.mocked(profileTrustQueue.add).mockResolvedValue({} as any)
-      vi.mocked(prisma.profileTrustFlag.update).mockResolvedValue({} as any)
+      vi.mocked(prisma.profileTrustFlag.updateMany).mockResolvedValue({ count: 1 } as any)
 
       await processProfileTrustJob(mockJob<ProfileTrustJobData>({ kind: 'clear-unvetted-window' }))
 
-      expect(prisma.profileTrustFlag.update).toHaveBeenCalledTimes(2)
+      expect(prisma.profileTrustFlag.updateMany).toHaveBeenCalledTimes(2)
       expect(profileTrustQueue.add).toHaveBeenCalledTimes(2)
       expect(profileTrustQueue.add).toHaveBeenCalledWith(
         'promote-pendings',
@@ -72,10 +72,28 @@ describe('processProfileTrustJob', () => {
       )
     })
 
+    it('clear write is conditional on clearedAt:null (preserves attribution if admin won the race)', async () => {
+      vi.mocked(prisma.profileTrustFlag.findMany).mockResolvedValue([
+        { id: 'f1', profileId: 'p1' },
+      ] as any)
+      vi.mocked(profileTrustQueue.add).mockResolvedValue({} as any)
+      // count=0 simulates "admin already cleared this flag between findMany and update"
+      vi.mocked(prisma.profileTrustFlag.updateMany).mockResolvedValue({ count: 0 } as any)
+
+      await processProfileTrustJob(mockJob<ProfileTrustJobData>({ kind: 'clear-unvetted-window' }))
+
+      // updateMany was issued with the race-safety guard.
+      expect(prisma.profileTrustFlag.updateMany).toHaveBeenCalledWith({
+        where: { id: 'f1', clearedAt: null },
+        data: { clearedAt: expect.any(Date), clearedBy: 'system:unvetted_window' },
+      })
+      // The 0-row outcome is not treated as a failure — no throw, loop continues.
+    })
+
     it('skips the scan when nothing is aged', async () => {
       vi.mocked(prisma.profileTrustFlag.findMany).mockResolvedValue([] as any)
       await processProfileTrustJob(mockJob<ProfileTrustJobData>({ kind: 'clear-unvetted-window' }))
-      expect(prisma.profileTrustFlag.update).not.toHaveBeenCalled()
+      expect(prisma.profileTrustFlag.updateMany).not.toHaveBeenCalled()
       expect(profileTrustQueue.add).not.toHaveBeenCalled()
     })
 
@@ -103,16 +121,16 @@ describe('processProfileTrustJob', () => {
       vi.mocked(profileTrustQueue.add)
         .mockRejectedValueOnce(new Error('redis blip'))
         .mockResolvedValueOnce({} as any)
-      vi.mocked(prisma.profileTrustFlag.update).mockResolvedValue({} as any)
+      vi.mocked(prisma.profileTrustFlag.updateMany).mockResolvedValue({ count: 1 } as any)
 
       await processProfileTrustJob(mockJob<ProfileTrustJobData>({ kind: 'clear-unvetted-window' }))
 
       // Both profiles must be attempted (proves loop continues after failure).
       expect(profileTrustQueue.add).toHaveBeenCalledTimes(2)
       // Only p2 reached the update step (p1's update skipped by the thrown enqueue).
-      expect(prisma.profileTrustFlag.update).toHaveBeenCalledTimes(1)
-      expect(prisma.profileTrustFlag.update).toHaveBeenCalledWith({
-        where: { id: 'f2' },
+      expect(prisma.profileTrustFlag.updateMany).toHaveBeenCalledTimes(1)
+      expect(prisma.profileTrustFlag.updateMany).toHaveBeenCalledWith({
+        where: { id: 'f2', clearedAt: null },
         data: { clearedAt: expect.any(Date), clearedBy: 'system:unvetted_window' },
       })
     })

--- a/apps/backend/src/api/routes/messaging.route.ts
+++ b/apps/backend/src/api/routes/messaging.route.ts
@@ -31,7 +31,6 @@ import {
 import type { MessageDTO } from '@zod/messaging/messaging.dto'
 import { InteractionService } from '@/services/interaction.service'
 import { notifierService } from '@/services/notifier.service'
-import { profileTrustQueue } from '@/queues/profileTrustQueue'
 import { ProfileTrustService } from '@/services/profileTrust.service'
 import { appConfig } from '@/lib/appconfig'
 import i18next from 'i18next'
@@ -170,24 +169,14 @@ const messageRoutes: FastifyPluginAsync = async (fastify) => {
     // isNew=true is a no-op when already cleared.
     await interactionService.markMatchAsSeen(senderProfileId, recipientProfileId)
 
-    // Enqueue SPAM_BURST reconcile when the sender added a new row to their count.
-    // BullMQ forbids ':' in custom jobIds (Redis key separator) and throws
-    // synchronously from validateOptions, so a .catch() on the returned Promise
-    // wouldn't contain it — wrap in try/catch to keep enqueue failures out of the
-    // user-facing response.
+    // Run SPAM_BURST reconcile inline when the sender added a new row to their count.
+    // Wrapped in try/catch so a reconcile failure can't surface to the user — their
+    // send already succeeded; convergence is non-user-facing best-effort.
     if (outcome === 'pending' || outcome === 'new_conversation') {
       try {
-        await profileTrustQueue.add(
-          'reconcile-one',
-          { kind: 'reconcile-one', profileId: senderProfileId },
-          {
-            jobId: `trust-${senderProfileId}`,
-            removeOnComplete: { count: 0 },
-            removeOnFail: { count: 100 },
-          }
-        )
+        await trustService.reconcileSpamBurst(senderProfileId)
       } catch (err) {
-        fastify.log.error({ err, senderProfileId }, 'profile-trust enqueue failed')
+        fastify.log.error({ err, senderProfileId }, 'profile-trust reconcile failed')
       }
     }
 

--- a/apps/backend/src/queues/profileTrustQueue.ts
+++ b/apps/backend/src/queues/profileTrustQueue.ts
@@ -4,7 +4,6 @@ import { logger } from '@/lib/logger'
 
 // Job payload — discriminated union on `kind`.
 export type ProfileTrustJobData =
-  | { kind: 'reconcile-one'; profileId: string }
   | { kind: 'promote-pendings'; profileId: string }
   | { kind: 'clear-unvetted-window' }
   | { kind: 'reconcile-many'; allProfiles?: boolean }

--- a/apps/backend/src/services/messaging.service.ts
+++ b/apps/backend/src/services/messaging.service.ts
@@ -485,9 +485,10 @@ export class MessageService {
   /**
    * Best-effort PENDING → INITIATED promotion plus the missing participant row, atomic
    * with the caller's tx. count===0 is a silent no-op: the row was already promoted by
-   * a peer, moved to DISCARDED by SPAM_BURST, blocked by the recipient, or never
-   * existed — in every case the caller's intent is already satisfied or the row should
-   * not be revived, so skipping the participant insert is the right behavior.
+   * a peer, transitioned to a terminal/blocked state (recipient blocked, admin
+   * moderation, etc.), or never existed — in every case the caller's intent is already
+   * satisfied or the row should not be revived, so skipping the participant insert is
+   * the right behavior.
    *
    * createMany + skipDuplicates keeps participant insertion idempotent under worker
    * re-runs and route races (otherwise P2002 on @@unique([profileId, conversationId])).

--- a/apps/backend/src/services/profileTrust.service.ts
+++ b/apps/backend/src/services/profileTrust.service.ts
@@ -7,11 +7,19 @@ import { MessageService } from '@/services/messaging.service'
 // promote to appConfig only if runtime tuning becomes routine.
 export const SPAM_BURST_THRESHOLD = 3
 
-// Burst window. The count is scoped to conversations created within this many ms
-// of "now". Matches the PROFILE_UNVETTED window so both quarantine windows are
-// symmetric. Without this bound, an all-time count punishes users with old
-// unanswered intros forever — that's unresponsiveness, not burst spam.
-export const SPAM_BURST_WINDOW_MS = 24 * 60 * 60 * 1000
+// Shared trust-quarantine window. Both the PROFILE_UNVETTED soft-quarantine
+// (new-account vetting) and the SPAM_BURST burst-count predicate use this
+// length. Symmetric by design: a fresh account graduates after 24h of normal
+// behavior, and burst detection only counts the last 24h of sends — so a user
+// who behaves normally after their first day is never penalized for ancient
+// unanswered intros. If the two ever need to diverge, the diverging consumer
+// should declare its own constant and this one keeps the shared meaning.
+export const TRUST_WINDOW_MS = 24 * 60 * 60 * 1000
+
+// Burst window. Scopes the SPAM_BURST count to conversations created within
+// this many ms of "now". Without this bound, an all-time count punishes users
+// with old unanswered intros forever — that's unresponsiveness, not burst spam.
+export const SPAM_BURST_WINDOW_MS = TRUST_WINDOW_MS
 
 // Shared builder so every enqueue site uses the same BullMQ dedup key. If the clear
 // path here and the clear-unvetted-window worker (Task 6) drifted to different

--- a/apps/backend/src/services/profileTrust.service.ts
+++ b/apps/backend/src/services/profileTrust.service.ts
@@ -3,9 +3,15 @@ import { prisma } from '@/lib/prisma'
 import { MessageService } from '@/services/messaging.service'
 
 // Tunable threshold — number of active INITIATED+PENDING conversations (sender = profile)
-// that trips the SPAM_BURST flag. Module-local by design; promote to appConfig
-// only if runtime tuning becomes routine.
+// within the burst window that trips the SPAM_BURST flag. Module-local by design;
+// promote to appConfig only if runtime tuning becomes routine.
 export const SPAM_BURST_THRESHOLD = 3
+
+// Burst window. The count is scoped to conversations created within this many ms
+// of "now". Matches the PROFILE_UNVETTED window so both quarantine windows are
+// symmetric. Without this bound, an all-time count punishes users with old
+// unanswered intros forever — that's unresponsiveness, not burst spam.
+export const SPAM_BURST_WINDOW_MS = 24 * 60 * 60 * 1000
 
 // Shared builder so every enqueue site uses the same BullMQ dedup key. If the clear
 // path here and the clear-unvetted-window worker (Task 6) drifted to different
@@ -61,10 +67,9 @@ export class ProfileTrustService {
    * that the heuristic threshold-down branch uses, so held messages get released
    * the same way regardless of who closed the flag.
    *
-   * Note: heuristic SPAM_BURST flags can be cleared this way too, but the
-   * already-DISCARDED conversations stay terminal — clearing the flag does not
-   * revive them. The next reconcile pass may re-flag if the threshold is still
-   * breached.
+   * Heuristic SPAM_BURST flags can be cleared this way too — held conversations
+   * (PENDING, including any demoted from INITIATED while the flag was on) are
+   * released to recipients by promote-pendings the same way as PROFILE_UNVETTED.
    *
    * Returns a result code; the caller maps it to its protocol-specific response.
    */
@@ -147,24 +152,36 @@ export class ProfileTrustService {
 
   /**
    * Convergence function for SPAM_BURST. Drives the world toward the invariant:
-   * "a SPAM_BURST-flagged profile has zero INITIATED or PENDING conversations as initiator".
-   * ACCEPTED conversations stand — those represent mutual engagement from the recipient.
+   * "a SPAM_BURST-flagged profile has zero recent INITIATED initiator-side conversations".
+   * "Recent" = created within SPAM_BURST_WINDOW_MS. ACCEPTED conversations stand —
+   * those represent mutual engagement from the recipient. PENDING is the held-state
+   * primitive: rows that originated as PENDING (sender quarantined at send time) and
+   * rows demoted by this function both wait for promote-pendings on flag clear.
    *
-   * Cases:
-   * - count >= threshold AND not flagged: write flag AND DISCARD active rows (INITIATED+PENDING).
-   * - count >= threshold AND already flagged: DISCARD any active rows that slipped through
-   *   a race (e.g. a send that crossed the hasTrustFlag check at the route before the flag
-   *   landed). Idempotent: updateMany hits zero rows in the steady state.
+   * Cases (count is windowed by SPAM_BURST_WINDOW_MS):
+   * - count >= threshold AND not flagged: write flag AND demote in-window INITIATED → PENDING.
+   * - count >= threshold AND already flagged: demote any in-window INITIATED that slipped
+   *   through a race (e.g. a send that crossed the hasTrustFlag check at the route before
+   *   the flag landed). Idempotent: updateMany hits zero rows in the steady state.
    * - count < threshold AND already flagged: clear the flag AND enqueue promote-pendings
    *   so held messages (if any) can be delivered.
    * - count < threshold AND not flagged: no-op.
+   *
+   * Demotion is non-destructive — PENDING rows are filtered out of inbox queries the
+   * same way DISCARDED ones used to be, but they remain restorable. The flag-clear
+   * branch reuses the existing promote-pendings worker to release them. Out-of-window
+   * INITIATED rows are left untouched: hiding a weeks-old intro from a recipient who's
+   * already had it in inbox would be a surprise UX side-effect of a fresh burst.
    */
   async reconcileSpamBurst(profileId: string): Promise<void> {
-    // Only the count drives the threshold decision; we don't need every ID in memory.
+    // Window-scoped count. Old unanswered intros are unresponsiveness, not burst spam,
+    // and shouldn't keep a profile flagged forever.
+    const since = new Date(Date.now() - SPAM_BURST_WINDOW_MS)
     const count = await prisma.conversation.count({
       where: {
         initiatorProfileId: profileId,
         status: { in: ['INITIATED', 'PENDING'] },
+        createdAt: { gte: since },
       },
     })
     const alreadyFlagged = await this.hasTrustFlag(profileId, 'SPAM_BURST')
@@ -180,15 +197,18 @@ export class ProfileTrustService {
           },
         })
       }
-      // Enforce the invariant regardless of whether we just wrote the flag or it
-      // was already there — closes the race window between the route's pre-tx
-      // quarantine check and the tx commit.
+      // Enforce the invariant by demoting in-window INITIATED to PENDING. Runs whether
+      // we just wrote the flag or it was already there — closes the race between the
+      // route's pre-tx quarantine check and tx commit. PENDING (not DISCARDED) keeps
+      // the messages recoverable via promote-pendings when the flag clears. PENDING
+      // rows are already in the held state, so they're not in the predicate.
       await prisma.conversation.updateMany({
         where: {
           initiatorProfileId: profileId,
-          status: { in: ['INITIATED', 'PENDING'] },
+          status: 'INITIATED',
+          createdAt: { gte: since },
         },
-        data: { status: 'DISCARDED' },
+        data: { status: 'PENDING' },
       })
     } else if (alreadyFlagged) {
       await prisma.profileTrustFlag.updateMany({

--- a/apps/backend/src/services/profileTrust.service.ts
+++ b/apps/backend/src/services/profileTrust.service.ts
@@ -159,31 +159,26 @@ export class ProfileTrustService {
   }
 
   /**
-   * Convergence function for SPAM_BURST. Drives the world toward the invariant:
-   * "a SPAM_BURST-flagged profile has zero recent INITIATED initiator-side conversations".
-   * "Recent" = created within SPAM_BURST_WINDOW_MS. ACCEPTED conversations stand —
-   * those represent mutual engagement from the recipient. PENDING is the held-state
-   * primitive: rows that originated as PENDING (sender quarantined at send time) and
-   * rows demoted by this function both wait for promote-pendings on flag clear.
+   * Maintains the SPAM_BURST flag based on a windowed burst count. The flag's only
+   * effect is to gate *future* sends via the route's `hasTrustFlag` check —
+   * quarantined sends are written as PENDING (sender-only participant), so recipients
+   * don't see them. Existing rows are not touched here: a row that was already
+   * INITIATED stays INITIATED and remains visible to its recipient. ACCEPTED rows
+   * stand — mutual engagement outranks the heuristic.
    *
-   * Cases (count is windowed by SPAM_BURST_WINDOW_MS):
-   * - count >= threshold AND not flagged: write flag AND demote in-window INITIATED → PENDING.
-   * - count >= threshold AND already flagged: demote any in-window INITIATED that slipped
-   *   through a race (e.g. a send that crossed the hasTrustFlag check at the route before
-   *   the flag landed). Idempotent: updateMany hits zero rows in the steady state.
-   * - count < threshold AND already flagged: clear the flag AND enqueue promote-pendings
-   *   so held messages (if any) can be delivered.
-   * - count < threshold AND not flagged: no-op.
+   * Cases (count is windowed by SPAM_BURST_WINDOW_MS over INITIATED+PENDING):
+   * - count >= threshold AND not flagged: write SPAM_BURST flag.
+   * - count >= threshold AND already flagged: no-op (flag is in the right state).
+   * - count <  threshold AND already flagged: clear the flag AND enqueue
+   *   promote-pendings so any PENDING rows held under the flag get released.
+   * - count <  threshold AND not flagged: no-op.
    *
-   * Demotion is non-destructive — PENDING rows are filtered out of inbox queries the
-   * same way DISCARDED ones used to be, but they remain restorable. The flag-clear
-   * branch reuses the existing promote-pendings worker to release them. Out-of-window
-   * INITIATED rows are left untouched: hiding a weeks-old intro from a recipient who's
-   * already had it in inbox would be a surprise UX side-effect of a fresh burst.
+   * The windowed count is the policy lever: old unanswered intros are
+   * unresponsiveness, not burst spam, and shouldn't keep a profile flagged forever.
+   * Release of held PENDING messages on flag clear flows through the existing
+   * promote-pendings worker — same path as PROFILE_UNVETTED.
    */
   async reconcileSpamBurst(profileId: string): Promise<void> {
-    // Window-scoped count. Old unanswered intros are unresponsiveness, not burst spam,
-    // and shouldn't keep a profile flagged forever.
     const since = new Date(Date.now() - SPAM_BURST_WINDOW_MS)
     const count = await prisma.conversation.count({
       where: {
@@ -205,19 +200,6 @@ export class ProfileTrustService {
           },
         })
       }
-      // Enforce the invariant by demoting in-window INITIATED to PENDING. Runs whether
-      // we just wrote the flag or it was already there — closes the race between the
-      // route's pre-tx quarantine check and tx commit. PENDING (not DISCARDED) keeps
-      // the messages recoverable via promote-pendings when the flag clears. PENDING
-      // rows are already in the held state, so they're not in the predicate.
-      await prisma.conversation.updateMany({
-        where: {
-          initiatorProfileId: profileId,
-          status: 'INITIATED',
-          createdAt: { gte: since },
-        },
-        data: { status: 'PENDING' },
-      })
     } else if (alreadyFlagged) {
       await prisma.profileTrustFlag.updateMany({
         where: { profileId, reason: 'SPAM_BURST', clearedAt: null },

--- a/apps/backend/src/workers/profileTrustWorker.ts
+++ b/apps/backend/src/workers/profileTrustWorker.ts
@@ -16,12 +16,6 @@ export async function processProfileTrustJob(job: Job<ProfileTrustJobData>): Pro
   const svc = ProfileTrustService.getInstance()
   const data = job.data
 
-  if (data.kind === 'reconcile-one') {
-    await svc.reconcileSpamBurst(data.profileId)
-    await job.log(`reconciled ${data.profileId}`)
-    return
-  }
-
   if (data.kind === 'promote-pendings') {
     await svc.promotePendingsIfClear(data.profileId)
     await job.log(`promoted pendings (if clear) for ${data.profileId}`)

--- a/apps/backend/src/workers/profileTrustWorker.ts
+++ b/apps/backend/src/workers/profileTrustWorker.ts
@@ -1,10 +1,16 @@
 import type { Job } from 'bullmq'
 import { logger } from '@/lib/logger'
 import { prisma } from '@/lib/prisma'
-import { ProfileTrustService, promotePendingsJobId } from '@/services/profileTrust.service'
+import {
+  ProfileTrustService,
+  promotePendingsJobId,
+  TRUST_WINDOW_MS,
+} from '@/services/profileTrust.service'
 import { profileTrustQueue, type ProfileTrustJobData } from '@/queues/profileTrustQueue'
 
-const UNVETTED_WINDOW_MS = 24 * 60 * 60 * 1000 // 24h
+// PROFILE_UNVETTED soft-quarantine length. Shares TRUST_WINDOW_MS with SPAM_BURST
+// by design — see the constant's definition for the symmetry rationale.
+const UNVETTED_WINDOW_MS = TRUST_WINDOW_MS
 
 export async function processProfileTrustJob(job: Job<ProfileTrustJobData>): Promise<void> {
   const svc = ProfileTrustService.getInstance()

--- a/apps/backend/src/workers/profileTrustWorker.ts
+++ b/apps/backend/src/workers/profileTrustWorker.ts
@@ -51,8 +51,12 @@ export async function processProfileTrustJob(job: Job<ProfileTrustJobData>): Pro
             removeOnFail: { count: 100 },
           }
         )
-        await prisma.profileTrustFlag.update({
-          where: { id },
+        // Conditional clear: if an admin (or any other path) cleared this flag
+        // between findMany and now, the updateMany affects 0 rows and we leave
+        // their clearedAt/clearedBy attribution intact. Mirrors the pattern in
+        // ProfileTrustService.clearFlag.
+        await prisma.profileTrustFlag.updateMany({
+          where: { id, clearedAt: null },
           data: { clearedAt: new Date(), clearedBy: 'system:unvetted_window' },
         })
       } catch (err) {


### PR DESCRIPTION
## Summary

Fixes the SPAM_BURST quarantine system, which was destroying legitimate user conversations during normal use. Discovered while investigating a real user's "not getting messages" report — a single oscillation cycle of the buggy reconcile cost one user 6 conversations across 21 minutes of normal first-contact behavior; another user lost 18 across two days.

This PR replaces the destructive enforcement with a **flag-and-gate** policy:

- The SPAM_BURST flag is maintained based on a windowed burst count (last 24h).
- The flag's only effect is to gate **future** sends via the existing `hasTrustFlag` check — new sends from flagged users land as PENDING (held, recipient doesn't see).
- Existing conversation rows are never touched by the trust system. Held PENDING messages release via the existing promote-pendings path when the flag clears.

## The original bug

`reconcileSpamBurst` did two harmful things together:

1. **Destructive enforcement**. When the threshold was hit, an `updateMany` flipped all in-window `INITIATED`/`PENDING` initiator-side conversations to `DISCARDED` (terminal). Per the partial unique index, DISCARDED rows are tombstones — they exist in the DB but are filtered from every active-conversation query. Clearing the flag did not revive them. The code itself admitted this: *"already-DISCARDED conversations stay terminal — clearing the flag does not revive them."*

2. **All-time threshold count**. The count predicate had no `createdAt` bound — three months-old unanswered intros counted equally with three messages sent in the same minute. Combined with the destructive enforcement, this caused **flag oscillation**: write flag → DISCARD 3 conversations → count drops to 0 → clear flag → next 3 sends → write flag → DISCARD 3 more.

Real-world impact at the time of investigation: 6 legitimate messages destroyed for user A (~ 21 minutes of normal use), 18 destroyed for user B (over ~2 days).

## What this PR changes

**Commit 1 — `3afceb0e` non-destructive fix + 24h window**

- The destructive `updateMany WHERE status IN (INITIATED, PENDING) → DISCARDED` is gone.
- Count is scoped to `createdAt >= now() - 24h` (matches the existing PROFILE_UNVETTED window).
- New constant `SPAM_BURST_WINDOW_MS = 24 * 60 * 60 * 1000`.

**Commit 2 — `eb39d15d` constant centralization**

- Extract `TRUST_WINDOW_MS` shared by both UNVETTED and SPAM_BURST windows.

**Commit 3 — `e41b6cde` inline reconcile + flag-and-gate**

- `reconcileSpamBurst` is now called inline from the send path instead of enqueued as a `reconcile-one` job. The `reconcile-one` queue kind, worker arm, and tests are deleted.
- Demotion `updateMany` removed entirely. `reconcileSpamBurst` now only writes the flag — existing INITIATED rows stay visible.
- Policy is now **flag-and-gate**: the flag gates future sends via the route's `hasTrustFlag` check; existing rows are not retroactively quarantined.

**Commit 4 — `9637907b` race fix**

- `clear-unvetted-window` cron's per-flag clear is now conditional: `updateMany WHERE id=X AND clearedAt: null`. Closes the admin-attribution-overwrite race between this cron and the `clearFlag` admin route (which already used the conditional pattern).

## Behavior after this PR (full case matrix)

| Scenario | Behavior |
|---|---|
| User sends 3 unanswered intros in 24h | SPAM_BURST flag fires. Existing 3 INITIATED rows stay visible. 4th+ sends create PENDING. |
| Flagged user's burst count drops below 3 (in-window aging out) | Flag clears, promote-pendings releases held PENDING. |
| New profile (UNVETTED) sends 3+ messages | All sends create PENDING. SPAM_BURST may also fire alongside UNVETTED; both must clear before PENDING releases. |
| User sends 3 intros, none answered, 6 weeks later sends a 4th | Count is windowed — 6-week-old rows don't count. 4th send is INITIATED, no flag fires. |
| Admin clears a SPAM_BURST flag | Inline-cleared by admin, promote-pendings runs. Attribution preserved against concurrent cron clear (new in commit 4). |

## Out of scope (separate work)

- **Restoring historically DISCARDED rows.** User A's 6 conversations were manually restored via direct DB UPDATE during investigation. User B's 18 still need restoring; that's a one-off operation, not a code change.
- **Sweeper architecture for stranded-PENDING race.** The current design still has a small race window between cron-driven flag clears and the `promote-pendings` queue's dedup-jobId. The architecturally correct fix (state-driven sweeper + inline-on-admin-action) is the next refactor; left for a separate PR to keep this one focused.
- **Stale comment on `promotePendingsIfClear`** referencing "DISCARDs" — cosmetic, separate cleanup.

## Test plan

- [x] `pnpm --filter backend test` — 751/751 pass.
- [x] `pnpm --filter backend exec tsc --noEmit` — clean.
- [x] `pnpm lint` — clean.
- [x] New regression test: `reconcileSpamBurst` never writes any conversation-row change, on any of 12 case-matrix permutations (threshold × flagged state).
- [x] New regression test: per-send reconcile failures don't surface to user (route returns 200).
- [x] New race test: cron's conditional clear leaves admin attribution intact when admin won the race.
- [x] Test rewrites: 4 messaging-route tests migrated from queue-enqueue assertion to direct-call assertion.
- [ ] Manual: replay user A's exact send timeline on a prod-shape replica, confirm no row ends DISCARDED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)