### PR TITLE
refactor(messaging): replace promote-pendings queue with state-driven trust-sweep

### DIFF
--- a/.changeset/odd-plants-talk.md
+++ b/.changeset/odd-plants-talk.md
@@ -1,0 +1,5 @@
+---
+"@opencupid/backend": patch
+---
+
+refactor(messaging): replace promote-pendings queue with state-driven trust-sweep

--- a/apps/backend/src/__tests__/routes/admin.route.spec.ts
+++ b/apps/backend/src/__tests__/routes/admin.route.spec.ts
@@ -26,6 +26,9 @@ const mockPrisma = vi.hoisted(() => {
       update: vi.fn(),
       updateMany: vi.fn(),
     },
+    conversation: {
+      findMany: vi.fn().mockResolvedValue([]),
+    },
     tag: {
       findMany: vi.fn(),
       findUnique: vi.fn(),
@@ -1606,10 +1609,6 @@ describe('POST /trust-flags/:id/clear', () => {
       flaggedBy: 'admin:manual',
     })
     mockPrisma.profileTrustFlag.updateMany.mockResolvedValue({ count: 1 })
-    // The service dynamically imports the queue; provide a mock so the import succeeds.
-    vi.doMock('@/queues/profileTrustQueue', () => ({
-      profileTrustQueue: { add: vi.fn().mockResolvedValue({}) },
-    }))
 
     const handler = fastify.routes['POST /trust-flags/:id/clear']
     await handler({ params: { id: 'f1' } }, reply)
@@ -1639,9 +1638,6 @@ describe('POST /trust-flags/:id/clear', () => {
       flaggedBy: 'heuristic:spam_burst',
     })
     mockPrisma.profileTrustFlag.updateMany.mockResolvedValue({ count: 1 })
-    vi.doMock('@/queues/profileTrustQueue', () => ({
-      profileTrustQueue: { add: vi.fn().mockResolvedValue({}) },
-    }))
 
     const handler = fastify.routes['POST /trust-flags/:id/clear']
     await handler({ params: { id: 'f1' } }, reply)

--- a/apps/backend/src/__tests__/services/profileTrust.service.spec.ts
+++ b/apps/backend/src/__tests__/services/profileTrust.service.spec.ts
@@ -133,7 +133,7 @@ describe('ProfileTrustService', () => {
       expect(queueAdd).not.toHaveBeenCalled()
     })
 
-    it('clears flag and enqueues promote-pendings when condition resolves', async () => {
+    it('clears flag (only) when condition resolves — release is sweeper-driven', async () => {
       conversationCount.mockResolvedValue(1) // below threshold
       mockedFindFirst.mockResolvedValue({ id: 'flag-1' } as any) // currently flagged
 
@@ -143,11 +143,8 @@ describe('ProfileTrustService', () => {
         where: { profileId: 'profile-1', reason: 'SPAM_BURST', clearedAt: null },
         data: { clearedAt: expect.any(Date), clearedBy: 'heuristic:spam_burst_below_threshold' },
       })
-      expect(queueAdd).toHaveBeenCalledWith(
-        'promote-pendings',
-        { kind: 'promote-pendings', profileId: 'profile-1' },
-        expect.objectContaining({ jobId: 'promote-pendings-profile-1' })
-      )
+      // No enqueue — the trust-sweep cron handles the release on its next tick.
+      expect(queueAdd).not.toHaveBeenCalled()
       expect(profileTrustFlagCreate).not.toHaveBeenCalled()
       expect(conversationUpdateMany).not.toHaveBeenCalled()
     })
@@ -361,94 +358,144 @@ describe('ProfileTrustService', () => {
   })
 
   describe('clearFlag', () => {
-    const flagFindUnique = vi.fn()
-    const flagUpdateMany = vi.fn()
-    const queueAdd = vi.fn()
+    // clearFlag wraps everything in a serializable $transaction: findUnique, conditional
+    // updateMany, inline promotePendingsInTx. Mock $transaction to pass through a tx object
+    // exposing the methods the implementation calls.
+    const transactionFn = vi.fn()
+    const txFlagFindUnique = vi.fn()
+    const txFlagUpdateMany = vi.fn()
+    const txFlagFindFirst = vi.fn()
+    const txConversationFindMany = vi.fn()
 
     beforeEach(() => {
-      ;(prisma as any).profileTrustFlag = {
-        ...(prisma as any).profileTrustFlag,
-        findUnique: flagFindUnique,
-        updateMany: flagUpdateMany,
-      }
-      vi.doMock('@/queues/profileTrustQueue', () => ({
-        profileTrustQueue: { add: queueAdd },
-      }))
-      flagFindUnique.mockReset()
-      flagUpdateMany.mockReset()
-      queueAdd.mockReset()
+      ;(prisma as any).$transaction = transactionFn
+      transactionFn.mockImplementation(async (cb: any) => {
+        return cb({
+          profileTrustFlag: {
+            findUnique: txFlagFindUnique,
+            updateMany: txFlagUpdateMany,
+            findFirst: txFlagFindFirst,
+          },
+          conversation: { findMany: txConversationFindMany },
+        })
+      })
+      txFlagFindUnique.mockReset()
+      txFlagUpdateMany.mockReset()
+      txFlagFindFirst.mockReset()
+      txConversationFindMany.mockReset()
+      promoteConversationMock.mockReset()
     })
 
-    it('writes clearedAt + clearedBy via conditional updateMany, enqueues promote-pendings, returns "cleared"', async () => {
-      flagFindUnique.mockResolvedValue({
+    it('clears the flag and inline-promotes PENDING when no other flags remain — returns "cleared"', async () => {
+      txFlagFindUnique.mockResolvedValue({
         id: 'f1',
         profileId: 'p1',
         clearedAt: null,
         flaggedBy: 'admin:manual',
       })
-      flagUpdateMany.mockResolvedValue({ count: 1 })
-      queueAdd.mockResolvedValue({})
+      txFlagUpdateMany.mockResolvedValue({ count: 1 })
+      txFlagFindFirst.mockResolvedValue(null) // no other active flag → inline promote runs
+      txConversationFindMany.mockResolvedValue([
+        { id: 'c1', profileAId: 'p1', profileBId: 'recipient' },
+      ])
 
       const result = await svc.clearFlag('f1', 'admin:manual')
 
       expect(result).toBe('cleared')
-      expect(flagUpdateMany).toHaveBeenCalledWith({
+      expect(txFlagUpdateMany).toHaveBeenCalledWith({
         where: { id: 'f1', clearedAt: null },
         data: { clearedAt: expect.any(Date), clearedBy: 'admin:manual' },
       })
-      expect(queueAdd).toHaveBeenCalledWith(
-        'promote-pendings',
-        { kind: 'promote-pendings', profileId: 'p1' },
-        expect.objectContaining({ jobId: 'promote-pendings-p1' })
+      // Inline promote ran inside the same tx (the mock tx is what gets passed through).
+      expect(promoteConversationMock).toHaveBeenCalledWith(expect.anything(), 'c1', 'recipient')
+    })
+
+    it('skips inline promote when another active flag remains on the profile', async () => {
+      txFlagFindUnique.mockResolvedValue({
+        id: 'f1',
+        profileId: 'p1',
+        clearedAt: null,
+        flaggedBy: 'admin:manual',
+      })
+      txFlagUpdateMany.mockResolvedValue({ count: 1 })
+      txFlagFindFirst.mockResolvedValue({ id: 'other-flag' } as any) // other flag still active
+
+      const result = await svc.clearFlag('f1', 'admin:manual')
+
+      expect(result).toBe('cleared')
+      expect(txConversationFindMany).not.toHaveBeenCalled()
+      expect(promoteConversationMock).not.toHaveBeenCalled()
+    })
+
+    it('uses Serializable isolation level', async () => {
+      txFlagFindUnique.mockResolvedValue({
+        id: 'f1',
+        profileId: 'p1',
+        clearedAt: null,
+        flaggedBy: 'admin:manual',
+      })
+      txFlagUpdateMany.mockResolvedValue({ count: 1 })
+      txFlagFindFirst.mockResolvedValue(null)
+      txConversationFindMany.mockResolvedValue([])
+
+      await svc.clearFlag('f1', 'admin:manual')
+
+      expect(transactionFn).toHaveBeenCalledWith(
+        expect.any(Function),
+        expect.objectContaining({ isolationLevel: 'Serializable' })
       )
     })
 
     it('returns "not_found" when the flag is missing', async () => {
-      flagFindUnique.mockResolvedValue(null)
+      txFlagFindUnique.mockResolvedValue(null)
       expect(await svc.clearFlag('missing', 'admin:manual')).toBe('not_found')
-      expect(flagUpdateMany).not.toHaveBeenCalled()
+      expect(txFlagUpdateMany).not.toHaveBeenCalled()
+      expect(promoteConversationMock).not.toHaveBeenCalled()
     })
 
     it('returns "already_cleared" when the flag is already cleared at read time', async () => {
-      flagFindUnique.mockResolvedValue({
+      txFlagFindUnique.mockResolvedValue({
         id: 'f1',
         profileId: 'p1',
         clearedAt: new Date(),
         flaggedBy: 'admin:manual',
       })
       expect(await svc.clearFlag('f1', 'admin:manual')).toBe('already_cleared')
-      expect(flagUpdateMany).not.toHaveBeenCalled()
+      expect(txFlagUpdateMany).not.toHaveBeenCalled()
+      expect(promoteConversationMock).not.toHaveBeenCalled()
     })
 
     it('returns "already_cleared" when a concurrent caller wins the race (count=0)', async () => {
-      flagFindUnique.mockResolvedValue({
+      txFlagFindUnique.mockResolvedValue({
         id: 'f1',
         profileId: 'p1',
         clearedAt: null,
         flaggedBy: 'admin:manual',
       })
-      flagUpdateMany.mockResolvedValue({ count: 0 })
+      txFlagUpdateMany.mockResolvedValue({ count: 0 })
 
       const result = await svc.clearFlag('f1', 'admin:manual')
 
       expect(result).toBe('already_cleared')
-      expect(queueAdd).not.toHaveBeenCalled()
+      // No inline promote — we didn't actually clear anything.
+      expect(promoteConversationMock).not.toHaveBeenCalled()
     })
 
     it('clears heuristic-set flags too (admin override)', async () => {
-      flagFindUnique.mockResolvedValue({
+      txFlagFindUnique.mockResolvedValue({
         id: 'f1',
         profileId: 'p1',
         clearedAt: null,
         flaggedBy: 'heuristic:spam_burst',
       })
-      flagUpdateMany.mockResolvedValue({ count: 1 })
-      queueAdd.mockResolvedValue({})
+      txFlagUpdateMany.mockResolvedValue({ count: 1 })
+      txFlagFindFirst.mockResolvedValue(null)
+      txConversationFindMany.mockResolvedValue([])
 
       const result = await svc.clearFlag('f1', 'admin:manual')
 
       expect(result).toBe('cleared')
-      expect(flagUpdateMany).toHaveBeenCalledWith({
+      expect(txFlagUpdateMany).toHaveBeenCalledWith({
         where: { id: 'f1', clearedAt: null },
         data: { clearedAt: expect.any(Date), clearedBy: 'admin:manual' },
       })

--- a/apps/backend/src/__tests__/workers/profileTrustWorker.spec.ts
+++ b/apps/backend/src/__tests__/workers/profileTrustWorker.spec.ts
@@ -12,12 +12,8 @@ vi.mock('../../lib/prisma', () => ({
     },
   },
 }))
-vi.mock('../../queues/profileTrustQueue', () => ({
-  profileTrustQueue: { add: vi.fn() },
-}))
 
 import { prisma } from '../../lib/prisma'
-import { profileTrustQueue } from '../../queues/profileTrustQueue'
 import { ProfileTrustService } from '../../services/profileTrust.service'
 import { processProfileTrustJob } from '../../workers/profileTrustWorker'
 import type { ProfileTrustJobData } from '../../queues/profileTrustQueue'
@@ -37,68 +33,104 @@ beforeEach(() => {
 })
 
 describe('processProfileTrustJob', () => {
-  describe('promote-pendings', () => {
-    it('calls promotePendingsIfClear with the payload profileId', async () => {
-      await processProfileTrustJob(
-        mockJob<ProfileTrustJobData>({ kind: 'promote-pendings', profileId: 'p1' })
-      )
-      expect(promotePendingsIfClear).toHaveBeenCalledTimes(1)
-      expect(promotePendingsIfClear).toHaveBeenCalledWith('p1')
-    })
-  })
-
-  describe('clear-unvetted-window', () => {
-    it('clears aged PROFILE_UNVETTED flags and enqueues promote-pendings per profile', async () => {
+  describe('clear-unvetted-window (trust-sweep)', () => {
+    it('phase 1: clears aged PROFILE_UNVETTED flags conditionally', async () => {
       vi.mocked(prisma.profileTrustFlag.findMany).mockResolvedValue([
         { id: 'f1', profileId: 'p1' },
         { id: 'f2', profileId: 'p2' },
       ] as any)
-      vi.mocked(profileTrustQueue.add).mockResolvedValue({} as any)
       vi.mocked(prisma.profileTrustFlag.updateMany).mockResolvedValue({ count: 1 } as any)
+      vi.mocked(prisma.profile.findMany).mockResolvedValue([] as any)
 
       await processProfileTrustJob(mockJob<ProfileTrustJobData>({ kind: 'clear-unvetted-window' }))
 
       expect(prisma.profileTrustFlag.updateMany).toHaveBeenCalledTimes(2)
-      expect(profileTrustQueue.add).toHaveBeenCalledTimes(2)
-      expect(profileTrustQueue.add).toHaveBeenCalledWith(
-        'promote-pendings',
-        { kind: 'promote-pendings', profileId: 'p1' },
-        expect.objectContaining({ jobId: 'promote-pendings-p1' })
-      )
-      expect(profileTrustQueue.add).toHaveBeenCalledWith(
-        'promote-pendings',
-        { kind: 'promote-pendings', profileId: 'p2' },
-        expect.objectContaining({ jobId: 'promote-pendings-p2' })
-      )
-    })
-
-    it('clear write is conditional on clearedAt:null (preserves attribution if admin won the race)', async () => {
-      vi.mocked(prisma.profileTrustFlag.findMany).mockResolvedValue([
-        { id: 'f1', profileId: 'p1' },
-      ] as any)
-      vi.mocked(profileTrustQueue.add).mockResolvedValue({} as any)
-      // count=0 simulates "admin already cleared this flag between findMany and update"
-      vi.mocked(prisma.profileTrustFlag.updateMany).mockResolvedValue({ count: 0 } as any)
-
-      await processProfileTrustJob(mockJob<ProfileTrustJobData>({ kind: 'clear-unvetted-window' }))
-
-      // updateMany was issued with the race-safety guard.
       expect(prisma.profileTrustFlag.updateMany).toHaveBeenCalledWith({
         where: { id: 'f1', clearedAt: null },
         data: { clearedAt: expect.any(Date), clearedBy: 'system:unvetted_window' },
       })
-      // The 0-row outcome is not treated as a failure — no throw, loop continues.
+      expect(prisma.profileTrustFlag.updateMany).toHaveBeenCalledWith({
+        where: { id: 'f2', clearedAt: null },
+        data: { clearedAt: expect.any(Date), clearedBy: 'system:unvetted_window' },
+      })
     })
 
-    it('skips the scan when nothing is aged', async () => {
+    it('phase 1: clear write is conditional on clearedAt:null (preserves admin attribution on race)', async () => {
+      vi.mocked(prisma.profileTrustFlag.findMany).mockResolvedValue([
+        { id: 'f1', profileId: 'p1' },
+      ] as any)
+      // count=0 simulates "admin already cleared this flag between findMany and update"
+      vi.mocked(prisma.profileTrustFlag.updateMany).mockResolvedValue({ count: 0 } as any)
+      vi.mocked(prisma.profile.findMany).mockResolvedValue([] as any)
+
+      await processProfileTrustJob(mockJob<ProfileTrustJobData>({ kind: 'clear-unvetted-window' }))
+
+      expect(prisma.profileTrustFlag.updateMany).toHaveBeenCalledWith({
+        where: { id: 'f1', clearedAt: null },
+        data: { clearedAt: expect.any(Date), clearedBy: 'system:unvetted_window' },
+      })
+    })
+
+    it('phase 1: no longer enqueues anything (sweeper-only release)', async () => {
+      // The promote-pendings BullMQ queue kind has been deleted; phase 1 just
+      // clears flags. Phase 2 (sweep) handles release.
+      vi.mocked(prisma.profileTrustFlag.findMany).mockResolvedValue([
+        { id: 'f1', profileId: 'p1' },
+      ] as any)
+      vi.mocked(prisma.profileTrustFlag.updateMany).mockResolvedValue({ count: 1 } as any)
+      vi.mocked(prisma.profile.findMany).mockResolvedValue([] as any)
+
+      await processProfileTrustJob(mockJob<ProfileTrustJobData>({ kind: 'clear-unvetted-window' }))
+
+      // phase 2 candidate scan happened but returned empty
+      expect(prisma.profile.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: {
+            trustFlags: { none: { clearedAt: null } },
+            Conversation: { some: { status: 'PENDING' } },
+          },
+        })
+      )
+      expect(promotePendingsIfClear).not.toHaveBeenCalled()
+    })
+
+    it('phase 2: sweeps profiles with no active flags + initiator-side PENDING', async () => {
       vi.mocked(prisma.profileTrustFlag.findMany).mockResolvedValue([] as any)
+      vi.mocked(prisma.profile.findMany).mockResolvedValue([{ id: 'p1' }, { id: 'p2' }] as any)
+
+      await processProfileTrustJob(mockJob<ProfileTrustJobData>({ kind: 'clear-unvetted-window' }))
+
+      expect(promotePendingsIfClear).toHaveBeenCalledTimes(2)
+      expect(promotePendingsIfClear).toHaveBeenCalledWith('p1')
+      expect(promotePendingsIfClear).toHaveBeenCalledWith('p2')
+    })
+
+    it('phase 2: SQL anti-join filters out profiles with any active flag', async () => {
+      vi.mocked(prisma.profileTrustFlag.findMany).mockResolvedValue([] as any)
+      vi.mocked(prisma.profile.findMany).mockResolvedValue([] as any)
+
+      await processProfileTrustJob(mockJob<ProfileTrustJobData>({ kind: 'clear-unvetted-window' }))
+
+      expect(prisma.profile.findMany).toHaveBeenCalledWith({
+        where: {
+          trustFlags: { none: { clearedAt: null } },
+          Conversation: { some: { status: 'PENDING' } },
+        },
+        select: { id: true },
+      })
+    })
+
+    it('skips both phases when nothing is aged and no sweep candidates exist', async () => {
+      vi.mocked(prisma.profileTrustFlag.findMany).mockResolvedValue([] as any)
+      vi.mocked(prisma.profile.findMany).mockResolvedValue([] as any)
       await processProfileTrustJob(mockJob<ProfileTrustJobData>({ kind: 'clear-unvetted-window' }))
       expect(prisma.profileTrustFlag.updateMany).not.toHaveBeenCalled()
-      expect(profileTrustQueue.add).not.toHaveBeenCalled()
+      expect(promotePendingsIfClear).not.toHaveBeenCalled()
     })
 
-    it('excludes admin-set flags from the auto-clear scan', async () => {
+    it('excludes admin-set flags from phase 1', async () => {
       vi.mocked(prisma.profileTrustFlag.findMany).mockResolvedValue([] as any)
+      vi.mocked(prisma.profile.findMany).mockResolvedValue([] as any)
       await processProfileTrustJob(mockJob<ProfileTrustJobData>({ kind: 'clear-unvetted-window' }))
       expect(prisma.profileTrustFlag.findMany).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -111,28 +143,31 @@ describe('processProfileTrustJob', () => {
       )
     })
 
-    it('continues when one profile fails', async () => {
+    it('phase 1 continues when one flag clear fails', async () => {
       vi.mocked(prisma.profileTrustFlag.findMany).mockResolvedValue([
         { id: 'f1', profileId: 'p1' },
         { id: 'f2', profileId: 'p2' },
       ] as any)
-      // With enqueue-before-update ordering, a failed enqueue on p1 short-circuits
-      // the update for p1 (flag stays set, next scan retries). p2 proceeds normally.
-      vi.mocked(profileTrustQueue.add)
-        .mockRejectedValueOnce(new Error('redis blip'))
-        .mockResolvedValueOnce({} as any)
-      vi.mocked(prisma.profileTrustFlag.updateMany).mockResolvedValue({ count: 1 } as any)
+      vi.mocked(prisma.profileTrustFlag.updateMany)
+        .mockRejectedValueOnce(new Error('db blip'))
+        .mockResolvedValueOnce({ count: 1 } as any)
+      vi.mocked(prisma.profile.findMany).mockResolvedValue([] as any)
 
       await processProfileTrustJob(mockJob<ProfileTrustJobData>({ kind: 'clear-unvetted-window' }))
 
-      // Both profiles must be attempted (proves loop continues after failure).
-      expect(profileTrustQueue.add).toHaveBeenCalledTimes(2)
-      // Only p2 reached the update step (p1's update skipped by the thrown enqueue).
-      expect(prisma.profileTrustFlag.updateMany).toHaveBeenCalledTimes(1)
-      expect(prisma.profileTrustFlag.updateMany).toHaveBeenCalledWith({
-        where: { id: 'f2', clearedAt: null },
-        data: { clearedAt: expect.any(Date), clearedBy: 'system:unvetted_window' },
-      })
+      expect(prisma.profileTrustFlag.updateMany).toHaveBeenCalledTimes(2)
+    })
+
+    it('phase 2 continues when one profile promote fails', async () => {
+      vi.mocked(prisma.profileTrustFlag.findMany).mockResolvedValue([] as any)
+      vi.mocked(prisma.profile.findMany).mockResolvedValue([{ id: 'p1' }, { id: 'p2' }] as any)
+      promotePendingsIfClear
+        .mockRejectedValueOnce(new Error('40001 serializable conflict'))
+        .mockResolvedValueOnce(undefined)
+
+      await processProfileTrustJob(mockJob<ProfileTrustJobData>({ kind: 'clear-unvetted-window' }))
+
+      expect(promotePendingsIfClear).toHaveBeenCalledTimes(2)
     })
   })
 

--- a/apps/backend/src/queues/profileTrustQueue.ts
+++ b/apps/backend/src/queues/profileTrustQueue.ts
@@ -4,7 +4,6 @@ import { logger } from '@/lib/logger'
 
 // Job payload — discriminated union on `kind`.
 export type ProfileTrustJobData =
-  | { kind: 'promote-pendings'; profileId: string }
   | { kind: 'clear-unvetted-window' }
   | { kind: 'reconcile-many'; allProfiles?: boolean }
 

--- a/apps/backend/src/queues/profileTrustQueue.ts
+++ b/apps/backend/src/queues/profileTrustQueue.ts
@@ -7,8 +7,13 @@ export type ProfileTrustJobData =
   | { kind: 'clear-unvetted-window' }
   | { kind: 'reconcile-many'; allProfiles?: boolean }
 
-const DAILY_CRON = '0 3 * * *' // daily at 03:00 UTC
-const UNVETTED_WINDOW_CRON = '*/15 * * * *' // every 15 minutes
+// Both schedulers tick on the same 15-min cadence. SPAM_BURST release
+// (reconcile-many) and PROFILE_UNVETTED ageing + PENDING promote
+// (clear-unvetted-window) must share cadence: the sweep's Phase 2 AND-composes
+// all active flags, so the slower clear path bottlenecks release for compound
+// cases. Worst-case promote SLA is one tick = 15 min, not 24h + 15 min.
+const RECONCILE_CRON = '*/15 * * * *'
+const UNVETTED_WINDOW_CRON = '*/15 * * * *'
 
 export const profileTrustQueue = new Queue<ProfileTrustJobData>('profile-trust', {
   connection: bullConnection,
@@ -23,11 +28,11 @@ export const profileTrustQueue = new Queue<ProfileTrustJobData>('profile-trust',
   },
 })
 
-/** Register the repeatable daily + unvetted-window jobs. Safe to call on every startup. */
+/** Register the repeatable reconcile + unvetted-window jobs. Safe to call on every startup. */
 export async function registerProfileTrustJobs(): Promise<void> {
   await profileTrustQueue.upsertJobScheduler(
-    'profile-trust-daily',
-    { pattern: DAILY_CRON },
+    'profile-trust-reconcile',
+    { pattern: RECONCILE_CRON },
     { name: 'reconcile-many', data: { kind: 'reconcile-many' } }
   )
   await profileTrustQueue.upsertJobScheduler(
@@ -36,7 +41,7 @@ export async function registerProfileTrustJobs(): Promise<void> {
     { name: 'clear-unvetted-window', data: { kind: 'clear-unvetted-window' } }
   )
   logger.info(
-    { queue: 'profile-trust', daily: DAILY_CRON, unvetted_window: UNVETTED_WINDOW_CRON },
+    { queue: 'profile-trust', reconcile: RECONCILE_CRON, unvetted_window: UNVETTED_WINDOW_CRON },
     'profile-trust cron registered'
   )
 }

--- a/apps/backend/src/services/profileTrust.service.ts
+++ b/apps/backend/src/services/profileTrust.service.ts
@@ -183,6 +183,13 @@ export class ProfileTrustService {
 
     if (count >= SPAM_BURST_THRESHOLD) {
       if (!alreadyFlagged) {
+        // TODO(race): non-idempotent under concurrent reconcile. The check-then-create
+        // window between hasTrustFlag() and create() lets two callers (e.g. inline post-send
+        // reconcile racing the cron reconcile-many on the same profile) both decide
+        // "create flag" and write two active SPAM_BURST rows. Consequence: hasTrustFlag
+        // still works, but admin clearFlag(flagId) only clears one row, leaving the other
+        // active. Fix: partial unique index on ProfileTrustFlag(profileId, reason) WHERE
+        // clearedAt IS NULL; treat P2002 here as "lost the race, flag already exists".
         await prisma.profileTrustFlag.create({
           data: {
             profileId,

--- a/apps/backend/src/services/profileTrust.service.ts
+++ b/apps/backend/src/services/profileTrust.service.ts
@@ -1,4 +1,5 @@
 import type { TrustReasonType } from '@zod/generated/inputTypeSchemas/TrustReasonSchema'
+import { Prisma } from '@prisma/client'
 import { prisma } from '@/lib/prisma'
 import { MessageService } from '@/services/messaging.service'
 
@@ -20,12 +21,6 @@ export const TRUST_WINDOW_MS = 24 * 60 * 60 * 1000
 // this many ms of "now". Without this bound, an all-time count punishes users
 // with old unanswered intros forever — that's unresponsiveness, not burst spam.
 export const SPAM_BURST_WINDOW_MS = TRUST_WINDOW_MS
-
-// Shared builder so every enqueue site uses the same BullMQ dedup key. If the clear
-// path here and the clear-unvetted-window worker (Task 6) drifted to different
-// formats, two promote-pendings jobs could race inside the serializable tx.
-// BullMQ rejects ':' in custom jobIds (Redis key separator); use '-' as separator.
-export const promotePendingsJobId = (profileId: string) => `promote-pendings-${profileId}`
 
 /**
  * Result of attempting to clear a flag. The service stays HTTP-agnostic;
@@ -71,42 +66,38 @@ export class ProfileTrustService {
   }
 
   /**
-   * Manual flag clear. Reuses the same promote-pendings enqueue path
-   * that the heuristic threshold-down branch uses, so held messages get released
-   * the same way regardless of who closed the flag.
+   * Manual (typically admin) flag clear. Atomic clear-and-release: in a single
+   * serializable tx, clears the named flag and — if no other active flag remains
+   * on the profile — promotes the profile's PENDING initiator-side conversations
+   * to INITIATED, making them visible to recipients.
    *
-   * Heuristic SPAM_BURST flags can be cleared this way too — held conversations
-   * (PENDING, including any demoted from INITIATED while the flag was on) are
-   * released to recipients by promote-pendings the same way as PROFILE_UNVETTED.
+   * Admin-initiated clears deserve zero-latency release; the inline promote
+   * delivers that. System-driven clears (heuristic threshold-down, unvetted-window
+   * cron) intentionally do not inline-promote — the trust-sweep cron handles them.
    *
    * Returns a result code; the caller maps it to its protocol-specific response.
    */
   async clearFlag(flagId: string, clearedBy: string): Promise<ClearFlagResult> {
-    const flag = await prisma.profileTrustFlag.findUnique({ where: { id: flagId } })
-    if (!flag) return 'not_found'
-    if (flag.clearedAt) return 'already_cleared'
+    return await prisma.$transaction(
+      async (tx) => {
+        const flag = await tx.profileTrustFlag.findUnique({ where: { id: flagId } })
+        if (!flag) return 'not_found' as ClearFlagResult
+        if (flag.clearedAt) return 'already_cleared' as ClearFlagResult
 
-    // Conditional write: only the call that actually transitions clearedAt
-    // null→now wins. A concurrent clearer's update affects 0 rows and we
-    // skip the enqueue, avoiding a duplicate promote-pendings job and
-    // timestamp drift on clearedAt/clearedBy.
-    const result = await prisma.profileTrustFlag.updateMany({
-      where: { id: flagId, clearedAt: null },
-      data: { clearedAt: new Date(), clearedBy },
-    })
-    if (result.count === 0) return 'already_cleared'
+        // Conditional write: only the call that actually transitions clearedAt
+        // null→now wins. A concurrent clearer's update affects 0 rows and we
+        // skip the inline promote, avoiding duplicate work and timestamp drift.
+        const result = await tx.profileTrustFlag.updateMany({
+          where: { id: flagId, clearedAt: null },
+          data: { clearedAt: new Date(), clearedBy },
+        })
+        if (result.count === 0) return 'already_cleared' as ClearFlagResult
 
-    const { profileTrustQueue } = await import('@/queues/profileTrustQueue')
-    await profileTrustQueue.add(
-      'promote-pendings',
-      { kind: 'promote-pendings', profileId: flag.profileId },
-      {
-        jobId: promotePendingsJobId(flag.profileId),
-        removeOnComplete: { count: 0 },
-        removeOnFail: { count: 100 },
-      }
+        await this.promotePendingsInTx(tx, flag.profileId)
+        return 'cleared' as ClearFlagResult
+      },
+      { isolationLevel: 'Serializable' }
     )
-    return 'cleared'
   }
 
   /**
@@ -169,14 +160,15 @@ export class ProfileTrustService {
    * Cases (count is windowed by SPAM_BURST_WINDOW_MS over INITIATED+PENDING):
    * - count >= threshold AND not flagged: write SPAM_BURST flag.
    * - count >= threshold AND already flagged: no-op (flag is in the right state).
-   * - count <  threshold AND already flagged: clear the flag AND enqueue
-   *   promote-pendings so any PENDING rows held under the flag get released.
+   * - count <  threshold AND already flagged: clear the flag. The trust-sweep
+   *   cron will release any held PENDING rows on its next tick.
    * - count <  threshold AND not flagged: no-op.
    *
    * The windowed count is the policy lever: old unanswered intros are
    * unresponsiveness, not burst spam, and shouldn't keep a profile flagged forever.
-   * Release of held PENDING messages on flag clear flows through the existing
-   * promote-pendings worker — same path as PROFILE_UNVETTED.
+   * System-driven clears (this branch, and the unvetted-window cron) do NOT
+   * inline-promote — releasing held messages is the sweeper's job, not the
+   * route's hot path. Admin-initiated clearFlag does inline-promote.
    */
   async reconcileSpamBurst(profileId: string): Promise<void> {
     const since = new Date(Date.now() - SPAM_BURST_WINDOW_MS)
@@ -205,50 +197,57 @@ export class ProfileTrustService {
         where: { profileId, reason: 'SPAM_BURST', clearedAt: null },
         data: { clearedAt: new Date(), clearedBy: 'heuristic:spam_burst_below_threshold' },
       })
-      // Dynamic import — the profile-trust worker (Task 6) imports this service,
-      // so a top-level import of the queue would close a cycle once that lands.
-      const { profileTrustQueue } = await import('@/queues/profileTrustQueue')
-      await profileTrustQueue.add(
-        'promote-pendings',
-        { kind: 'promote-pendings', profileId },
-        {
-          jobId: promotePendingsJobId(profileId),
-          // drop completed jobs immediately (minimize Redis footprint);
-          // retain last 100 failures for diagnostics.
-          removeOnComplete: { count: 0 },
-          removeOnFail: { count: 100 },
-        }
-      )
     }
   }
 
   /**
-   * Worker handler: if the profile has zero active flags, promote all its PENDING conversations.
-   * Runs in a serializable tx to close the race with reconcileSpamBurst writing DISCARDs.
-   * Per-row races are absorbed by promoteConversation's best-effort no-op; genuine R-W
-   * conflicts surface as 40001 at commit, retried by BullMQ (requires attempts > 1 — Prisma
-   * does not auto-retry). On retry `stillFlagged` short-circuits if SPAM_BURST landed.
+   * Public per-profile release: if the profile has zero active flags, promote
+   * all its initiator-side PENDING conversations to INITIATED. Runs in its own
+   * serializable tx — used by the trust-sweep cron, one tx per candidate.
+   *
+   * Per-row races are absorbed by promoteConversation's best-effort no-op;
+   * genuine R-W conflicts surface as 40001 at commit, retried by BullMQ.
+   * On retry `stillFlagged` short-circuits if a new flag landed.
    */
   async promotePendingsIfClear(profileId: string): Promise<void> {
-    const messageService = MessageService.getInstance()
     await prisma.$transaction(
       async (tx) => {
-        const stillFlagged = await tx.profileTrustFlag.findFirst({
-          where: { profileId, clearedAt: null },
-          select: { id: true },
-        })
-        if (stillFlagged) return
-
-        const pendings = await tx.conversation.findMany({
-          where: { initiatorProfileId: profileId, status: 'PENDING' },
-          select: { id: true, profileAId: true, profileBId: true },
-        })
-        for (const convo of pendings) {
-          const recipientId = convo.profileAId === profileId ? convo.profileBId : convo.profileAId
-          await messageService.promoteConversation(tx, convo.id, recipientId)
-        }
+        await this.promotePendingsInTx(tx, profileId)
       },
       { isolationLevel: 'Serializable' }
     )
+  }
+
+  /**
+   * In-tx release helper. Idempotent: if any flag is still active for the
+   * profile, returns without promoting. Per-row update is conditional on
+   * `status: 'PENDING'`, so concurrent recipient replies (`accept_and_promote_pending`)
+   * that flipped the row to ACCEPTED leave it untouched.
+   *
+   * Callers must run this inside a serializable transaction — both the
+   * stillFlagged check and the row promotions need consistent isolation to
+   * avoid a partial release across a concurrent flag write.
+   */
+  private async promotePendingsInTx(
+    tx: Prisma.TransactionClient,
+    profileId: string
+  ): Promise<void> {
+    const stillFlagged = await tx.profileTrustFlag.findFirst({
+      where: { profileId, clearedAt: null },
+      select: { id: true },
+    })
+    if (stillFlagged) return
+
+    const pendings = await tx.conversation.findMany({
+      where: { initiatorProfileId: profileId, status: 'PENDING' },
+      select: { id: true, profileAId: true, profileBId: true },
+    })
+    if (pendings.length === 0) return
+
+    const messageService = MessageService.getInstance()
+    for (const convo of pendings) {
+      const recipientId = convo.profileAId === profileId ? convo.profileBId : convo.profileAId
+      await messageService.promoteConversation(tx, convo.id, recipientId)
+    }
   }
 }

--- a/apps/backend/src/services/profileTrust.service.ts
+++ b/apps/backend/src/services/profileTrust.service.ts
@@ -205,9 +205,11 @@ export class ProfileTrustService {
    * all its initiator-side PENDING conversations to INITIATED. Runs in its own
    * serializable tx — used by the trust-sweep cron, one tx per candidate.
    *
-   * Per-row races are absorbed by promoteConversation's best-effort no-op;
-   * genuine R-W conflicts surface as 40001 at commit, retried by BullMQ.
-   * On retry `stillFlagged` short-circuits if a new flag landed.
+   * Per-row races are absorbed by promoteConversation's best-effort no-op
+   * (per-row `updateMany WHERE status: 'PENDING'`). Genuine R-W conflicts
+   * surface as 40001 at commit; the next 15-min sweeper tick re-picks up the
+   * profile because the SQL anti-join still matches, and `stillFlagged` inside
+   * `promotePendingsInTx` short-circuits if a flag landed in the meantime.
    */
   async promotePendingsIfClear(profileId: string): Promise<void> {
     await prisma.$transaction(

--- a/apps/backend/src/workers/profileTrustWorker.ts
+++ b/apps/backend/src/workers/profileTrustWorker.ts
@@ -1,12 +1,8 @@
 import type { Job } from 'bullmq'
 import { logger } from '@/lib/logger'
 import { prisma } from '@/lib/prisma'
-import {
-  ProfileTrustService,
-  promotePendingsJobId,
-  TRUST_WINDOW_MS,
-} from '@/services/profileTrust.service'
-import { profileTrustQueue, type ProfileTrustJobData } from '@/queues/profileTrustQueue'
+import { ProfileTrustService, TRUST_WINDOW_MS } from '@/services/profileTrust.service'
+import { type ProfileTrustJobData } from '@/queues/profileTrustQueue'
 
 // PROFILE_UNVETTED soft-quarantine length. Shares TRUST_WINDOW_MS with SPAM_BURST
 // by design — see the constant's definition for the symmetry rationale.
@@ -16,14 +12,14 @@ export async function processProfileTrustJob(job: Job<ProfileTrustJobData>): Pro
   const svc = ProfileTrustService.getInstance()
   const data = job.data
 
-  if (data.kind === 'promote-pendings') {
-    await svc.promotePendingsIfClear(data.profileId)
-    await job.log(`promoted pendings (if clear) for ${data.profileId}`)
-    return
-  }
-
   if (data.kind === 'clear-unvetted-window') {
+    // Two-phase trust-sweep: (1) age out PROFILE_UNVETTED flags, then
+    // (2) state-driven release of PENDING for any profile with zero active flags.
+    // The sweep replaces the deleted promote-pendings BullMQ queue — release is
+    // now a SQL-driven convergence step, not an event-driven side-channel.
     const cutoff = new Date(Date.now() - UNVETTED_WINDOW_MS)
+
+    // Phase 1 — clear aged PROFILE_UNVETTED flags (non-admin only).
     const flagsToClear = await prisma.profileTrustFlag.findMany({
       where: {
         reason: 'PROFILE_UNVETTED',
@@ -33,24 +29,9 @@ export async function processProfileTrustJob(job: Job<ProfileTrustJobData>): Pro
       },
       select: { id: true, profileId: true },
     })
-    let failed = 0
+    let p1Failed = 0
     for (const { id, profileId } of flagsToClear) {
       try {
-        // Enqueue BEFORE clearing the flag. If enqueue fails we never clear, and
-        // the next 15-min scan re-finds the still-aged flag and retries. If enqueue
-        // succeeds but update then fails, the dedup jobId prevents duplicates and
-        // promotePendingsIfClear short-circuits on `stillFlagged`; the next scan
-        // will clear. Reverse order would strand PENDINGs on a cleared-but-unqueued
-        // failure (no retry path).
-        await profileTrustQueue.add(
-          'promote-pendings',
-          { kind: 'promote-pendings', profileId },
-          {
-            jobId: promotePendingsJobId(profileId),
-            removeOnComplete: { count: 0 },
-            removeOnFail: { count: 100 },
-          }
-        )
         // Conditional clear: if an admin (or any other path) cleared this flag
         // between findMany and now, the updateMany affects 0 rows and we leave
         // their clearedAt/clearedBy attribution intact. Mirrors the pattern in
@@ -60,16 +41,44 @@ export async function processProfileTrustJob(job: Job<ProfileTrustJobData>): Pro
           data: { clearedAt: new Date(), clearedBy: 'system:unvetted_window' },
         })
       } catch (err) {
-        failed += 1
+        p1Failed += 1
         await job.log(
           `failed to clear ${profileId}: ${err instanceof Error ? err.message : String(err)}`
         )
-        logger.error({ err, profileId }, 'clear-unvetted-window per-profile failure')
+        logger.error({ err, profileId }, 'trust-sweep phase 1 (clear) failure')
       }
     }
+
+    // Phase 2 — sweep: promote PENDING for any profile with zero active flags
+    // and at least one initiator-side PENDING. The SQL anti-join encapsulates
+    // the convergence invariant; promotePendingsIfClear's own stillFlagged
+    // re-check inside its serializable tx absorbs a flag landing between this
+    // findMany and the per-profile tx start.
+    const sweepCandidates = await prisma.profile.findMany({
+      where: {
+        trustFlags: { none: { clearedAt: null } },
+        Conversation: { some: { status: 'PENDING' } },
+      },
+      select: { id: true },
+    })
+    let p2Failed = 0
+    for (const { id: profileId } of sweepCandidates) {
+      try {
+        await svc.promotePendingsIfClear(profileId)
+      } catch (err) {
+        p2Failed += 1
+        await job.log(
+          `failed to promote ${profileId}: ${err instanceof Error ? err.message : String(err)}`
+        )
+        logger.warn({ err, profileId }, 'trust-sweep phase 2 (promote) failure')
+      }
+    }
+
     await job.log(
-      `cleared ${flagsToClear.length - failed} PROFILE_UNVETTED flag(s)` +
-        (failed > 0 ? ` (${failed} failed)` : '')
+      `phase 1: cleared ${flagsToClear.length - p1Failed} PROFILE_UNVETTED flag(s)` +
+        (p1Failed > 0 ? ` (${p1Failed} failed)` : '') +
+        ` | phase 2: promoted ${sweepCandidates.length - p2Failed} profile(s)` +
+        (p2Failed > 0 ? ` (${p2Failed} failed)` : '')
     )
     return
   }


### PR DESCRIPTION
## Summary

Eliminates the dedup-jobId race class in the trust system by replacing the event-driven `promote-pendings` BullMQ queue with a state-driven sweeper that runs as Phase 2 of the existing 15-min cron, plus inline-promote-in-tx for admin clears. Also brings `reconcile-many` onto the same 15-min cadence so that SPAM_BURST release (a sender-side flag) shares the same SLA as PROFILE_UNVETTED release.

After this PR:
- **No `promote-pendings` queue exists.** No jobId, no dedup, no `stillFlagged` re-check against external state.
- **All flag-clear writes are conditional `updateMany WHERE clearedAt: null`** — admin attribution survives any race.
- **Admin clears release messages atomically in one serializable tx** (zero-latency).
- **System clears** (unvetted-window cron, SPAM_BURST threshold-down) **release messages via the sweeper** within one cron tick (~15 min worst case for a single flag, ~30 min for compound cases where order between the two cron jobs matters).

## The race this fixes

Two paths could enqueue `promote-pendings` for the same profile with a deterministic jobId. If path A's worker started executing, did its `stillFlagged` check against a flag set by path B's source, returned no-op, and was removed by `removeOnComplete`, **and** path B's enqueue arrived during A's execution window, BullMQ would drop B as a duplicate. Both paths reasonably believed their work was scheduled; neither actually ran the release. The profile's PENDING rows stayed PENDING until an unrelated future flag-clear event re-triggered the chain.

The sweeper replaces the enqueue-chain with a SQL anti-join: *find profiles with no active flags + has initiator-side PENDING, promote them*. The predicate IS the check. Re-running converges to zero candidates.

## What changed

| File | Change |
|---|---|
| [`profileTrust.service.ts`](apps/backend/src/services/profileTrust.service.ts) | `clearFlag` now wraps everything in a serializable tx with inline promote via `promotePendingsInTx`. `reconcileSpamBurst` threshold-down drops the enqueue — just clears the flag. New private `promotePendingsInTx` helper shared by the sweeper and admin path. `promotePendingsJobId` export removed. TODO(race) marker added at the SPAM_BURST flag-create site — see Known limitations below. |
| [`queues/profileTrustQueue.ts`](apps/backend/src/queues/profileTrustQueue.ts) | `promote-pendings` removed from the job kind union. `reconcile-many` scheduler cadence changed from daily (`0 3 * * *`) to 15-min (`*/15 * * * *`) so both schedulers tick on the same cron and the sweeper's AND-composed flag gate doesn't bottleneck on the slower clear path. Scheduler key renamed `profile-trust-daily` → `profile-trust-reconcile`; constant renamed accordingly. |
| [`workers/profileTrustWorker.ts`](apps/backend/src/workers/profileTrustWorker.ts) | `promote-pendings` arm deleted. `clear-unvetted-window` now runs Phase 1 (clear aged flags) + Phase 2 (sweep + promote). Single 15-min tick handles both. |
| Tests across 3 files | Rewrote `clearFlag` tests to mock `$transaction`; dropped `promote-pendings` worker tests; added Phase 2 sweep tests; added `conversation` to admin route's prisma mock for the new inline promote. |

Production code: net subtractive. Tests: net additive (the new sweep invariants get explicit coverage).

## Behavior matrix

| Trigger | Latency to release | Mechanism |
|---|---|---|
| Admin `clearFlag` | ~tx commit time (~20-50ms) | Inline promote in same serializable tx |
| `reconcileSpamBurst` threshold-down (system) | ≤ 15 min (single flag); ≤ 30 min (compound flags, order-dependent) | reconcile-many cron clears flag, sweeper Phase 2 promotes |
| `clear-unvetted-window` cron Phase 1 (system) | Phase 2 of same tick when no other flag active | Sweeper Phase 2 in same handler invocation |
| Recipient reply to a PENDING (race outside trust system) | ~tx commit time | Existing `accept_and_promote_pending` route path, unchanged |

The compound-flag 30-min case: at a given `*/15` tick, BullMQ does not guarantee inter-job ordering. If `clear-unvetted-window` runs before `reconcile-many`, Phase 2's anti-join sees SPAM_BURST still active and skips. The next tick (15 min later) catches the convergence after the previous tick's `reconcile-many` cleared SPAM_BURST. Verified end-to-end during UAT on dev.

## Races eliminated

| Race | Before | After |
|---|---|---|
| Stranded-PENDING via dedup-jobId | Real, infrequent | **Structurally impossible** — no queue |
| Admin attribution clobber by cron | Already fixed in #1467's commit 4 | Unchanged |
| Sweeper picks profile, flag lands before per-profile tx | N/A | Absorbed by `promotePendingsInTx`'s `stillFlagged` check inside serializable tx |
| Sweeper picks profile, recipient reply lands during sweep | N/A | Absorbed by per-row `updateMany WHERE status: 'PENDING'` (race-loser hits 0 rows) |
| Two clearFlag callers race | Already conditional updateMany | One wins, other returns `already_cleared` |
| SPAM_BURST release blocked by daily cron | Real (up to ~24h+15min worst case) | **Fixed** — both cron jobs share 15-min cadence; worst case is 30 min for compound flags |

## Known limitations / follow-up

**Class 3a race — duplicate SPAM_BURST flag rows** (deferred to a follow-up PR):

`reconcileSpamBurst` has a check-then-create window between `hasTrustFlag()` and `profileTrustFlag.create()`. Two concurrent callers (inline post-send racing cron `reconcile-many` on the same profile) can both decide "create flag" and write two active SPAM_BURST rows. Consequence is bounded: `hasTrustFlag` still gates correctly, but admin `clearFlag(flagId)` operates on a single row, so an admin clear would leave the duplicate active.

The cadence change in this PR widens the race surface very slightly (reconcile-many now runs 96x/day instead of 1x/day), but realistic frequency remains low. The race was marked in code with `TODO(race)` at the create site for discoverability via grep.

**Structural fix** (deferred): partial unique index on `ProfileTrustFlag(profileId, reason) WHERE clearedAt IS NULL` + P2002 catch at the create site to treat the loser as "flag already exists." Kept off this branch to keep the scope focused on the SLA correction.

## What stays as-is

- **15-min cron cadence** for both `clear-unvetted-window` and (now) `reconcile-many`. Both schedulers tick on `*/15 * * * *`.
- **`reconcileSpamBurst` inline-on-send** (per send path) is unchanged from #1467 — no policy regression there.
- **`promotePendingsIfClear` public method survives** as the per-profile sweep entry point; both the sweeper and admin path go through it (sweeper directly, admin path via the in-tx helper).
- **DISCARDED, BLOCKED, ARCHIVED** tombstone semantics unchanged. The state machine is untouched.

## Test plan

- [x] `pnpm --filter backend test` — full suite passes.
- [x] `pnpm --filter backend exec tsc --noEmit` — clean.
- [x] `pnpm lint` — clean.
- [x] New tests: Phase 1 (conditional clear, no enqueue), Phase 2 (SQL anti-join, per-profile promote, failure isolation), `clearFlag` (inline promote happy path, skip-when-other-flag, serializable isolation, race-loser semantics).
- [x] UAT on dev: full end-to-end timeline validated — UNVETTED + SPAM_BURST coexistence, recipient reply reduces windowed count, reconcile-many clears SPAM_BURST when count < threshold, sweeper Phase 2 promotes PENDING when zero active flags, admin clearFlag inline promote atomicity (≤6ms flag-clear → row promote in same tx), same-tick convergence at `*/15` boundary (16:30:00.441 flag clear → 16:30:00.486 row promote, +45ms).

## Migration / deployment notes

- **In-flight `promote-pendings` jobs at deploy time will fail** (worker has no arm for that kind). The work they would have done is exactly what the sweeper does on its next tick — within 15 min of deploy, all stranded PENDING rows release. No data loss, just a 15-min release latency for those specific profiles.
- **No DB migration.** The schema is untouched; only behavior changes.
- **Old BullMQ scheduler `profile-trust-daily` in Redis** is orphaned by the rename. One-time cleanup against production Redis after deploy:
  ```
  redis-cli ZREM bull:profile-trust:repeat profile-trust-daily
  redis-cli --scan --pattern 'bull:profile-trust:repeat:profile-trust-daily*' | xargs -r redis-cli DEL
  ```
  The orphan is benign — no scheduler-key matching means it never fires — but leaving it adds noise to Redis key dumps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)