### PR TITLE
fix(seed): use adapter-wired Prisma singleton in seed scripts

### DIFF
--- a/.changeset/copper-seeds-revive.md
+++ b/.changeset/copper-seeds-revive.md
@@ -1,0 +1,5 @@
+---
+'@opencupid/backend': patch
+---
+
+Fix database seed crash on Prisma 7 by importing the adapter-wired PrismaClient singleton instead of constructing a bare client.

--- a/apps/backend/prisma/seed/index.js
+++ b/apps/backend/prisma/seed/index.js
@@ -1,8 +1,6 @@
-const { PrismaClient } = require('@prisma/client')
+const { prisma } = require('../../dist/lib/prisma')
 const seedTags = require('./tags')
 const seedMessageTemplates = require('./message-templates')
-
-const prisma = new PrismaClient()
 
 async function main() {
   await seedTags()

--- a/apps/backend/prisma/seed/message-templates.js
+++ b/apps/backend/prisma/seed/message-templates.js
@@ -1,6 +1,4 @@
-const { PrismaClient } = require('@prisma/client')
-
-const prisma = new PrismaClient()
+const { prisma } = require('../../dist/lib/prisma')
 
 // Default content for the welcome message, copied from the previous i18n strings
 // (packages/shared/i18n/{en,hu}.json -> messages.welcome_message). Kept here as the

--- a/apps/backend/prisma/seed/tags.js
+++ b/apps/backend/prisma/seed/tags.js
@@ -1,8 +1,6 @@
-const { PrismaClient } = require('@prisma/client')
+const { prisma } = require('../../dist/lib/prisma')
 const fs = require('fs')
 const path = require('path')
-
-const prisma = new PrismaClient()
 
 async function main() {
   const tags = JSON.parse(fs.readFileSync(path.join(__dirname, 'tags-data.json'), 'utf-8'))

--- a/apps/backend/tsup.config.ts
+++ b/apps/backend/tsup.config.ts
@@ -6,7 +6,7 @@ const appVersion = getPackageVersion(path.join(__dirname, 'package.json'))
 const frontendVersion = getPackageVersion(path.join(__dirname, '../frontend/package.json'))
 
 export default defineConfig({
-  entry: ['src/api.ts', 'src/worker.ts'],
+  entry: ['src/api.ts', 'src/worker.ts', 'src/lib/prisma.ts'],
   outDir: 'dist',
   format: ['cjs'],
   splitting: false,


### PR DESCRIPTION
## Summary

Prisma 7 removed the bare `new PrismaClient()` constructor — it now requires a driver adapter or explicit `PrismaClientOptions`. The three seed scripts in `apps/backend/prisma/seed/` still constructed it bare, which worked on Prisma ≤6 (auto-reading `DATABASE_URL` from env) but throws `PrismaClientInitializationError: 'PrismaClientOptions' needs to be... non-empty, valid` on 7.

This bug only surfaces on **fresh-DB deploys** (e.g. staging), because:

- `prisma migrate deploy` uses the Prisma CLI engine (configured via `prisma.config.ts` → `datasource.url`), so all 18 migrations apply cleanly — including `20260515120000_image_attachments_generalize`.
- The crash happens in the post-migration **seed** step, before any rows are inserted, leaving the DB schema-correct but unseeded.

### Fix

- Add `src/lib/prisma.ts` as a third tsup entry so the adapter-wired singleton ships as `dist/lib/prisma.js` (5.27 KB).
- Replace `new PrismaClient()` in all three seed files (`index.js`, `tags.js`, `message-templates.js`) with `require('../../dist/lib/prisma').prisma`.
- Single source of truth: seeds now use the same `PrismaPg` adapter + `DATABASE_URL` wiring as the rest of the backend.

The Docker image already builds the backend before the seed runs, so the new require path is satisfied at deploy time.

## Test plan

- [ ] `pnpm --filter backend exec tsup` emits `dist/lib/prisma.js` ✅ (verified locally — 5.27 KB)
- [ ] `pnpm type-check` passes ✅ (verified locally — 3/3 packages clean)
- [ ] On a fresh DB: `pnpm --filter backend build && prisma migrate deploy && prisma db seed` completes without error
- [ ] CI green on this PR
- [ ] Staging redeploy of v0.64.0 succeeds end-to-end (migrations + seed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)