### PR TITLE
Slim messaging payloads: narrow sender / partnerProfile to MessageProfileRef

### DIFF
--- a/.changeset/slim-messaging-payloads.md
+++ b/.changeset/slim-messaging-payloads.md
@@ -1,0 +1,7 @@
+---
+'@opencupid/backend': minor
+'@opencupid/frontend': minor
+'@opencupid/shared': minor
+---
+
+Slim messaging payloads: narrow `MessageDTO.sender`, `ConversationSummary.partnerProfile`, and `ConversationDraftSummary.partnerProfile` to a new `MessageProfileRef` shape (`id`, `publicName`, single-image `profileImages`). Drops `location` and every-image-variant duplication from message/conversation responses and `ws:new_message` payloads — the inbox list, message bubbles, and new-message toast only ever rendered the first image's thumbnail. Backend Prisma includes are scoped to a single `profileImages` row per profile on the messaging paths. (#1369)

--- a/apps/backend/src/__tests__/routes/messaging.route.spec.ts
+++ b/apps/backend/src/__tests__/routes/messaging.route.spec.ts
@@ -72,10 +72,11 @@ vi.mock('../../api/mappers/messaging.mappers', () => ({
     ...(currentProfileId !== undefined && { isMine: m?.senderId === currentProfileId }),
   })),
   mapConversationParticipantToSummary: vi.fn(() => ({ id: 'summary', partnerProfile: {} })),
-}))
-
-vi.mock('../../api/mappers/profile.mappers', () => ({
-  mapProfileSummary: vi.fn((p: any) => ({ id: p.id, publicName: p.publicName ?? 'Partner' })),
+  mapMessageProfileRef: vi.fn((p: any) => ({
+    id: p.id,
+    publicName: p.publicName ?? 'Partner',
+    profileImages: [],
+  })),
 }))
 
 vi.mock('@/services/profile.service', () => ({

--- a/apps/backend/src/api/mappers/messaging.mappers.ts
+++ b/apps/backend/src/api/mappers/messaging.mappers.ts
@@ -3,15 +3,31 @@ import type {
   ConversationSummary,
   MessageAttachmentDTO,
   MessageDTO,
+  MessageProfileRef,
 } from '@zod/messaging/messaging.dto'
-import { mapProfileSummary } from './profile.mappers'
 import {
   canSendMessageInConversation,
   type MessageWithSender,
 } from '../../services/messaging.service'
 import { mediaUrl } from '../../lib/media'
 import { appConfig } from '../../lib/appconfig'
-import { toPublicImage } from './image.mappers'
+import { toPublicImage, type MinimalImage } from './image.mappers'
+
+// Trimmed profile projection for messaging payloads. Drops `location` and
+// caps `profileImages` to the first image (thumbnail) — the only data the
+// inbox list, message bubbles, and new-message toast actually render.
+// Issue #1369.
+export function mapMessageProfileRef(profile: {
+  id: string
+  publicName: string
+  profileImages: { image: MinimalImage }[]
+}): MessageProfileRef {
+  return {
+    id: profile.id,
+    publicName: profile.publicName,
+    profileImages: profile.profileImages.slice(0, 1).map((g) => toPublicImage(g.image)),
+  }
+}
 
 function mapConversationMeta(c: { id: string; updatedAt: Date; createdAt: Date }) {
   return {
@@ -64,7 +80,7 @@ export function mapConversationParticipantToSummary(
         }
       : null,
     conversation: mapConversationMeta(conversation),
-    partnerProfile: mapProfileSummary(partner),
+    partnerProfile: mapMessageProfileRef(partner),
   }
 }
 
@@ -76,7 +92,7 @@ export function mapMessageToDTO(m: MessageWithSender, currentProfileId?: string)
     content: m.content,
     messageType: m.messageType,
     createdAt: m.createdAt,
-    sender: mapProfileSummary(m.sender),
+    sender: mapMessageProfileRef(m.sender),
     attachment: m.attachment ? mapAttachmentDTO(m.attachment) : null,
     images: m.images.map((j) => toPublicImage(j.image)),
     ...(currentProfileId !== undefined && { isMine: m.senderId === currentProfileId }),

--- a/apps/backend/src/api/routes/messaging.route.ts
+++ b/apps/backend/src/api/routes/messaging.route.ts
@@ -12,8 +12,11 @@ import { computeSendOutcome, type SendOutcome } from '@/services/messaging.state
 import { WebPushService } from '@/services/webpush.service'
 
 import { z } from 'zod'
-import { mapConversationParticipantToSummary, mapMessageToDTO } from '../mappers/messaging.mappers'
-import { mapProfileSummary } from '../mappers/profile.mappers'
+import {
+  mapConversationParticipantToSummary,
+  mapMessageProfileRef,
+  mapMessageToDTO,
+} from '../mappers/messaging.mappers'
 import type {
   MessagesResponse,
   ConversationsResponse,
@@ -344,7 +347,7 @@ const messageRoutes: FastifyPluginAsync = async (fastify) => {
         const viewer = await profileService.getProfileById(viewerProfileId)
         const draft: ConversationDraftSummary = {
           isDraft: true,
-          partnerProfile: mapProfileSummary(partner),
+          partnerProfile: mapMessageProfileRef(partner),
           canReply: true,
           isCallable: partner.isCallable !== false,
           myIsCallable: viewer?.isCallable !== false,

--- a/apps/backend/src/services/messaging.service.ts
+++ b/apps/backend/src/services/messaging.service.ts
@@ -33,8 +33,24 @@ const conversationSummaryInclude = {
       // the mapper can resolve the partner profile without depending on the
       // participants list — required because PENDING conversations have only the
       // sender as a participant until the trust flag clears.
-      profileA: { include: { profileImages: { include: { image: true } } } },
-      profileB: { include: { profileImages: { include: { image: true } } } },
+      profileA: {
+        include: {
+          profileImages: {
+            include: { image: true },
+            orderBy: { image: { position: 'asc' as const } },
+            take: 1,
+          },
+        },
+      },
+      profileB: {
+        include: {
+          profileImages: {
+            include: { image: true },
+            orderBy: { image: { position: 'asc' as const } },
+            take: 1,
+          },
+        },
+      },
       participants: {
         select: {
           profileId: true,
@@ -59,13 +75,10 @@ export const messageWithSenderInclude = {
     select: {
       id: true,
       publicName: true,
-      country: true,
-      cityName: true,
-      lat: true,
-      lon: true,
       profileImages: {
         include: { image: true },
         orderBy: { image: { position: 'asc' } },
+        take: 1,
       },
     },
   },

--- a/apps/frontend/src/features/messaging/composables/__tests__/useConversationDetailViewModel.spec.ts
+++ b/apps/frontend/src/features/messaging/composables/__tests__/useConversationDetailViewModel.spec.ts
@@ -103,7 +103,6 @@ function makePersistedSummary(
       id: partnerId,
       publicName: 'Partner',
       profileImages: [],
-      location: { country: '' },
     },
     lastMessage: null,
   }
@@ -116,7 +115,6 @@ function makeDraftSummary(partnerId = 'partner-1'): ConversationDraftSummary {
       id: partnerId,
       publicName: 'Partner',
       profileImages: [],
-      location: { country: '' },
     },
     canReply: true,
     isCallable: true,

--- a/apps/frontend/src/features/messaging/stores/__tests__/messageStore.spec.ts
+++ b/apps/frontend/src/features/messaging/stores/__tests__/messageStore.spec.ts
@@ -46,7 +46,6 @@ function makeConvo(conversationId: string, partnerName: string): ConversationSum
       id: `partner-${conversationId}`,
       publicName: partnerName,
       profileImages: [],
-      location: { country: '' },
     },
     lastMessage: null,
   }
@@ -84,7 +83,6 @@ describe('messageStore', () => {
           id: 'partner-profile-1',
           publicName: 'Partner',
           profileImages: [],
-          location: { country: '' },
         },
         lastMessage: {
           content: 'Initial message',
@@ -109,7 +107,6 @@ describe('messageStore', () => {
           id: 'partner-profile-1',
           publicName: 'Partner',
           profileImages: [],
-          location: { country: '' },
         },
       }
 
@@ -146,7 +143,6 @@ describe('messageStore', () => {
           id: 'partner-1',
           publicName: 'Partner 1',
           profileImages: [],
-          location: { country: '' },
         },
         lastMessage: null,
       }
@@ -172,7 +168,6 @@ describe('messageStore', () => {
           id: 'partner-2',
           publicName: 'Partner 2',
           profileImages: [],
-          location: { country: '' },
         },
         lastMessage: null,
       }
@@ -192,7 +187,6 @@ describe('messageStore', () => {
           id: 'partner-2',
           publicName: 'Partner 2',
           profileImages: [],
-          location: { country: '' },
         },
       }
 
@@ -228,7 +222,6 @@ describe('messageStore', () => {
           id: 'partner-1',
           publicName: 'Partner',
           profileImages: [],
-          location: { country: '' },
         },
         lastMessage: null,
       }
@@ -248,7 +241,6 @@ describe('messageStore', () => {
           id: 'partner-1',
           publicName: 'Partner',
           profileImages: [],
-          location: { country: '' },
         },
       }
 
@@ -282,7 +274,6 @@ describe('messageStore', () => {
           id: 'partner-1',
           publicName: 'Partner',
           profileImages: [],
-          location: { country: '' },
         },
         lastMessage: null,
       }
@@ -302,7 +293,6 @@ describe('messageStore', () => {
           id: 'partner-1',
           publicName: 'Partner',
           profileImages: [],
-          location: { country: '' },
         },
       }
 
@@ -673,7 +663,6 @@ describe('resolveConversationByProfile', () => {
         id: 'p2',
         publicName: 'Partner',
         profileImages: [],
-        location: { country: '' },
       },
       canReply: true,
       isCallable: true,

--- a/packages/shared/zod/messaging/messaging.dto.ts
+++ b/packages/shared/zod/messaging/messaging.dto.ts
@@ -58,7 +58,7 @@ export type DbMessageImage = z.infer<typeof DbMessageImageSchema>
 export const MessageProfileRefSchema = z.object({
   id: z.string(),
   publicName: z.string(),
-  profileImages: z.array(PublicImageSchema),
+  profileImages: z.array(PublicImageSchema).max(1),
 })
 export type MessageProfileRef = z.infer<typeof MessageProfileRefSchema>
 

--- a/packages/shared/zod/messaging/messaging.dto.ts
+++ b/packages/shared/zod/messaging/messaging.dto.ts
@@ -50,6 +50,18 @@ const DbMessageImageSchema = z.object({
 })
 export type DbMessageImage = z.infer<typeof DbMessageImageSchema>
 
+// Messaging-only profile reference. Trimmed projection of ProfileSummary used
+// wherever a conversation/message payload carries a "who is this profile"
+// pointer. Drops `location` (never read in messaging UI) and is intended to
+// carry at most one PublicImage (the thumbnail used by message bubbles, the
+// inbox list, and the new-message toast). Issue #1369.
+export const MessageProfileRefSchema = z.object({
+  id: z.string(),
+  publicName: z.string(),
+  profileImages: z.array(PublicImageSchema),
+})
+export type MessageProfileRef = z.infer<typeof MessageProfileRefSchema>
+
 // this is used in the db layer
 const DbMessageInConversationSchema = MessageSchema.pick({
   id: true,
@@ -74,7 +86,7 @@ const MessageInConversationSchema = MessageSchema.pick({
   messageType: true,
   createdAt: true,
 }).extend({
-  sender: ProfileSummarySchema,
+  sender: MessageProfileRefSchema,
   attachment: MessageAttachmentDTOSchema.nullable().optional(),
   images: z.array(PublicImageSchema).default([]),
 })
@@ -82,7 +94,7 @@ export type MessageInConversation = z.infer<typeof MessageInConversationSchema>
 
 // this is used in the dto layer
 const MessageDTOSchema = MessageInConversationSchema.extend({
-  sender: ProfileSummarySchema,
+  sender: MessageProfileRefSchema,
   isMine: z.boolean().optional(),
   attachment: MessageAttachmentDTOSchema.nullable().optional(),
   images: z.array(PublicImageSchema).default([]),
@@ -115,7 +127,7 @@ export const ConversationSummarySchema = ConversationParticipantSchema.pick({
   isAdminInitiator: z.boolean().default(false),
   isCallable: z.boolean().default(true),
   myIsCallable: z.boolean().default(true),
-  partnerProfile: ProfileSummarySchema,
+  partnerProfile: MessageProfileRefSchema,
   lastMessage: MessageInConversationSummarySchema.nullable(),
 })
 
@@ -127,7 +139,7 @@ export type ConversationSummary = z.infer<typeof ConversationSummarySchema>
 // ConversationSummary.
 export const ConversationDraftSummarySchema = z.object({
   isDraft: z.literal(true),
-  partnerProfile: ProfileSummarySchema,
+  partnerProfile: MessageProfileRefSchema,
   canReply: z.boolean(),
   isCallable: z.boolean(),
   myIsCallable: z.boolean(),


### PR DESCRIPTION
## Summary

Addresses #1369. Drops the redundant `ProfileSummary` ballast from messaging wire payloads (send-message responses, conversation summaries, `ws:new_message`) by introducing a tighter `MessageProfileRef` projection.

Deliberately scoped narrowly — unlike the previous attempt (#1374) this PR does not touch frontend logic or components, only:

- The shared zod schema (`MessageProfileRef` replaces `ProfileSummary` on `MessageDTO.sender`, `ConversationSummary.partnerProfile`, `ConversationDraftSummary.partnerProfile`)
- Backend mappers (`mapMessageProfileRef` replaces `mapProfileSummary` on messaging paths)
- Backend Prisma includes (sender / profileA / profileB `profileImages` is `take: 1`, location columns dropped from the sender select)
- Test fixtures (drop now-invalid `location` fields)

## What shrinks

`MessageProfileRef = { id, publicName, profileImages: PublicImage[] }`

- No `location` (never read in messaging UI)
- `profileImages` capped to one entry — the thumbnail used by `MessageReceivedToast`, `ConversationSummaries`, and message bubbles

Same shape on the wire whatever the `outcome` of a send. The discriminated-union variant of `SendMessageResponse` proposed in the issue is intentionally **not** in this PR because it would require changes inside `messageStore.handleSendResponse` — outside the agreed scope.

## Test plan

- [x] `pnpm test` — 885 backend / 708 frontend tests pass
- [x] `pnpm type-check` green across admin, backend, frontend
- [ ] CI green


---
_Generated by [Claude Code](https://claude.ai/code/session_017MQJPU6ENnQrM2khutZfqx)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Messaging payloads slimmed: sender and partner profile objects now include only id, publicName, and a single profile image.
  * Location information removed from message and conversation contexts.
  * Messaging responses and real-time message payloads now return one profile image per user, reducing payload size.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->