### PR TITLE
feat(search): include events and communities in /search results

### DIFF
--- a/.changeset/violet-search-expands.md
+++ b/.changeset/violet-search-expands.md
@@ -1,0 +1,7 @@
+---
+'@opencupid/backend': minor
+'@opencupid/frontend': minor
+'@opencupid/shared': minor
+---
+
+Search now includes events and communities alongside posts, surfaced as separate sections in the omnibox.

--- a/apps/backend/src/__tests__/routes/search.route.spec.ts
+++ b/apps/backend/src/__tests__/routes/search.route.spec.ts
@@ -14,6 +14,7 @@ vi.mock('../../api/mappers/profile.mappers', () => ({
 vi.mock('../../api/mappers/post.mappers', () => ({
   mapPostSummary: vi.fn((p: any) => ({
     id: p.id,
+    kind: 'post',
     type: p.type,
     content: p.content,
     location: p.location ?? { country: '' },
@@ -21,6 +22,30 @@ vi.mock('../../api/mappers/post.mappers', () => ({
       id: p.postedBy.id,
       publicName: p.postedBy.publicName,
       profileImages: (p.postedBy.profileImages ?? []).map((g: any) => g.image),
+    },
+  })),
+  mapEventSummary: vi.fn((e: any) => ({
+    id: e.id,
+    kind: 'event',
+    content: e.content,
+    startsAt: e.event.startsAt,
+    location: e.location ?? { country: '' },
+    postedBy: {
+      id: e.postedBy.id,
+      publicName: e.postedBy.publicName,
+      profileImages: (e.postedBy.profileImages ?? []).map((g: any) => g.image),
+    },
+  })),
+  mapCommunitySummary: vi.fn((c: any) => ({
+    id: c.id,
+    kind: 'community',
+    content: c.content,
+    yearFounded: c.community.yearFounded,
+    location: c.location ?? { country: '' },
+    postedBy: {
+      id: c.postedBy.id,
+      publicName: c.postedBy.publicName,
+      profileImages: (c.postedBy.profileImages ?? []).map((g: any) => g.image),
     },
   })),
 }))
@@ -57,7 +82,7 @@ describe('GET /search', () => {
   const handler = () => fastify.routes['GET /']
 
   it('forwards session language and profileId to the service', async () => {
-    mockSearch.mockResolvedValue({ tags: [], profiles: [], posts: [] })
+    mockSearch.mockResolvedValue({ tags: [], profiles: [], posts: [], events: [], communities: [] })
 
     await handler()(
       { session: { ...baseSession, lang: 'hu' }, query: { q: 'guitar' }, log: { error: vi.fn() } },
@@ -68,6 +93,7 @@ describe('GET /search', () => {
   })
 
   it('returns grouped results mapped to public/summary shapes', async () => {
+    const startsAt = new Date('2026-06-01T18:00:00Z')
     mockSearch.mockResolvedValue({
       tags: [
         {
@@ -97,6 +123,30 @@ describe('GET /search', () => {
           },
         },
       ],
+      events: [
+        {
+          id: 'evt-1',
+          content: 'Guitar concert',
+          event: { startsAt },
+          postedBy: {
+            id: 'p1',
+            publicName: 'Alice',
+            profileImages: [{ image: { storagePath: 'a/b' } }],
+          },
+        },
+      ],
+      communities: [
+        {
+          id: 'com-1',
+          content: 'Guitar players',
+          community: { yearFounded: 2010 },
+          postedBy: {
+            id: 'p1',
+            publicName: 'Alice',
+            profileImages: [{ image: { storagePath: 'a/b' } }],
+          },
+        },
+      ],
     })
 
     await handler()(
@@ -110,14 +160,29 @@ describe('GET /search', () => {
     expect(reply.payload.profiles[0]).toMatchObject({ id: 'p1', publicName: 'Alice' })
     expect(reply.payload.posts[0]).toMatchObject({
       id: 'post-1',
+      kind: 'post',
       type: 'OFFER',
       content: 'Guitar lessons',
+      postedBy: { id: 'p1', publicName: 'Alice' },
+    })
+    expect(reply.payload.events[0]).toMatchObject({
+      id: 'evt-1',
+      kind: 'event',
+      content: 'Guitar concert',
+      startsAt,
+      postedBy: { id: 'p1', publicName: 'Alice' },
+    })
+    expect(reply.payload.communities[0]).toMatchObject({
+      id: 'com-1',
+      kind: 'community',
+      content: 'Guitar players',
+      yearFounded: 2010,
       postedBy: { id: 'p1', publicName: 'Alice' },
     })
   })
 
   it('defaults missing q to empty string (and the service short-circuits)', async () => {
-    mockSearch.mockResolvedValue({ tags: [], profiles: [], posts: [] })
+    mockSearch.mockResolvedValue({ tags: [], profiles: [], posts: [], events: [], communities: [] })
 
     await handler()({ session: baseSession, query: {}, log: { error: vi.fn() } }, reply)
 
@@ -127,6 +192,8 @@ describe('GET /search', () => {
       tags: [],
       profiles: [],
       posts: [],
+      events: [],
+      communities: [],
     })
   })
 

--- a/apps/backend/src/__tests__/services/search.service.spec.ts
+++ b/apps/backend/src/__tests__/services/search.service.spec.ts
@@ -7,15 +7,37 @@ let mockTagSearch: ReturnType<typeof vi.fn>
 
 /**
  * Install a routing mock for `$queryRaw` that dispatches by inspecting the
- * template SQL. Profiles query hits `LocalizedProfileField`; posts query
- * hits `FROM "Post"`. Returns separate capture arrays + setters so tests
- * can control each branch independently.
+ * template SQL. Profiles query hits `LocalizedProfileField`; UserContent
+ * queries hit `FROM "UserContent"` and embed the kind as a raw SQL fragment
+ * (e.g. `'post'::"ContentKind"`) which we parse out to dispatch per kind.
+ * Returns separate capture arrays + setters so tests can control each
+ * branch independently.
  */
 function installQueryRawRouter() {
   const profileCalls: unknown[][] = []
   const postCalls: unknown[][] = []
+  const eventCalls: unknown[][] = []
+  const communityCalls: unknown[][] = []
   let profileResult: any[] = []
   let postResult: any[] = []
+  let eventResult: any[] = []
+  let communityResult: any[] = []
+
+  /**
+   * The ContentKind enum literal is injected via `Prisma.sql([...])` and
+   * arrives in the `values` array (not the `strings` array). We sniff each
+   * value's `.strings[0]` — `Prisma.sql` stores fragments there — to route
+   * by kind.
+   */
+  const findKind = (values: unknown[]): 'post' | 'event' | 'community' | null => {
+    for (const v of values) {
+      const frag = (v as { strings?: string[] })?.strings?.[0] ?? ''
+      if (frag.includes(`'event'`)) return 'event'
+      if (frag.includes(`'community'`)) return 'community'
+      if (frag.includes(`'post'`)) return 'post'
+    }
+    return null
+  }
 
   mockPrisma.$queryRaw.mockImplementation((strings: TemplateStringsArray, ...values: unknown[]) => {
     const sql = Array.isArray(strings) ? strings.join('?') : String(strings)
@@ -24,6 +46,15 @@ function installQueryRawRouter() {
       return Promise.resolve(profileResult)
     }
     if (sql.includes('FROM "UserContent"')) {
+      const kind = findKind(values)
+      if (kind === 'event') {
+        eventCalls.push([strings, ...values])
+        return Promise.resolve(eventResult)
+      }
+      if (kind === 'community') {
+        communityCalls.push([strings, ...values])
+        return Promise.resolve(communityResult)
+      }
       postCalls.push([strings, ...values])
       return Promise.resolve(postResult)
     }
@@ -33,11 +64,19 @@ function installQueryRawRouter() {
   return {
     profileCalls,
     postCalls,
+    eventCalls,
+    communityCalls,
     setProfileResult: (r: any[]) => {
       profileResult = r
     },
     setPostResult: (r: any[]) => {
       postResult = r
+    },
+    setEventResult: (r: any[]) => {
+      eventResult = r
+    },
+    setCommunityResult: (r: any[]) => {
+      communityResult = r
     },
   }
 }
@@ -66,7 +105,7 @@ beforeEach(async () => {
 describe('SearchService.search — short-circuit', () => {
   it('returns empty arrays for queries shorter than the minimum length', async () => {
     const result = await service.search('a', 'en', 'me')
-    expect(result).toEqual({ tags: [], profiles: [], posts: [] })
+    expect(result).toEqual({ tags: [], profiles: [], posts: [], events: [], communities: [] })
     expect(mockTagSearch).not.toHaveBeenCalled()
     expect(mockPrisma.$queryRaw).not.toHaveBeenCalled()
   })
@@ -163,30 +202,38 @@ describe('SearchService.search — posts (trigram)', () => {
       { id: 'post-b', rank: 0.9 },
       { id: 'post-a', rank: 0.5 },
     ])
-    mockPrisma.userContent.findMany.mockResolvedValue([
-      {
-        id: 'post-a',
-        kind: 'post',
-        content: 'hello',
-        country: null,
-        cityName: null,
-        lat: null,
-        lon: null,
-        post: { type: 'OFFER' },
-        postedBy: { id: 'p1', publicName: 'Alice', profileImages: [] },
-      },
-      {
-        id: 'post-b',
-        kind: 'post',
-        content: 'world',
-        country: null,
-        cityName: null,
-        lat: null,
-        lon: null,
-        post: { type: 'REQUEST' },
-        postedBy: { id: 'p2', publicName: 'Bob', profileImages: [] },
-      },
-    ])
+    // The post hydration `findMany` is dispatched with `where.kind = 'post'`;
+    // mock it to return only post rows, and let event/community hydration
+    // default to []. We key on `where.kind` to route per-kind hydration.
+    mockPrisma.userContent.findMany.mockImplementation(({ where }: any) => {
+      if (where?.kind === 'post') {
+        return Promise.resolve([
+          {
+            id: 'post-a',
+            kind: 'post',
+            content: 'hello',
+            country: null,
+            cityName: null,
+            lat: null,
+            lon: null,
+            post: { type: 'OFFER' },
+            postedBy: { id: 'p1', publicName: 'Alice', profileImages: [] },
+          },
+          {
+            id: 'post-b',
+            kind: 'post',
+            content: 'world',
+            country: null,
+            cityName: null,
+            lat: null,
+            lon: null,
+            post: { type: 'REQUEST' },
+            postedBy: { id: 'p2', publicName: 'Bob', profileImages: [] },
+          },
+        ])
+      }
+      return Promise.resolve([])
+    })
 
     const result = await service.search('hello', 'en', 'me')
 
@@ -200,9 +247,123 @@ describe('SearchService.search — posts (trigram)', () => {
     const result = await service.search('xyzzy', 'en', 'me')
 
     expect(result.posts).toEqual([])
+    // No `id: {in: …}` hydration should have been issued for any kind.
     const hydrationCalls = mockPrisma.userContent.findMany.mock.calls.filter(
       ([arg]: [any]) => arg?.where?.id?.in !== undefined
     )
     expect(hydrationCalls).toHaveLength(0)
+  })
+})
+
+describe('SearchService.search — events (trigram)', () => {
+  it('runs the event query and hydrates events in rank order with startsAt', async () => {
+    const router = installQueryRawRouter()
+    router.setEventResult([
+      { id: 'evt-b', rank: 0.9 },
+      { id: 'evt-a', rank: 0.5 },
+    ])
+    const startsAtA = new Date('2026-06-01T18:00:00Z')
+    const startsAtB = new Date('2026-07-15T20:00:00Z')
+    mockPrisma.userContent.findMany.mockImplementation(({ where }: any) => {
+      if (where?.kind === 'event') {
+        return Promise.resolve([
+          {
+            id: 'evt-a',
+            kind: 'event',
+            content: 'concert',
+            country: null,
+            cityName: null,
+            lat: null,
+            lon: null,
+            event: { startsAt: startsAtA },
+            postedBy: { id: 'p1', publicName: 'Alice', profileImages: [] },
+          },
+          {
+            id: 'evt-b',
+            kind: 'event',
+            content: 'meetup',
+            country: null,
+            cityName: null,
+            lat: null,
+            lon: null,
+            event: { startsAt: startsAtB },
+            postedBy: { id: 'p2', publicName: 'Bob', profileImages: [] },
+          },
+        ])
+      }
+      return Promise.resolve([])
+    })
+
+    const result = await service.search('concert', 'en', 'me')
+
+    expect(router.eventCalls).toHaveLength(1)
+    expect(result.events.map((e: any) => e.id)).toEqual(['evt-b', 'evt-a'])
+    expect(result.events[0].event.startsAt).toBe(startsAtB)
+  })
+
+  it('returns empty events array when no events match', async () => {
+    installQueryRawRouter()
+
+    const result = await service.search('xyzzy', 'en', 'me')
+
+    expect(result.events).toEqual([])
+  })
+})
+
+describe('SearchService.search — communities (trigram)', () => {
+  it('runs the community query and hydrates with yearFounded', async () => {
+    const router = installQueryRawRouter()
+    router.setCommunityResult([{ id: 'com-a', rank: 0.9 }])
+    mockPrisma.userContent.findMany.mockImplementation(({ where }: any) => {
+      if (where?.kind === 'community') {
+        return Promise.resolve([
+          {
+            id: 'com-a',
+            kind: 'community',
+            content: 'book club',
+            country: null,
+            cityName: null,
+            lat: null,
+            lon: null,
+            community: { yearFounded: 1998 },
+            postedBy: { id: 'p1', publicName: 'Alice', profileImages: [] },
+          },
+        ])
+      }
+      return Promise.resolve([])
+    })
+
+    const result = await service.search('book', 'en', 'me')
+
+    expect(router.communityCalls).toHaveLength(1)
+    expect(result.communities.map((c: any) => c.id)).toEqual(['com-a'])
+    expect(result.communities[0].community.yearFounded).toBe(1998)
+  })
+
+  it('preserves a null yearFounded through to the result', async () => {
+    const router = installQueryRawRouter()
+    router.setCommunityResult([{ id: 'com-b', rank: 0.7 }])
+    mockPrisma.userContent.findMany.mockImplementation(({ where }: any) => {
+      if (where?.kind === 'community') {
+        return Promise.resolve([
+          {
+            id: 'com-b',
+            kind: 'community',
+            content: 'no-year community',
+            country: null,
+            cityName: null,
+            lat: null,
+            lon: null,
+            community: { yearFounded: null },
+            postedBy: { id: 'p1', publicName: 'Alice', profileImages: [] },
+          },
+        ])
+      }
+      return Promise.resolve([])
+    })
+
+    const result = await service.search('community', 'en', 'me')
+
+    expect(result.communities[0].community.yearFounded).toBeNull()
   })
 })

--- a/apps/backend/src/api/mappers/post.mappers.ts
+++ b/apps/backend/src/api/mappers/post.mappers.ts
@@ -5,6 +5,8 @@ import {
   type OwnerPost,
   type PostSummary,
 } from '@zod/post/post.dto'
+import type { EventSummary } from '@zod/event/event.dto'
+import type { CommunitySummary } from '@zod/community/community.dto'
 import type { PostWithMetadata, PostWithMetadataAndContext } from '@/services/post.service'
 import type { DbProfileSummary } from '@zod/profile/profile.db'
 import type { PostType } from '@prisma/client'
@@ -84,6 +86,56 @@ export function mapPostSummary(row: DbPostForSummary): PostSummary {
     kind: 'post',
     type: row.post.type,
     content: row.content,
+    location: DbLocationToLocationDTO(row),
+    postedBy: mapProfileSummary(row.postedBy),
+  }
+}
+
+/** Input shape for `mapEventSummary` — what the search query hydrates. */
+export type DbEventForSummary = {
+  id: string
+  kind: 'event'
+  content: string
+  country: string | null
+  cityName: string | null
+  lat: number | null
+  lon: number | null
+  postedBy: DbProfileSummary
+  event: { startsAt: Date }
+}
+
+/** Lightweight event mapper used by /search omnibox results. */
+export function mapEventSummary(row: DbEventForSummary): EventSummary {
+  return {
+    id: row.id,
+    kind: 'event',
+    content: row.content,
+    startsAt: row.event.startsAt,
+    location: DbLocationToLocationDTO(row),
+    postedBy: mapProfileSummary(row.postedBy),
+  }
+}
+
+/** Input shape for `mapCommunitySummary` — what the search query hydrates. */
+export type DbCommunityForSummary = {
+  id: string
+  kind: 'community'
+  content: string
+  country: string | null
+  cityName: string | null
+  lat: number | null
+  lon: number | null
+  postedBy: DbProfileSummary
+  community: { yearFounded: number | null }
+}
+
+/** Lightweight community mapper used by /search omnibox results. */
+export function mapCommunitySummary(row: DbCommunityForSummary): CommunitySummary {
+  return {
+    id: row.id,
+    kind: 'community',
+    content: row.content,
+    yearFounded: row.community.yearFounded,
     location: DbLocationToLocationDTO(row),
     postedBy: mapProfileSummary(row.postedBy),
   }

--- a/apps/backend/src/api/routes/search.route.ts
+++ b/apps/backend/src/api/routes/search.route.ts
@@ -3,7 +3,7 @@ import { FastifyPluginAsync } from 'fastify'
 import { sendError, sendForbiddenError } from '../helpers'
 import { SearchService } from '@/services/search.service'
 import { mapProfileSummary } from '../mappers/profile.mappers'
-import { mapPostSummary } from '../mappers/post.mappers'
+import { mapCommunitySummary, mapEventSummary, mapPostSummary } from '../mappers/post.mappers'
 import { DbTagToPublicTagTransform } from '../mappers/tag.mappers'
 import { SearchQuerySchema, type SearchResponse } from '@zod/search/search.dto'
 
@@ -12,9 +12,9 @@ const searchRoutes: FastifyPluginAsync = async (fastify) => {
 
   /**
    * GET /search?q=<query>
-   * Returns results grouped by content kind: tags, profiles, posts.
-   * All three queries run in parallel. Below the minimum query length the
-   * endpoint short-circuits with empty arrays.
+   * Returns results grouped by content kind: tags, profiles, posts, events,
+   * communities. All queries run in parallel. Below the minimum query length
+   * the endpoint short-circuits with empty arrays.
    */
   fastify.get('/', { onRequest: [fastify.authenticate] }, async (req, reply) => {
     if (!req.session.profile.isSocialActive) {
@@ -29,13 +29,19 @@ const searchRoutes: FastifyPluginAsync = async (fastify) => {
     const { lang, profileId } = req.session
 
     try {
-      const { tags, profiles, posts } = await searchService.search(q, lang, profileId)
+      const { tags, profiles, posts, events, communities } = await searchService.search(
+        q,
+        lang,
+        profileId
+      )
 
       const response: SearchResponse = {
         success: true,
         tags: tags.map((t) => DbTagToPublicTagTransform(t, lang)),
         profiles: profiles.map(mapProfileSummary),
         posts: posts.map(mapPostSummary),
+        events: events.map(mapEventSummary),
+        communities: communities.map(mapCommunitySummary),
       }
       return reply.code(200).send(response)
     } catch (err) {

--- a/apps/backend/src/services/search.service.ts
+++ b/apps/backend/src/services/search.service.ts
@@ -4,8 +4,14 @@ import { profileImageInclude } from '../db/includes/profileIncludes'
 import { TagService } from './tag.service'
 import type { TagWithTranslations } from '@zod/tag/tag.db'
 import type { DbProfileSummary } from '@zod/profile/profile.db'
-import type { DbPostForSummary } from '../api/mappers/post.mappers'
+import type {
+  DbPostForSummary,
+  DbEventForSummary,
+  DbCommunityForSummary,
+} from '../api/mappers/post.mappers'
 import {
+  SEARCH_COMMUNITY_LIMIT,
+  SEARCH_EVENT_LIMIT,
   SEARCH_MIN_QUERY_LENGTH,
   SEARCH_POST_LIMIT,
   SEARCH_PROFILE_LIMIT,
@@ -16,11 +22,13 @@ export interface SearchResults {
   tags: TagWithTranslations[]
   profiles: DbProfileSummary[]
   posts: DbPostForSummary[]
+  events: DbEventForSummary[]
+  communities: DbCommunityForSummary[]
 }
 
 /** Factory so callers never share array references with each other. */
 function emptyResults(): SearchResults {
-  return { tags: [], profiles: [], posts: [] }
+  return { tags: [], profiles: [], posts: [], events: [], communities: [] }
 }
 
 /**
@@ -33,14 +41,14 @@ function escapeLikePattern(term: string): string {
 }
 
 /**
- * Multi-kind search: fans out to tag, profile trigram, post trigram, and
- * location queries in parallel, then returns grouped results for an
- * omnibox UI.
+ * Multi-kind search: fans out to tag, profile trigram, and UserContent
+ * trigram queries (one per kind) in parallel, then returns grouped results
+ * for an omnibox UI.
  *
- * Profile intro text and post content are indexed with pg_trgm GIN indexes
- * (see migrations/20260415000000_add_search_trgm_indexes). This gives fast,
- * language-agnostic substring matching — no per-locale dictionary
- * configuration is needed.
+ * Profile intro text and UserContent.content are indexed with pg_trgm GIN
+ * indexes (see migrations/20260415000000_add_search_trgm_indexes). This
+ * gives fast, language-agnostic substring matching — no per-locale
+ * dictionary configuration is needed.
  */
 export class SearchService {
   private static instance: SearchService
@@ -64,13 +72,15 @@ export class SearchService {
       return emptyResults()
     }
 
-    const [tags, profiles, posts] = await Promise.all([
+    const [tags, profiles, posts, events, communities] = await Promise.all([
       this.searchTags(term, locale),
       this.searchProfiles(term, locale, myProfileId),
       this.searchPosts(term, myProfileId),
+      this.searchEvents(term, myProfileId),
+      this.searchCommunities(term, myProfileId),
     ])
 
-    return { tags, profiles, posts }
+    return { tags, profiles, posts, events, communities }
   }
 
   // ── Tags ────────────────────────────────────────────────────────────
@@ -123,16 +133,34 @@ export class SearchService {
     return rows.map((r) => byId.get(r.id)).filter((p): p is (typeof profiles)[number] => Boolean(p))
   }
 
-  // ── Posts (trigram substring on UserContent.content where kind=post) ──
-  private async searchPosts(term: string, myProfileId: string): Promise<DbPostForSummary[]> {
+  // ── UserContent search shared between post / event / community ──────
+  /**
+   * Trigram substring rank over `UserContent.content` for one ContentKind.
+   * Filters apply uniformly across kinds: visible, non-deleted content
+   * authored by an active, onboarded, social-active profile not in a
+   * blocking relationship with the searcher.
+   *
+   * `Prisma.sql` interpolation is used for the kind literal because Prisma's
+   * tagged template parameter substitution doesn't compose inside enum casts
+   * — `${kind}::"ContentKind"` would be sent as a parameter, breaking the
+   * cast. The kind value comes from a closed enum, not user input, so this
+   * interpolation is safe.
+   */
+  private async searchUserContent(
+    kind: 'post' | 'event' | 'community',
+    limit: number,
+    term: string,
+    myProfileId: string
+  ): Promise<Array<{ id: string; rank: number }>> {
     const pattern = `%${escapeLikePattern(term)}%`
+    const kindLiteral = Prisma.sql([`'${kind}'::"ContentKind"`])
 
-    const rows = await prisma.$queryRaw<Array<{ id: string; rank: number }>>`
+    return prisma.$queryRaw<Array<{ id: string; rank: number }>>`
       SELECT p.id,
              similarity(p."content", ${term}) AS rank
       FROM "UserContent" p
       JOIN "Profile" pr ON pr.id = p."postedById"
-      WHERE p."kind" = 'post'::"ContentKind"
+      WHERE p."kind" = ${kindLiteral}
         AND p."isVisible" = true
         AND p."isDeleted" = false
         AND p."content" ILIKE ${pattern}
@@ -145,15 +173,16 @@ export class SearchService {
              OR (bp."B" = pr.id AND bp."A" = ${myProfileId})
         )
       ORDER BY rank DESC
-      LIMIT ${SEARCH_POST_LIMIT}
+      LIMIT ${limit}
     `
+  }
 
+  // ── Posts ───────────────────────────────────────────────────────────
+  private async searchPosts(term: string, myProfileId: string): Promise<DbPostForSummary[]> {
+    const rows = await this.searchUserContent('post', SEARCH_POST_LIMIT, term, myProfileId)
     if (rows.length === 0) return []
 
     const ids = rows.map((r) => r.id)
-    // `profileImages` is loaded with the joined Image so downstream mappers
-    // (toPublicImage) receive the full row — they need mimeType, altText,
-    // position and blurhash, not just storagePath.
     const posts = await prisma.userContent.findMany({
       where: { id: { in: ids }, kind: 'post' },
       select: {
@@ -195,6 +224,113 @@ export class SearchService {
         lon: p.lon,
         postedBy: p.postedBy,
         post: { type: p.post.type },
+      }))
+  }
+
+  // ── Events ──────────────────────────────────────────────────────────
+  private async searchEvents(term: string, myProfileId: string): Promise<DbEventForSummary[]> {
+    const rows = await this.searchUserContent('event', SEARCH_EVENT_LIMIT, term, myProfileId)
+    if (rows.length === 0) return []
+
+    const ids = rows.map((r) => r.id)
+    const events = await prisma.userContent.findMany({
+      where: { id: { in: ids }, kind: 'event' },
+      select: {
+        id: true,
+        kind: true,
+        content: true,
+        country: true,
+        cityName: true,
+        lat: true,
+        lon: true,
+        event: { select: { startsAt: true } },
+        postedBy: {
+          select: {
+            id: true,
+            publicName: true,
+            profileImages: {
+              include: { image: true },
+              orderBy: { image: { position: 'asc' } },
+            },
+          },
+        },
+      },
+    })
+
+    const byId = new Map(events.map((e) => [e.id, e]))
+    return rows
+      .map((r) => byId.get(r.id))
+      .filter((e): e is (typeof events)[number] & { event: { startsAt: Date } } =>
+        Boolean(e?.event)
+      )
+      .map((e) => ({
+        id: e.id,
+        kind: 'event' as const,
+        content: e.content,
+        country: e.country,
+        cityName: e.cityName,
+        lat: e.lat,
+        lon: e.lon,
+        postedBy: e.postedBy,
+        event: { startsAt: e.event.startsAt },
+      }))
+  }
+
+  // ── Communities ─────────────────────────────────────────────────────
+  private async searchCommunities(
+    term: string,
+    myProfileId: string
+  ): Promise<DbCommunityForSummary[]> {
+    const rows = await this.searchUserContent(
+      'community',
+      SEARCH_COMMUNITY_LIMIT,
+      term,
+      myProfileId
+    )
+    if (rows.length === 0) return []
+
+    const ids = rows.map((r) => r.id)
+    const communities = await prisma.userContent.findMany({
+      where: { id: { in: ids }, kind: 'community' },
+      select: {
+        id: true,
+        kind: true,
+        content: true,
+        country: true,
+        cityName: true,
+        lat: true,
+        lon: true,
+        community: { select: { yearFounded: true } },
+        postedBy: {
+          select: {
+            id: true,
+            publicName: true,
+            profileImages: {
+              include: { image: true },
+              orderBy: { image: { position: 'asc' } },
+            },
+          },
+        },
+      },
+    })
+
+    const byId = new Map(communities.map((c) => [c.id, c]))
+    return rows
+      .map((r) => byId.get(r.id))
+      .filter(
+        (c): c is (typeof communities)[number] & { community: { yearFounded: number | null } } =>
+          Boolean(c?.community)
+      )
+      .map((c) => ({
+        id: c.id,
+        kind: 'community' as const,
+        content: c.content,
+        country: c.country,
+        cityName: c.cityName,
+        lat: c.lat,
+        lon: c.lon,
+        postedBy: c.postedBy,
+        community: { yearFounded: c.community.yearFounded },
       }))
   }
 }

--- a/apps/frontend/src/features/browse/components/SearchBar.vue
+++ b/apps/frontend/src/features/browse/components/SearchBar.vue
@@ -13,6 +13,8 @@ import type { LocationDTO, GeoPoint } from '@zod/dto/location.dto'
 import type { OwnerProfile, ProfileSummary } from '@zod/profile/profile.dto'
 import type { PublicTag } from '@zod/tag/tag.dto'
 import type { PostSummary } from '@zod/post/post.dto'
+import type { EventSummary } from '@zod/event/event.dto'
+import type { CommunitySummary } from '@zod/community/community.dto'
 import { SEARCH_MIN_QUERY_LENGTH } from '@zod/search/search.dto'
 
 import { useSearchStore } from '@/features/browse/stores/searchStore'
@@ -31,6 +33,8 @@ const emit = defineEmits<{
   'location:set': [point: GeoPoint]
   'profile:select': [profile: ProfileSummary]
   'post:select': [post: PostSummary]
+  'event:select': [event: EventSummary]
+  'community:select': [community: CommunitySummary]
 }>()
 
 const searchStore = useSearchStore()
@@ -96,8 +100,24 @@ function onSelectPost(post: PostSummary) {
   emit('post:select', post)
 }
 
+function onSelectEvent(event: EventSummary) {
+  const point = toGeoPoint(event.location)
+  if (point) emit('location:set', point)
+  emit('event:select', event)
+}
+
+function onSelectCommunity(community: CommunitySummary) {
+  const point = toGeoPoint(community.location)
+  if (point) emit('location:set', point)
+  emit('community:select', community)
+}
+
 const isSearchMatchesEmpty = computed(
-  () => !searchResults.value?.profiles.length && !searchResults.value?.posts.length
+  () =>
+    !searchResults.value?.profiles.length &&
+    !searchResults.value?.posts.length &&
+    !searchResults.value?.events.length &&
+    !searchResults.value?.communities.length
 )
 
 const trackSearch = useDebounceFn(() => tracker.track('search'), 500)
@@ -175,8 +195,12 @@ watch(haveResults, () => {
         <SearchMatches
           :profiles="searchResults?.profiles ?? []"
           :posts="searchResults?.posts ?? []"
+          :events="searchResults?.events ?? []"
+          :communities="searchResults?.communities ?? []"
           @profile:select="onSelectProfile"
           @post:select="onSelectPost"
+          @event:select="onSelectEvent"
+          @community:select="onSelectCommunity"
         />
       </div>
     </div>

--- a/apps/frontend/src/features/browse/components/SearchMatches.vue
+++ b/apps/frontend/src/features/browse/components/SearchMatches.vue
@@ -12,7 +12,7 @@ import IconPostIt from '@/assets/icons/interface/post-it.svg'
 import IconCalendar from '@/assets/icons/interface/calendar.svg'
 import IconCommunity from '@/assets/icons/interface/community.svg'
 
-const props = defineProps<{
+defineProps<{
   profiles: ProfileSummary[]
   posts: PostSummary[]
   events: EventSummary[]

--- a/apps/frontend/src/features/browse/components/SearchMatches.vue
+++ b/apps/frontend/src/features/browse/components/SearchMatches.vue
@@ -1,19 +1,46 @@
 <script setup lang="ts">
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+
 import type { PostSummary } from '@zod/post/post.dto'
+import type { EventSummary } from '@zod/event/event.dto'
+import type { CommunitySummary } from '@zod/community/community.dto'
 import type { ProfileSummary } from '@zod/profile/profile.dto'
 
 import ProfileChipList from './ProfileChipList.vue'
 import IconPostIt from '@/assets/icons/interface/post-it.svg'
+import IconCalendar from '@/assets/icons/interface/calendar.svg'
+import IconCommunity from '@/assets/icons/interface/community.svg'
 
-defineProps<{
+const props = defineProps<{
   profiles: ProfileSummary[]
   posts: PostSummary[]
+  events: EventSummary[]
+  communities: CommunitySummary[]
 }>()
 
 defineEmits<{
   'post:select': [post: PostSummary]
+  'event:select': [event: EventSummary]
+  'community:select': [community: CommunitySummary]
   'profile:select': [profile: ProfileSummary]
 }>()
+
+const { locale } = useI18n()
+
+// One formatter instance, cached against the active locale — Intl.DateTimeFormat
+// construction is non-trivial and event lists can carry many rows.
+const dateFormatter = computed(
+  () =>
+    new Intl.DateTimeFormat(locale.value, {
+      dateStyle: 'medium',
+      timeStyle: 'short',
+    })
+)
+
+function formatStartsAt(d: Date): string {
+  return dateFormatter.value.format(d)
+}
 </script>
 
 <template>
@@ -50,6 +77,69 @@ defineEmits<{
         >
           <div class="small lh-sm text-truncate">
             {{ post.content }}
+          </div>
+        </BListGroupItem>
+      </BListGroup>
+    </section>
+
+    <section
+      v-if="events.length"
+      class="px-2 pt-2 d-flex align-items-start"
+    >
+      <IconCalendar
+        width="24"
+        height="24"
+        class="mt-1 mx-2 text-secondary flex-shrink-0"
+      />
+      <BListGroup
+        flush
+        class="flex-grow-1 min-w-0"
+      >
+        <BListGroupItem
+          v-for="event in events"
+          class="small px-1"
+          button
+          :key="event.id"
+          @click="$emit('event:select', event)"
+        >
+          <div class="small lh-sm text-truncate">
+            {{ event.content }}
+          </div>
+          <div class="small text-secondary fw-semibold">
+            {{ formatStartsAt(event.startsAt) }}
+          </div>
+        </BListGroupItem>
+      </BListGroup>
+    </section>
+
+    <section
+      v-if="communities.length"
+      class="px-2 pt-2 d-flex align-items-start"
+    >
+      <IconCommunity
+        width="24"
+        height="24"
+        class="mt-1 mx-2 text-secondary flex-shrink-0"
+      />
+      <BListGroup
+        flush
+        class="flex-grow-1 min-w-0"
+      >
+        <BListGroupItem
+          v-for="community in communities"
+          class="small px-1"
+          button
+          :key="community.id"
+          @click="$emit('community:select', community)"
+        >
+          <div class="small lh-sm text-truncate">
+            {{ community.content }}
+          </div>
+          <div
+            v-if="community.yearFounded !== null"
+            class="small text-secondary fw-semibold"
+          >
+            {{ community.yearFounded }}
           </div>
         </BListGroupItem>
       </BListGroup>

--- a/apps/frontend/src/features/browse/stores/__tests__/searchStore.spec.ts
+++ b/apps/frontend/src/features/browse/stores/__tests__/searchStore.spec.ts
@@ -84,6 +84,41 @@ describe('useSearchStore', () => {
     })
   })
 
+  describe('hasResults', () => {
+    /**
+     * `hasResults` drives the SearchBar panel-open watch. Regression guard:
+     * any non-empty collection — including events or communities — must
+     * flip it to true, otherwise event/community-only matches won't open
+     * the panel. We poke `searchResults` directly because exercising the
+     * full `search()` path would require schema-valid fixtures for every
+     * kind, which the parse layer enforces (covered elsewhere).
+     */
+    const withOnly = (key: 'profiles' | 'posts' | 'events' | 'communities' | 'tags') => ({
+      ...emptyResults,
+      [key]: [{ id: 'x' }],
+    })
+
+    it('is false before any search has run', () => {
+      const store = useSearchStore()
+      expect(store.hasResults).toBe(false)
+    })
+
+    it('is false when every collection in the response is empty', () => {
+      const store = useSearchStore()
+      store.searchResults = emptyResults as any
+      expect(store.hasResults).toBe(false)
+    })
+
+    it.each(['profiles', 'posts', 'events', 'communities', 'tags'] as const)(
+      'is true when only %s has matches',
+      (key) => {
+        const store = useSearchStore()
+        store.searchResults = withOnly(key) as any
+        expect(store.hasResults).toBe(true)
+      }
+    )
+  })
+
   describe('clearTags / reset', () => {
     it('clearTags empties the selection', () => {
       const store = useSearchStore()

--- a/apps/frontend/src/features/browse/stores/__tests__/searchStore.spec.ts
+++ b/apps/frontend/src/features/browse/stores/__tests__/searchStore.spec.ts
@@ -22,6 +22,8 @@ const emptyResults = {
   tags: [],
   profiles: [],
   posts: [],
+  events: [],
+  communities: [],
 }
 
 const tag = (id: string, name = id): PublicTag => ({ id, name, slug: id })
@@ -135,6 +137,8 @@ describe('useSearchStore', () => {
         tags: [{ id: 'cltagabc000000000000001', name: 'Hiking', slug: 'hiking' }],
         profiles: [],
         posts: [],
+        events: [],
+        communities: [],
       }
       mockGet.mockResolvedValueOnce({ data: payload })
 

--- a/apps/frontend/src/features/browse/stores/searchStore.ts
+++ b/apps/frontend/src/features/browse/stores/searchStore.ts
@@ -18,7 +18,14 @@ export const useSearchStore = defineStore('search', () => {
   const selectedTagIds = computed(() => selectedTags.value.map((t) => t.id))
   const hasResults = computed(() => {
     const r = searchResults.value
-    return !!r && (r.profiles.length > 0 || r.posts.length > 0 || r.tags.length > 0)
+    return (
+      !!r &&
+      (r.profiles.length > 0 ||
+        r.posts.length > 0 ||
+        r.events.length > 0 ||
+        r.communities.length > 0 ||
+        r.tags.length > 0)
+    )
   })
 
   function toggleTag(tag: PublicTag) {

--- a/apps/frontend/src/features/browse/views/BrowseProfiles.vue
+++ b/apps/frontend/src/features/browse/views/BrowseProfiles.vue
@@ -293,6 +293,8 @@ onMounted(async () => {
           @location:set="onLocationSet"
           @profile:select="handleProfileSelect"
           @post:select="handlePostSelect"
+          @event:select="handleEventSelect"
+          @community:select="handleCommunitySelect"
         />
         <MapLayerControl
           v-model="selectedLayers"

--- a/packages/shared/zod/community/community.dto.ts
+++ b/packages/shared/zod/community/community.dto.ts
@@ -70,6 +70,8 @@ export const CommunitySummarySchema = z.object({
   id: z.string(),
   kind: COMMUNITY_KIND,
   content: z.string(),
+  yearFounded: YearFoundedSchema,
   location: LocationSchema,
   postedBy: ProfileSummarySchema,
 })
+export type CommunitySummary = z.infer<typeof CommunitySummarySchema>

--- a/packages/shared/zod/event/event.dto.ts
+++ b/packages/shared/zod/event/event.dto.ts
@@ -62,9 +62,11 @@ export const EventSummarySchema = z.object({
   id: z.string(),
   kind: EVENT_KIND,
   content: z.string(),
+  startsAt: z.coerce.date(),
   location: LocationSchema,
   postedBy: ProfileSummarySchema,
 })
+export type EventSummary = z.infer<typeof EventSummarySchema>
 
 export const AttendanceStatusEnum = z.enum(['GOING', 'MAYBE'])
 export type AttendanceStatus = z.infer<typeof AttendanceStatusEnum>

--- a/packages/shared/zod/search/search.dto.ts
+++ b/packages/shared/zod/search/search.dto.ts
@@ -2,6 +2,8 @@ import z from 'zod'
 import { ProfileSummarySchema } from '../profile/profile.dto'
 import { PublicTagSchema } from '../tag/tag.dto'
 import { PostSummarySchema } from '../post/post.dto'
+import { EventSummarySchema } from '../event/event.dto'
+import { CommunitySummarySchema } from '../community/community.dto'
 
 /** Query-string schema for GET /search. */
 export const SearchQuerySchema = z.object({
@@ -17,6 +19,8 @@ export const SearchResponseSchema = z.object({
   tags: z.array(PublicTagSchema),
   profiles: z.array(ProfileSummarySchema),
   posts: z.array(PostSummarySchema),
+  events: z.array(EventSummarySchema),
+  communities: z.array(CommunitySummarySchema),
 })
 
 export type SearchResponse = z.infer<typeof SearchResponseSchema>
@@ -28,3 +32,5 @@ export const SEARCH_MIN_QUERY_LENGTH = 2
 export const SEARCH_TAG_LIMIT = 5
 export const SEARCH_PROFILE_LIMIT = 10
 export const SEARCH_POST_LIMIT = 10
+export const SEARCH_EVENT_LIMIT = 10
+export const SEARCH_COMMUNITY_LIMIT = 10


### PR DESCRIPTION
## Summary
- Backend: `GET /search` now returns `events[]` and `communities[]` alongside `posts[]`, populated via the same trigram path on `UserContent` (one new shared SQL helper, three Prisma hydration paths)
- Shared: `EventSummary` / `CommunitySummary` schemas gain the one distinguishing field per kind (`startsAt` for events, `yearFounded` for communities); `SearchResponseSchema` gains the two new arrays plus per-kind LIMIT constants
- Frontend: `SearchMatches.vue` renders events and communities as their own sections with distinct icons; `SearchBar.vue` fans selection events through to the existing `handleEventSelect` / `handleCommunitySelect` route handlers in `BrowseProfiles.vue`

## Notes
- The SQL kind literal is injected via `Prisma.sql([...])` rather than `${kind}::"ContentKind"` because parameter substitution doesn't compose inside enum casts. The kind value is constrained to a closed enum, so no injection risk.
- The empty-matches check in `SearchBar` now considers all four kinds, otherwise events/community-only results would hide the panel.

## Test plan
- [ ] Type a substring that matches an event — verify it appears under the calendar section with the formatted start time
- [ ] Type a substring that matches a community — verify it appears under the community-icon section with the year founded (if set)
- [ ] Click an event/community search result — verify navigation to the public event/community detail page
- [ ] Verify a search that matches only events still opens the matches panel (regression check on the empty-state guard)