### PR TITLE
chore(settings): tighten vertical spacing in Settings panel

### DIFF
--- a/.changeset/major-balloons-camp.md
+++ b/.changeset/major-balloons-camp.md
@@ -1,0 +1,5 @@
+---
+"@opencupid/frontend": patch
+---
+
+chore(settings): tighten vertical spacing in Settings panel

--- a/apps/frontend/src/features/settings/components/OptInCheckboxes.vue
+++ b/apps/frontend/src/features/settings/components/OptInCheckboxes.vue
@@ -76,7 +76,7 @@ async function handleOptInChange(event: Event, patch: UpdateProfileOptInPayload)
     </div>
   </fieldset>
 
-  <fieldset class="mb-2 mb-md-4">
+  <fieldset class="mb-2">
     <div class="form-check">
       <input
         id="newsletter-opt-in"

--- a/apps/frontend/src/features/settings/components/Settings.vue
+++ b/apps/frontend/src/features/settings/components/Settings.vue
@@ -52,17 +52,17 @@ function handleLogout() {
 </script>
 
 <template>
-  <div class="px-3 p-md-5 h-100 w-100 d-flex flex-column justify-content-center">
-    <fieldset class="d-flex align-items-center mb-3 mb-lg-5">
+  <div class="px-3 p-md-4 h-100 w-100 d-flex flex-column justify-content-center">
+    <fieldset class="d-flex align-items-center mb-3">
       <IconGlobe class="svg-icon svg-icon-lg me-2" />
       <LanguageSelectorDropdown size="md" />
     </fieldset>
 
-    <div class="mb-md-3">
+    <div class="mb-md-2">
       <h6>{{ $t('settings.notifications_label') }}</h6>
       <OptInCheckboxes v-model="optInModel" />
     </div>
-    <fieldset class="mb-md-3">
+    <fieldset class="mb-md-2">
       <PwaInstallButton />
     </fieldset>
     <fieldset class="d-flex flex-wrap align-items-center gap-2">


### PR DESCRIPTION
## Summary
- Reduce vertical margins across the Settings view (language selector, notifications block, PWA install row)
- Drop the extra bottom margin on the newsletter opt-in fieldset so it sits closer to the surrounding controls

## Test plan
- [ ] Open `/settings` on desktop and confirm the panel is more compact without overlapping
- [ ] Verify mobile layout still has adequate breathing room

🤖 Generated with [Claude Code](https://claude.com/claude-code)