### PR TITLE
chore(frontend): tidy button and avatar utility classes

### DIFF
--- a/.changeset/tidy-button-classes.md
+++ b/.changeset/tidy-button-classes.md
@@ -1,0 +1,5 @@
+---
+'@opencupid/frontend': patch
+---
+
+Tidy button and avatar utility classes (#1490)

--- a/apps/frontend/src/features/browse/components/OwnerDrawerControls.vue
+++ b/apps/frontend/src/features/browse/components/OwnerDrawerControls.vue
@@ -36,8 +36,8 @@ function openCreateCommunity() {
 <template>
   <div class="owner-drawer-controls d-flex flex-column flex-md-row gap-2">
     <BButton
-      variant="light"
-      class="btn-rounded shadow overflow-hidden order-1 order-md-1 border"
+      variant="outline-secondary"
+      class="btn-rounded shadow overflow-hidden order-1 order-md-1 "
       :aria-label="$t('nav.inbox')"
       @click="$emit('open:inbox')"
     >

--- a/apps/frontend/src/features/browse/views/BrowseProfiles.vue
+++ b/apps/frontend/src/features/browse/views/BrowseProfiles.vue
@@ -283,7 +283,7 @@ onMounted(async () => {
 <template>
   <div class="map-region h-100 position-relative overflow-hidden">
     <div
-      class="search-bar-wrapper position-absolute w-100 top-0 end-0 d-flex align-items-start justify-content-end gap-2 p-2 pb-5"
+      class="search-bar-wrapper position-absolute w-100 top-0 end-0 d-flex align-items-start justify-content-end gap-2 p-2"
       style="z-index: 1010"
     >
       <div class="flex-grow-1 d-flex">

--- a/apps/frontend/src/features/images/components/ImageEditor.vue
+++ b/apps/frontend/src/features/images/components/ImageEditor.vue
@@ -119,7 +119,7 @@ const isDeletable = computed(() => {
           >
             <div class="actions nodrag">
               <button
-                class="btn btn-sm btn-secondary rounded-circle"
+                class="btn btn-sm btn-secondary "
                 @mousedown.stop.prevent
                 @click="handleDelete(img)"
                 :disabled="isRemoving[img.id]"

--- a/apps/frontend/src/features/map/components/MapLayerControl.vue
+++ b/apps/frontend/src/features/map/components/MapLayerControl.vue
@@ -54,7 +54,7 @@ const { start: startHideTimer, stop: stopHideTimer } = useTimeoutFn(
     >
       <template #target>
         <BButton
-          class="btn-rounded rounded-circle shadow btn btn-light"
+          class="btn-rounded shadow btn btn-light"
           variant="outline-secondary"
           :aria-label="t('map.layer_control.aria_label')"
         >

--- a/apps/frontend/src/features/myprofile/components/ProfilePanel.vue
+++ b/apps/frontend/src/features/myprofile/components/ProfilePanel.vue
@@ -59,7 +59,7 @@ function handleClose() {
       <span class="d-flex align-items-center gap-2 flex-grow-1 overflow-hidden">
         <span
           v-if="ownerProfileStore.profile?.profileImages?.length"
-          class="owner-profile-avatar flex-shrink-0 overflow-hidden rounded-circle"
+          class="owner-profile-avatar flex-shrink-0 overflow-hidden "
         >
           <ProfileImage
             :profile="ownerProfileStore.profile"

--- a/apps/frontend/src/features/userContent/components/UserContentCreateSpeedDial.vue
+++ b/apps/frontend/src/features/userContent/components/UserContentCreateSpeedDial.vue
@@ -18,7 +18,7 @@ withDefaults(
   }>(),
   {
     triggerClass: 'btn-icon-lg btn-shadow',
-    actionClass: 'btn-icon-lg btn-shadow btn-light rounded-circle',
+    actionClass: 'btn-icon-lg btn-shadow btn-light ',
   }
 )
 


### PR DESCRIPTION
## Summary
- Drop redundant `rounded-circle` classes on owner avatar, image editor delete button, map layer control, and speed-dial actions
- Switch OwnerDrawerControls inbox button to `outline-secondary` variant (removes manual `border` + `light` combo)
- Remove extra `pb-5` from BrowseProfiles search-bar wrapper

## Test plan
- [ ] Visually verify owner drawer, browse search bar, image editor, map layer control, and content speed dial render correctly
- [ ] `pnpm --filter frontend test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)