### PR TITLE
fix(ProfileContent): guard ImageCarousel against empty profileImages

### DIFF
--- a/.changeset/quiet-stars-guard.md
+++ b/.changeset/quiet-stars-guard.md
@@ -1,0 +1,5 @@
+---
+'@opencupid/frontend': patch
+---
+
+Guard ImageCarousel in ProfileContent against undefined profileImages to avoid Vue prop warning and render crash on first MyProfile paint.

--- a/apps/frontend/src/features/publicprofile/components/ProfileContent.vue
+++ b/apps/frontend/src/features/publicprofile/components/ProfileContent.vue
@@ -36,7 +36,10 @@ const profileImageStore = useProfileImageStore()
 <template>
   <div class="position-relative">
     <div class="overflow-hidden carousel-wrapper">
-      <ImageCarousel :images="profile.profileImages" />
+      <ImageCarousel
+        v-if="profile.profileImages?.length"
+        :images="profile.profileImages"
+      />
     </div>
 
     <div class="icons">


### PR DESCRIPTION
## Summary

- MyProfile renders a placeholder `PublicProfile` from `useMyProfileViewModel` (a `reactive({} as PublicProfile)` plus `as PublicProfile` cast) before the async `fetchPreview()` resolves, so `profile.profileImages` is genuinely `undefined` on first paint.
- `ImageCarousel`'s `images` prop is required, so this produced a Vue prop type warning and a `TypeError: can't access property 0, props.images is undefined` from `currentImage` on the initial render of the owner drawer.
- Guards the carousel with `v-if="profile.profileImages?.length"`, matching the existing pattern in `PostCard` / `EventCard` / `CommunityCard`. No empty-state placeholder needed: the `carousel-wrapper` was already always rendered.

Follow-up from PR #1477 review (the `?? []` fallback in `ImageCarousel` was masking this; once removed the bug surfaced). There's also a deeper latent bug in `useMyProfileViewModel` — the phantom empty `PublicProfile` would trip any required field, not just `profileImages` — flagged for a separate PR.

## Test plan

- [x] `pnpm --filter frontend exec vitest run src/features/publicprofile` — 10/10 pass
- [x] `pnpm --filter frontend exec vue-tsc --noEmit` — clean
- [ ] Manual: open MyProfile in the owner drawer before profile data resolves; no Vue warning or render error in console
- [ ] Manual: confirm carousel still renders when `profileImages` is non-empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)