### PR TITLE
fix(myprofile): make useMyProfileViewModel.publicProfile honestly nullable

### DIFF
--- a/.changeset/honest-profile-preview.md
+++ b/.changeset/honest-profile-preview.md
@@ -1,0 +1,5 @@
+---
+'@opencupid/frontend': patch
+---
+
+Fix MyProfile owner drawer crashing on first paint by making `useMyProfileViewModel`'s `publicProfile` honestly nullable instead of a phantom-empty `reactive({} as PublicProfile)`. Removes a latent class of "required field is undefined" bugs across any consumer of `profilePreview`.

--- a/.changeset/honest-profile-preview.md
+++ b/.changeset/honest-profile-preview.md
@@ -2,4 +2,4 @@
 '@opencupid/frontend': patch
 ---
 
-Fix MyProfile owner drawer crashing on first paint by making `useMyProfileViewModel`'s `publicProfile` honestly nullable instead of a phantom-empty `reactive({} as PublicProfile)`. Removes a latent class of "required field is undefined" bugs across any consumer of `profilePreview`.
+Fix MyProfile owner drawer crashing on first paint with `TypeError: can't access property 0, props.images is undefined` when opening before profile data has loaded.

--- a/apps/frontend/src/features/myprofile/composables/useMyProfileViewModel.ts
+++ b/apps/frontend/src/features/myprofile/composables/useMyProfileViewModel.ts
@@ -53,6 +53,7 @@ export function useMyProfileViewModel(isEditMode: boolean) {
     if (!res.success) {
       return res
     }
+    if (!res.data) return
     publicProfile.value = res.data
   }
 

--- a/apps/frontend/src/features/myprofile/composables/useMyProfileViewModel.ts
+++ b/apps/frontend/src/features/myprofile/composables/useMyProfileViewModel.ts
@@ -1,5 +1,5 @@
 import { useI18nStore } from '@/store/i18nStore'
-import { computed, reactive, toRef, watch } from 'vue'
+import { computed, reactive, shallowRef, toRef, watch } from 'vue'
 
 import { type PublicProfile } from '@zod/profile/profile.dto'
 import { type EditFieldProfileFormWithImages } from '@zod/profile/profile.form'
@@ -19,11 +19,11 @@ export function useMyProfileViewModel(isEditMode: boolean) {
     currentScope: 'social',
   })
 
-  // computed properties
-  const publicProfile = reactive({} as PublicProfile)
-  const profilePreview = computed((): PublicProfile => {
+  const publicProfile = shallowRef<PublicProfile | null>(null)
+  const profilePreview = computed<PublicProfile | null>(() => {
+    if (!publicProfile.value) return null
     return {
-      ...publicProfile,
+      ...publicProfile.value,
       isDatingActive: viewState.currentScope === 'dating',
     } as PublicProfile
   })
@@ -53,7 +53,7 @@ export function useMyProfileViewModel(isEditMode: boolean) {
     if (!res.success) {
       return res
     }
-    Object.assign(publicProfile, res.data)
+    publicProfile.value = res.data
   }
 
   const updateScopes = async (payload: { isDatingActive: boolean }) => {


### PR DESCRIPTION
## Summary

Opening MyProfile in the owner drawer crashes on first paint with a Vue prop warning and `TypeError: can't access property 0, props.images is undefined` thrown from `ImageCarousel`.

Root cause: `useMyProfileViewModel` declares `publicProfile` as `reactive({} as PublicProfile)` — an empty object cast to a fully-required type. The derived `profilePreview` computed wraps this and is therefore always truthy, even before the async `fetchPreview()` resolves. The `v-if="profilePreview"` gate in `MyProfile.vue` is meaningless, so `ProfileContent` (and its `ImageCarousel`) renders against an empty object whose required fields are `undefined` at runtime.

## Changes

`useMyProfileViewModel.ts`:
- `publicProfile` is now `shallowRef<PublicProfile | null>(null)`.
- `profilePreview` returns `PublicProfile | null`, propagating null until the fetch resolves.
- `fetchPreview` assigns by reference rather than `Object.assign` onto a reactive placeholder.

The existing `v-if="profilePreview"` in `MyProfile.vue:73` now gates rendering as intended. No template or call-site changes required.

## Test plan

- [x] `pnpm --filter frontend exec vue-tsc --noEmit` — clean
- [x] `pnpm --filter frontend exec vitest run` — 682/682 pass
- [ ] Manual: open MyProfile in the owner drawer; no Vue warning, no render TypeError
- [ ] Manual: preview re-fetches and re-renders when switching preview language
- [ ] Manual: carousel renders when profile has images

🤖 Generated with [Claude Code](https://claude.com/claude-code)