### PR TITLE
fix(userContent): reset store on auth:logout

### DIFF
--- a/.changeset/silver-otters-reset.md
+++ b/.changeset/silver-otters-reset.md
@@ -1,0 +1,5 @@
+---
+'@opencupid/frontend': patch
+---
+
+Clear userContent store on logout

--- a/apps/frontend/src/features/userContent/stores/__tests__/userContentStore.spec.ts
+++ b/apps/frontend/src/features/userContent/stores/__tests__/userContentStore.spec.ts
@@ -14,6 +14,7 @@ vi.mock('@/lib/api', () => ({
 }))
 
 import type { MapBounds } from '@/features/map/types/map.types'
+import { bus } from '@/lib/bus'
 import { useUserContentStore } from '../userContentStore'
 
 const CUID_1 = 'cmc7t45x400086w39gj30pzn3'
@@ -336,6 +337,23 @@ describe('useUserContentStore', () => {
         [CUID_1, 'post'],
         ['event-2', 'event'],
       ])
+    })
+  })
+
+  describe('auth:logout', () => {
+    it('resets store state when auth:logout is emitted', () => {
+      const store = useUserContentStore()
+      store.myContent = [makeOwnerPost(CUID_1)] as any
+      store.feedItems = [{ id: CUID_2 }] as any
+      store.isInitialized = true
+      store.isLoading = true
+
+      bus.emit('auth:logout')
+
+      expect(store.myContent).toEqual([])
+      expect(store.feedItems).toEqual([])
+      expect(store.isInitialized).toBe(false)
+      expect(store.isLoading).toBe(false)
     })
   })
 })

--- a/apps/frontend/src/features/userContent/stores/userContentStore.ts
+++ b/apps/frontend/src/features/userContent/stores/userContentStore.ts
@@ -370,3 +370,7 @@ export const useUserContentStore = defineStore('userContent', {
     },
   },
 })
+
+bus.on('auth:logout', () => {
+  useUserContentStore().$reset()
+})


### PR DESCRIPTION
## Summary
- `userContentStore` was missing the `auth:logout` bus subscription used by every other feature store, so `myContent`, `feedItems`, and `isInitialized` leaked across user sessions.
- Add a module-scope `bus.on('auth:logout', () => useUserContentStore().$reset())` listener, matching the pattern in `messageStore`, `searchStore`, and `userStore`.
- Add a spec that seeds state, emits `auth:logout`, and asserts the store reset.

## Test plan
- [x] `pnpm --filter frontend exec vitest run src/features/userContent/stores/__tests__/userContentStore.spec.ts` — 18/18 pass
- [ ] Manual: log in as user A, create/view content, log out, log in as user B → user A's content does not appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)