### PR TITLE
Render admin dashboard detail charts as stacked columns

### DIFF
--- a/.changeset/stacked-charts-render.md
+++ b/.changeset/stacked-charts-render.md
@@ -1,0 +1,5 @@
+---
+'@opencupid/admin': minor
+---
+
+Render admin dashboard Messages and Interactions detail charts as stacked columns.

--- a/apps/admin/src/components/DashboardDrillDownModal.vue
+++ b/apps/admin/src/components/DashboardDrillDownModal.vue
@@ -107,7 +107,7 @@ const chartOptions = computed(() => {
     interaction: { mode: 'index' as const, intersect: false },
     scales: {
       x: {
-        stacked: false,
+        stacked: true,
         ticks: {
           autoSkip: false,
           maxRotation: 0,
@@ -118,6 +118,7 @@ const chartOptions = computed(() => {
         grid: { display: false },
       },
       y: {
+        stacked: true,
         beginAtZero: true,
         ticks: { precision: 0 },
       },

--- a/apps/admin/src/components/__tests__/DashboardDrillDownModal.spec.ts
+++ b/apps/admin/src/components/__tests__/DashboardDrillDownModal.spec.ts
@@ -86,6 +86,20 @@ describe('DashboardDrillDownModal', () => {
     expect(wrapper.text()).toContain('Matches')
   })
 
+  it('renders the bar chart with stacked axes', async () => {
+    const wrapper = mount(DashboardDrillDownModal, {
+      props: { metric: 'interactions', title: 'Interactions' },
+    })
+    await flushPromises()
+
+    const chart = wrapper.findComponent({ name: 'Bar' })
+    const options = chart.props('options') as {
+      scales: { x: { stacked: boolean }; y: { stacked: boolean } }
+    }
+    expect(options.scales.x.stacked).toBe(true)
+    expect(options.scales.y.stacked).toBe(true)
+  })
+
   it('refetches when the range dropdown changes', async () => {
     const wrapper = mount(DashboardDrillDownModal, {
       props: { metric: 'interactions', title: 'Interactions' },


### PR DESCRIPTION
## Summary
- Change the admin dashboard drill-down detail charts (Messages, Interactions) from grouped/side-by-side columns to a stacked column view, using the existing breakdown data and series.
- Set `stacked: true` on both the x and y axes in `DashboardDrillDownModal.vue` chart options; the per-series datasets and colors are unchanged.

## Test plan
- [x] `pnpm --filter admin test DashboardDrillDownModal` — added a test asserting both axes are stacked; all 5 tests pass
- [x] `pnpm --filter admin type-check`

https://claude.ai/code/session_01H6p76bMcDcGHGGqprcZKEw

---
_Generated by [Claude Code](https://claude.ai/code/session_01H6p76bMcDcGHGGqprcZKEw)_