### PR TITLE
refactor(profile): split ProfileContent into read-only and editable variants

### DIFF
--- a/.changeset/quiet-rivers-split.md
+++ b/.changeset/quiet-rivers-split.md
@@ -1,0 +1,5 @@
+---
+'@opencupid/frontend': patch
+---
+
+Split `ProfileContent` into a lean read-only component and an `EditableProfileContent` wrapper that injects edit fields via slots. Public/conversation views no longer load the edit-field machinery or form editor bundles.

--- a/apps/frontend/src/features/myprofile/components/EditableProfileContent.vue
+++ b/apps/frontend/src/features/myprofile/components/EditableProfileContent.vue
@@ -1,0 +1,128 @@
+<script lang="ts" setup>
+import { useI18n } from 'vue-i18n'
+
+import { type PublicProfile } from '@zod/profile/profile.dto'
+
+import ProfileContent from '@/features/publicprofile/components/ProfileContent.vue'
+import IconPhoto from '@/assets/icons/interface/photo.svg'
+import EditField from './EditField.vue'
+import PublicNameInput from '@/features/shared/profileform/PublicNameInput.vue'
+import LocationSelector from '@/features/shared/profileform/LocationSelector.vue'
+import LanguageSelector from '@/features/shared/profileform/LanguageSelector.vue'
+import TagSelector from '@/features/shared/profileform/TagSelector.vue'
+import IntrotextEditor from '@/features/shared/profileform/IntrotextEditor.vue'
+import ImageEditor from '@/features/images/components/ImageEditor.vue'
+import { useProfileImageStore } from '@/features/images/stores/profileImageStore'
+
+const { t } = useI18n()
+
+const props = defineProps<{
+  profile: PublicProfile
+}>()
+
+const profileImageStore = useProfileImageStore()
+</script>
+
+<template>
+  <ProfileContent :profile="props.profile">
+    <template #photo-edit>
+      <EditField
+        fieldName="profileImages"
+        :editComponent="ImageEditor"
+        :editProps="{ store: profileImageStore, minImages: 1 }"
+        buttonClass="btn-icon-lg btn-overlay photo-edit-button"
+      >
+        <IconPhoto class="svg-icon" />
+      </EditField>
+    </template>
+
+    <template #name-edit>
+      <EditField
+        fieldName="publicName"
+        :editComponent="PublicNameInput"
+      />
+    </template>
+
+    <template #location-edit>
+      <EditField
+        fieldName="location"
+        :editComponent="LocationSelector"
+      />
+    </template>
+
+    <template #tags-edit>
+      <EditField
+        fieldName="tags"
+        :editComponent="TagSelector"
+      >
+        <template #placeholder>
+          <div
+            class="editable-placeholder"
+            v-if="!props.profile.tags?.length"
+          >
+            {{ t('profiles.forms.tags_placeholder') }}
+          </div>
+        </template>
+      </EditField>
+    </template>
+
+    <template #languages-edit>
+      <EditField
+        fieldName="languages"
+        :editComponent="LanguageSelector"
+      />
+    </template>
+
+    <template #intro-social>
+      <EditField
+        fieldName="introSocialLocalized"
+        :editComponent="IntrotextEditor"
+        wrapper-class="editable-textarea"
+        :editProps="{
+          languages: props.profile.languages,
+          placeholder: t('profiles.forms.intro_placeholder'),
+        }"
+      >
+        <template #display>
+          {{ props.profile.introSocial }}
+        </template>
+        <template #placeholder>
+          <div class="editable-placeholder">
+            <span v-if="!props.profile.introSocial">
+              {{ t('profiles.forms.intro_placeholder') }}
+            </span>
+            <span v-else>
+              {{ props.profile.introSocial }}
+            </span>
+          </div>
+        </template>
+      </EditField>
+    </template>
+
+    <template #intro-dating>
+      <EditField
+        fieldName="introDatingLocalized"
+        :editComponent="IntrotextEditor"
+        wrapper-class="editable-textarea"
+        :editProps="{
+          languages: props.profile.languages,
+          placeholder: t('profiles.forms.intro_who_placeholder'),
+        }"
+      >
+        <template #display>
+          {{ props.profile.introDating }}
+        </template>
+        <template #placeholder>
+          <div class="editable-placeholder">
+            <span v-if="!props.profile.introDating">
+              {{ t('profiles.forms.intro_who_placeholder') }}
+            </span>
+            <span v-else>
+              {{ props.profile.introDating }}
+            </span>
+          </div>
+        </template>
+      </EditField>
+    </template>
+  </ProfileContent>
+</template>

--- a/apps/frontend/src/features/myprofile/components/MyProfile.vue
+++ b/apps/frontend/src/features/myprofile/components/MyProfile.vue
@@ -1,7 +1,5 @@
 <script setup lang="ts">
-import { ref } from 'vue'
-
-import ProfileContent from '@/features/publicprofile/components/ProfileContent.vue'
+import EditableProfileContent from './EditableProfileContent.vue'
 
 import { useMyProfileViewModel } from '../composables/useMyProfileViewModel'
 import MyProfileSecondaryNav from './MyProfileSecondaryNav.vue'
@@ -18,17 +16,8 @@ const emit = defineEmits<{
   (e: 'datingmode:wizard'): void
 }>()
 
-const showModal = ref(false)
-const {
-  error,
-  isLoading,
-  viewState,
-  formData,
-  profilePreview,
-  isDatingOnboarded,
-  updateScopes,
-  updateProfile,
-} = useMyProfileViewModel(props.editMode)
+const { viewState, formData, profilePreview, isDatingOnboarded, updateScopes, updateProfile } =
+  useMyProfileViewModel(props.editMode)
 
 const openDatingPrefs = () => {
   if (!isDatingOnboarded.value) {
@@ -69,10 +58,8 @@ const toggleDating = async () => {
         :class="[viewState.currentScope, { editable: viewState.isEditable }]"
         class="scroll hide-scrollbar"
       >
-        <ProfileContent
+        <EditableProfileContent
           v-if="profilePreview"
-          :isLoading="isLoading"
-          @intent:field:edit="showModal = true"
           :profile="profilePreview"
         />
       </EditableFields>

--- a/apps/frontend/src/features/publicprofile/components/ProfileContent.vue
+++ b/apps/frontend/src/features/publicprofile/components/ProfileContent.vue
@@ -1,27 +1,14 @@
 <script lang="ts" setup>
 import { computed, inject, type Ref } from 'vue'
-import { useI18n } from 'vue-i18n'
 
 import { type OwnerProfile, type PublicProfile } from '@zod/profile/profile.dto'
 
 import ImageCarousel from './ImageCarousel.vue'
-import IconPhoto from '@/assets/icons/interface/photo.svg'
-// Edit components
-import EditField from '@/features/myprofile/components/EditField.vue'
-import PublicNameInput from '@/features/shared/profileform/PublicNameInput.vue'
-import LocationSelector from '@/features/shared/profileform/LocationSelector.vue'
-import LanguageSelector from '@/features/shared/profileform/LanguageSelector.vue'
-import TagSelector from '@/features/shared/profileform/TagSelector.vue'
-import IntrotextEditor from '@/features/shared/profileform/IntrotextEditor.vue'
 import GenderPronounLabel from '@/features/shared/profiledisplay/GenderPronounLabel.vue'
 import RelationshipTags from '@/features/shared/profiledisplay/RelationshipTags.vue'
 import LanguageList from '@/features/shared/profiledisplay/LanguageList.vue'
 import TagList from '@/features/shared/profiledisplay/TagList.vue'
 import LocationLabel from '@/features/shared/profiledisplay/LocationLabel.vue'
-import ImageEditor from '@/features/images/components/ImageEditor.vue'
-import { useProfileImageStore } from '@/features/images/stores/profileImageStore'
-
-const { t } = useI18n()
 
 const props = defineProps<{
   profile: PublicProfile
@@ -29,8 +16,6 @@ const props = defineProps<{
 
 const viewerProfile = inject<Ref<OwnerProfile | null>>('viewerProfile')
 const viewerLocation = computed(() => viewerProfile?.value?.location)
-
-const profileImageStore = useProfileImageStore()
 </script>
 
 <template>
@@ -43,25 +28,18 @@ const profileImageStore = useProfileImageStore()
       <!-- <DatingIcon :profile /> -->
     </div>
 
-    <div class="action-buttons">
-      <EditField
-        fieldName="profileImages"
-        :editComponent="ImageEditor"
-        :editProps="{ store: profileImageStore, minImages: 1 }"
-        buttonClass="btn-icon-lg btn-overlay photo-edit-button"
-      >
-        <IconPhoto class="svg-icon" />
-      </EditField>
+    <div
+      class="action-buttons"
+      v-if="$slots['photo-edit']"
+    >
+      <slot name="photo-edit" />
     </div>
 
     <div class="mx-3">
       <div class="d-flex flex-row align-items-center mt-2">
         <div class="flex-grow-1 d-inline-flex align-items-center">
-          <span class="fw-bolder fs-2 me-1"> {{ props.profile.publicName }}</span>
-          <EditField
-            fieldName="publicName"
-            :editComponent="PublicNameInput"
-          />
+          <span class="fw-bolder fs-2 me-1">{{ props.profile.publicName }}</span>
+          <slot name="name-edit" />
         </div>
         <GenderPronounLabel :profile="props.profile" />
       </div>
@@ -75,62 +53,22 @@ const profileImageStore = useProfileImageStore()
             :showCountryIcon="false"
           />
         </span>
-        <EditField
-          fieldName="location"
-          :editComponent="LocationSelector"
-        />
+        <slot name="location-edit" />
       </div>
 
       <div class="mb-3">
         <div class="d-inline-flex align-items-center flex-wrap">
           <TagList :tags="profile.tags" />
-          <EditField
-            fieldName="tags"
-            :editComponent="TagSelector"
-          >
-            <template #placeholder>
-              <div
-                class="editable-placeholder"
-                v-if="!props.profile.tags?.length"
-              >
-                {{ t('profiles.forms.tags_placeholder') }}
-              </div>
-            </template>
-          </EditField>
+          <slot name="tags-edit" />
         </div>
 
         <div class="d-inline-flex align-items-center">
           <LanguageList :languages="profile.languages" />
-          <EditField
-            fieldName="languages"
-            :editComponent="LanguageSelector"
-          />
+          <slot name="languages-edit" />
         </div>
       </div>
       <div class="mb-3">
-        <EditField
-          fieldName="introSocialLocalized"
-          :editComponent="IntrotextEditor"
-          wrapper-class="editable-textarea"
-          :editProps="{
-            languages: profile.languages,
-            placeholder: t('profiles.forms.intro_placeholder'),
-          }"
-        >
-          <template #display>
-            {{ props.profile.introSocial }}
-          </template>
-          <template #placeholder>
-            <div class="editable-placeholder">
-              <span v-if="!props.profile.introSocial">
-                {{ t('profiles.forms.intro_placeholder') }}
-              </span>
-              <span v-else>
-                {{ props.profile.introSocial }}
-              </span>
-            </div>
-          </template>
-        </EditField>
+        <slot name="intro-social">{{ props.profile.introSocial }}</slot>
       </div>
 
       <div class="mb-3 dating-field">
@@ -141,29 +79,7 @@ const profileImageStore = useProfileImageStore()
           <span class="opacity-25">
             <hr />
           </span>
-          <EditField
-            fieldName="introDatingLocalized"
-            :editComponent="IntrotextEditor"
-            wrapper-class="editable-textarea"
-            :editProps="{
-              languages: profile.languages,
-              placeholder: t('profiles.forms.intro_who_placeholder'),
-            }"
-          >
-            <template #display>
-              {{ props.profile.introDating }}
-            </template>
-            <template #placeholder>
-              <div class="editable-placeholder">
-                <span v-if="!props.profile.introDating">
-                  {{ t('profiles.forms.intro_who_placeholder') }}
-                </span>
-                <span v-else>
-                  {{ props.profile.introDating }}
-                </span>
-              </div>
-            </template>
-          </EditField>
+          <slot name="intro-dating">{{ props.profile.introDating }}</slot>
         </div>
         <div class="mb-3">
           <RelationshipTags :profile="props.profile" />


### PR DESCRIPTION
## Summary

- `features/publicprofile/components/ProfileContent.vue` is now a pure read-only display: no `EditField`, no form-editor imports. Each previously-editable point exposes a named slot (`photo-edit`, `name-edit`, `location-edit`, `tags-edit`, `languages-edit`, `intro-social`, `intro-dating`). Intro slots fall back to the plain value so read-only consumers get the right output with zero slot usage.
- `features/myprofile/components/EditableProfileContent.vue` (new — replaces the edit-aware behaviour of the old `ProfileContent`) wraps `<ProfileContent>` and fills the slots with `EditField` instances. It owns the editor-component imports (`PublicNameInput`, `LocationSelector`, `LanguageSelector`, `TagSelector`, `IntrotextEditor`, `ImageEditor`).
- `MyProfile.vue` swaps to `EditableProfileContent`. Removed a couple of dead bindings on the way (`showModal` ref, unused `isLoading`/`error`, the `@intent:field:edit` listener — the old component never declared that prop/emit).
- `PublicProfile.vue` and `messaging/ConversationDetail.vue` are unchanged — they keep importing `ProfileContent`, now leaner and free of the edit-field machinery.

The layout (markup + classes + dating-section conditional) lives in exactly one file. The editable variant only contributes EditField wiring per slot, so visual tweaks stay in one place.

## Test plan

- [x] `pnpm --filter frontend exec vue-tsc --noEmit`
- [x] `pnpm --filter frontend test` (113 files / 659 tests pass)
- [ ] Manual: `/me` and `/me/edit` render unchanged; edit pencils still open the field modals
- [ ] Manual: `/profile/:profileId` and the messaging conversation profile panel render unchanged with no pencils

---
_Generated by [Claude Code](https://claude.ai/code/session_015n1wMyuQEsbYcTmtri5UzD)_