### PR TITLE
fix(backend): unblock Docker build under Prisma 7 by providing build-time DATABASE_URL

### DIFF
--- a/.changeset/copper-falcons-build.md
+++ b/.changeset/copper-falcons-build.md
@@ -1,0 +1,5 @@
+---
+'@opencupid/backend': patch
+---
+
+Fix docker build failing after Prisma 7 upgrade: set placeholder `DATABASE_URL` in builder stage so `prisma.config.ts` resolves at codegen time.

--- a/apps/backend/Dockerfile
+++ b/apps/backend/Dockerfile
@@ -26,10 +26,14 @@ RUN pnpm install --no-frozen-lockfile
 # Optional: for native Prisma CLI if needed
 # RUN apk add --no-cache libc6-compat
 
-# Generate Prisma client and build application
+# Generate Prisma client and build application.
+# Prisma 7's prisma.config.ts resolves env('DATABASE_URL') at config-load time,
+# so even `prisma generate` needs the var present. The build never connects —
+# a placeholder is fine and keeps real credentials out of the image.
 ENV PRISMA_DISABLE_WARNINGS=true
 ENV PRISMA_HIDE_UPDATE_MESSAGE=1
 ENV TURBO_NO_UPDATE_NOTIFIER=1
+ENV DATABASE_URL=postgres://build:build@localhost:5432/build
 RUN pnpm run prisma:generate && pnpm run build
 
 # Remove dev dependencies


### PR DESCRIPTION
## Summary

- The v0.63.0 release's Docker build failed at the backend's `prisma generate` step with `PrismaConfigEnvError: Cannot resolve environment variable: DATABASE_URL` ([failed run](https://github.com/opencupid/opencupid/actions/runs/25997607796/job/76414768826)).
- Root cause: PR #1451 upgraded to Prisma 7 and added [`apps/backend/prisma.config.ts`](../blob/main/apps/backend/prisma.config.ts), which calls `env('DATABASE_URL')` at config-load time. Prisma 7 evaluates `prisma.config.ts` for *every* CLI invocation, including pure codegen — so without the env var present, `prisma generate` aborts before doing anything. v0.63.0 was the first release built end-to-end on Prisma 7, which is why the regression only surfaced now.
- Fix: set a placeholder `DATABASE_URL` in the builder stage of `apps/backend/Dockerfile`. The build never connects, so a fake URL is safe; real credentials still come from the runtime env (compose `.env`) and shadow the placeholder.

## Test plan

- [x] Reproduced the CI failure locally against `main` HEAD with `docker buildx build --file apps/backend/Dockerfile --target builder .` — identical `PrismaConfigEnvError` at builder step `14/15`.
- [x] Built the **builder** stage with the fix locally — passes (`prisma generate` + `pnpm build` both succeed).
- [x] Built the **full multi-stage** image with the fix locally — passes end-to-end.
- [ ] CI Docker Build workflow re-runs green on this branch / after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)