### PR TITLE
fix(userContent): show ViewerToolbar on owner's own cards

### DIFF
--- a/.changeset/viewer-toolbar-owners-visible.md
+++ b/.changeset/viewer-toolbar-owners-visible.md
@@ -1,0 +1,5 @@
+---
+'@opencupid/frontend': patch
+---
+
+Show ViewerToolbar (copy/share/contact) on user-owned community, event, and post cards.

--- a/apps/frontend/src/features/community/components/CommunityCard.vue
+++ b/apps/frontend/src/features/community/components/CommunityCard.vue
@@ -91,7 +91,7 @@ const displayContent = computed(() => {
           <span>{{ community.postedBy.publicName }}</span>
         </div>
         <ViewerToolbar
-          v-if="showDetails && !community.isOwn"
+          v-if="showDetails"
           :actions="['copy', 'share']"
           :copy-text="community.content"
           :share-payload="shareCommunityPayload"

--- a/apps/frontend/src/features/events/components/EventCard.vue
+++ b/apps/frontend/src/features/events/components/EventCard.vue
@@ -115,7 +115,7 @@ const displayContent = computed(() => {
           <span>{{ event.postedBy.publicName }}</span>
         </div>
         <ViewerToolbar
-          v-if="showDetails && !event.isOwn"
+          v-if="showDetails"
           :actions="['copy', 'share']"
           :copy-text="event.content"
           :share-payload="shareEventPayload"

--- a/apps/frontend/src/features/posts/components/PostCard.vue
+++ b/apps/frontend/src/features/posts/components/PostCard.vue
@@ -138,7 +138,7 @@ const sharePostPayload = computed<SharePayload>(() => ({
               />
             </span>
             <ViewerToolbar
-              v-if="showDetails && !post.isOwn"
+              v-if="showDetails"
               :actions="['contact', 'copy', 'share']"
               :copy-text="post.content"
               :share-payload="sharePostPayload"


### PR DESCRIPTION
## Summary
- Remove the `!isOwn` guard on `ViewerToolbar` in `CommunityCard.vue`, `EventCard.vue`, and `PostCard.vue` so owners see copy/share (and contact, for posts) on their own cards.
- Ownership UI and viewer-utility UI are now decoupled — consistent with the recent `OwnerToolbar` lift in #1480.

## Test plan
- [ ] Open your own community/event/post card → ViewerToolbar visible with copy/share actions
- [ ] Open someone else's community/event/post card → ViewerToolbar still visible (unchanged)
- [ ] Post card as owner → contact action also present alongside copy/share

🤖 Generated with [Claude Code](https://claude.com/claude-code)