### PR TITLE
feat(auth): canonicalize Gmail email addresses for account identity

### DIFF
--- a/.changeset/gmail-canon-dedup.md
+++ b/.changeset/gmail-canon-dedup.md
@@ -1,0 +1,5 @@
+---
+'@opencupid/backend': minor
+---
+
+Canonicalize Gmail/Googlemail addresses (strip dots and +suffix) so equivalent inboxes resolve to one account.

--- a/apps/backend/src/__tests__/services/unsubscribeToken.spec.ts
+++ b/apps/backend/src/__tests__/services/unsubscribeToken.spec.ts
@@ -88,6 +88,16 @@ describe('unsubscribeToken', () => {
     expect(hashEmail('alice@example.com')).not.toBe(hashEmail('bob@example.com'))
   })
 
+  it('hashEmail unifies Gmail dot and plus variants', () => {
+    expect(hashEmail('j.smith@gmail.com')).toBe(hashEmail('jsmith@gmail.com'))
+    expect(hashEmail('jsmith+promo@gmail.com')).toBe(hashEmail('jsmith@gmail.com'))
+    expect(hashEmail('J.Smith+x@Googlemail.com')).toBe(hashEmail('jsmith@googlemail.com'))
+  })
+
+  it('hashEmail still distinguishes non-Gmail dotted addresses', () => {
+    expect(hashEmail('foo.bar@example.com')).not.toBe(hashEmail('foobar@example.com'))
+  })
+
   it('email fingerprint invalidates tokens on address change', () => {
     const token = signUnsubscribeToken({
       userId: 'user-1',

--- a/apps/backend/src/__tests__/services/user.service.spec.ts
+++ b/apps/backend/src/__tests__/services/user.service.spec.ts
@@ -114,6 +114,24 @@ describe('UserService.setLoginToken', () => {
     })
   })
 
+  it('canonicalizes Gmail dots and plus when looking up user', async () => {
+    const user = { id: 'u1', email: 'jsmith@gmail.com', isRegistrationConfirmed: true }
+    mockPrisma.user.findUnique.mockResolvedValue(user)
+    await service.setLoginToken({ email: 'J.Smith+promo@Gmail.com' }, '123', 'en', 'test.local')
+    expect(mockPrisma.user.findUnique).toHaveBeenCalledWith({
+      where: { email: 'jsmith@gmail.com' },
+    })
+  })
+
+  it('preserves dots for non-Gmail domains when looking up user', async () => {
+    mockPrisma.user.findUnique.mockResolvedValue(null)
+    mockPrisma.user.create.mockResolvedValue({ id: 'new' })
+    await service.setLoginToken({ email: 'Foo.Bar@Example.com' }, '123', 'en', 'test.local')
+    expect(mockPrisma.user.findUnique).toHaveBeenCalledWith({
+      where: { email: 'foo.bar@example.com' },
+    })
+  })
+
   it('normalizes email to lowercase when creating new user', async () => {
     mockPrisma.user.findUnique.mockResolvedValue(null)
     mockPrisma.user.create.mockResolvedValue({ id: 'new', email: 'new@example.com' })

--- a/apps/backend/src/__tests__/services/user.service.spec.ts
+++ b/apps/backend/src/__tests__/services/user.service.spec.ts
@@ -70,6 +70,16 @@ describe('UserService.validateLoginToken', () => {
   })
 })
 
+describe('UserService.findByAuthId', () => {
+  it('canonicalizes the auth id before lookup', async () => {
+    mockPrisma.user.findUnique.mockResolvedValue(null)
+    await service.findByAuthId('J.Smith+promo@Gmail.com')
+    expect(mockPrisma.user.findUnique).toHaveBeenCalledWith({
+      where: { email: 'jsmith@gmail.com' },
+    })
+  })
+})
+
 describe('UserService.setLoginToken', () => {
   it('updates existing user and gates the update on isBlocked=false', async () => {
     const user = { id: 'u1', isRegistrationConfirmed: true }

--- a/apps/backend/src/lib/__tests__/email.spec.ts
+++ b/apps/backend/src/lib/__tests__/email.spec.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest'
+import { canonicalizeEmail } from '../email'
+
+describe('canonicalizeEmail', () => {
+  it('trims and lowercases all domains', () => {
+    expect(canonicalizeEmail('  Foo@Example.COM ')).toBe('foo@example.com')
+  })
+
+  it('preserves dots for non-Gmail domains', () => {
+    expect(canonicalizeEmail('foo.bar@example.com')).toBe('foo.bar@example.com')
+  })
+
+  it('strips dots in the local part for gmail.com', () => {
+    expect(canonicalizeEmail('j.smith@gmail.com')).toBe('jsmith@gmail.com')
+  })
+
+  it('strips +suffix in the local part for gmail.com', () => {
+    expect(canonicalizeEmail('jsmith+netflix@gmail.com')).toBe('jsmith@gmail.com')
+  })
+
+  it('strips both dots and +suffix for gmail.com', () => {
+    expect(canonicalizeEmail('J.Smith+tag@Gmail.com')).toBe('jsmith@gmail.com')
+  })
+
+  it('treats googlemail.com like gmail.com', () => {
+    expect(canonicalizeEmail('j.smith+x@googlemail.com')).toBe('jsmith@googlemail.com')
+  })
+
+  it('is idempotent', () => {
+    const once = canonicalizeEmail('J.Smith+tag@Gmail.com')
+    expect(canonicalizeEmail(once)).toBe(once)
+  })
+
+  it('returns trim+lowercased input when there is no @', () => {
+    expect(canonicalizeEmail('  NotAnEmail ')).toBe('notanemail')
+  })
+})

--- a/apps/backend/src/lib/__tests__/email.spec.ts
+++ b/apps/backend/src/lib/__tests__/email.spec.ts
@@ -22,8 +22,11 @@ describe('canonicalizeEmail', () => {
     expect(canonicalizeEmail('foo+tag@example.com')).toBe('foo+tag@example.com')
   })
 
-  it('pins the degenerate Gmail empty-local-part case', () => {
-    expect(canonicalizeEmail('+tag@gmail.com')).toBe('@gmail.com')
+  it('preserves the local part when stripping would empty it', () => {
+    // A leading '+' or all-dots local part must not collapse to an invalid
+    // '@gmail.com' identifier; fall back to the trim/lowercased form.
+    expect(canonicalizeEmail('+tag@gmail.com')).toBe('+tag@gmail.com')
+    expect(canonicalizeEmail('.@Gmail.com')).toBe('.@gmail.com')
   })
 
   it('strips both dots and +suffix for gmail.com', () => {

--- a/apps/backend/src/lib/__tests__/email.spec.ts
+++ b/apps/backend/src/lib/__tests__/email.spec.ts
@@ -18,6 +18,14 @@ describe('canonicalizeEmail', () => {
     expect(canonicalizeEmail('jsmith+netflix@gmail.com')).toBe('jsmith@gmail.com')
   })
 
+  it('preserves +suffix for non-Gmail domains', () => {
+    expect(canonicalizeEmail('foo+tag@example.com')).toBe('foo+tag@example.com')
+  })
+
+  it('pins the degenerate Gmail empty-local-part case', () => {
+    expect(canonicalizeEmail('+tag@gmail.com')).toBe('@gmail.com')
+  })
+
   it('strips both dots and +suffix for gmail.com', () => {
     expect(canonicalizeEmail('J.Smith+tag@Gmail.com')).toBe('jsmith@gmail.com')
   })

--- a/apps/backend/src/lib/email.ts
+++ b/apps/backend/src/lib/email.ts
@@ -1,0 +1,27 @@
+const GMAIL_DOMAINS = new Set(['gmail.com', 'googlemail.com'])
+
+/**
+ * Canonicalize an email address for use as an account identifier.
+ *
+ * Applies to ALL domains: trim surrounding whitespace and lowercase.
+ * For Gmail (gmail.com / googlemail.com) ONLY, additionally normalize the
+ * local part the way Gmail's own mail server does — dots are insignificant
+ * and everything after the first '+' is ignored — so that j.smith@gmail.com,
+ * jsmith@gmail.com and j.smith+tag@gmail.com resolve to one identity.
+ *
+ * The dot/plus rule is provider-specific (per RFC 5321 only the receiving
+ * host may interpret the local part) and is gated behind a domain allowlist.
+ */
+export function canonicalizeEmail(email: string): string {
+  const normalized = email.trim().toLowerCase()
+  const atIndex = normalized.lastIndexOf('@')
+  if (atIndex === -1) return normalized
+
+  const local = normalized.slice(0, atIndex)
+  const domain = normalized.slice(atIndex + 1)
+  if (!GMAIL_DOMAINS.has(domain)) return normalized
+
+  const withoutPlus = local.split('+', 1)[0]
+  const withoutDots = withoutPlus.replace(/\./g, '')
+  return `${withoutDots}@${domain}`
+}

--- a/apps/backend/src/lib/email.ts
+++ b/apps/backend/src/lib/email.ts
@@ -21,7 +21,10 @@ export function canonicalizeEmail(email: string): string {
   const domain = normalized.slice(atIndex + 1)
   if (!GMAIL_DOMAINS.has(domain)) return normalized
 
-  const withoutPlus = local.split('+', 1)[0]
-  const withoutDots = withoutPlus.replace(/\./g, '')
-  return `${withoutDots}@${domain}`
+  const canonicalLocal = local.split('+', 1)[0].replace(/\./g, '')
+  // A leading '+' or an all-dots local part (e.g. '+tag@gmail.com', '.@gmail.com')
+  // would canonicalize to an empty local part — an invalid address and a
+  // degenerate shared identifier. Keep the trim/lowercased form in that case.
+  if (canonicalLocal === '') return normalized
+  return `${canonicalLocal}@${domain}`
 }

--- a/apps/backend/src/services/email/unsubscribeToken.ts
+++ b/apps/backend/src/services/email/unsubscribeToken.ts
@@ -24,9 +24,12 @@ const verifier = createVerifier({
 })
 
 /**
- * Derive a stable per-email fingerprint. If the user changes their email
- * address this changes too, which implicitly revokes outstanding unsubscribe
- * tokens issued against the old address.
+ * Derive a stable per-email fingerprint from the canonical form of the
+ * address (see canonicalizeEmail). Changing to an address with a different
+ * canonical form changes the fingerprint, which implicitly revokes
+ * outstanding unsubscribe tokens issued against the old address. Gmail
+ * variants that share a canonical form (dots, +suffix, case) keep the same
+ * fingerprint and do not revoke.
  */
 export function hashEmail(email: string): string {
   return createHash('sha256').update(canonicalizeEmail(email)).digest('base64url').slice(0, 22)

--- a/apps/backend/src/services/email/unsubscribeToken.ts
+++ b/apps/backend/src/services/email/unsubscribeToken.ts
@@ -1,6 +1,7 @@
 import { createHash } from 'crypto'
 import { createSigner, createVerifier } from 'fast-jwt'
 import { appConfig } from '@/lib/appconfig'
+import { canonicalizeEmail } from '@/lib/email'
 
 export type UnsubscribePayload = {
   userId: string
@@ -28,7 +29,7 @@ const verifier = createVerifier({
  * tokens issued against the old address.
  */
 export function hashEmail(email: string): string {
-  return createHash('sha256').update(email.trim().toLowerCase()).digest('base64url').slice(0, 22)
+  return createHash('sha256').update(canonicalizeEmail(email)).digest('base64url').slice(0, 22)
 }
 
 /**

--- a/apps/backend/src/services/user.service.ts
+++ b/apps/backend/src/services/user.service.ts
@@ -1,3 +1,4 @@
+import { canonicalizeEmail } from '@/lib/email'
 import { prisma } from '@/lib/prisma'
 import { Prisma, UserRole } from '@prisma/client'
 import type { User } from '@zod/generated'
@@ -63,7 +64,7 @@ export class UserService {
     user: User
     isNewUser: boolean
   }> {
-    const email = authId.email.trim().toLowerCase()
+    const email = canonicalizeEmail(authId.email)
     const userExists = await prisma.user.findUnique({ where: { email } })
     const tokenExpiration = getTokenExpiration()
 
@@ -134,7 +135,7 @@ export class UserService {
   }
 
   async findByAuthId(authId: string): Promise<User | null> {
-    return prisma.user.findUnique({ where: { email: authId.toLowerCase() } })
+    return prisma.user.findUnique({ where: { email: canonicalizeEmail(authId) } })
   }
 
   generateLoginToken() {


### PR DESCRIPTION
## Summary

Consolidates all email normalization into a single `canonicalizeEmail()` function and makes it Gmail-aware, so addresses that Gmail treats as one inbox resolve to one account.

- **New `canonicalizeEmail()`** (`apps/backend/src/lib/email.ts`): trims + lowercases **every** address, and for `gmail.com` / `googlemail.com` **only**, strips dots and `+suffix` from the local part (Gmail ignores both). The dot/plus rule is gated behind a domain allowlist — per RFC 5321, only the receiving host may reinterpret the local part, so this is deliberately not applied to other providers.
- **Three call sites consolidated** onto it: `UserService.setLoginToken`, `UserService.findByAuthId`, and `hashEmail` (unsubscribe-token fingerprint). This replaces three drifted inline `.trim().toLowerCase()` expressions and incidentally fixes `findByAuthId`, which previously lowercased without trimming.
- **Backfill migration** rewrites existing Gmail/Googlemail rows to canonical form. It **detects collisions first and aborts** (raises) if two existing rows would collapse to the same canonical address — it never auto-merges accounts.

## Test plan

- [x] `pnpm --filter backend test` — 901/901 pass
- [x] `pnpm type-check` — clean (backend, frontend, admin)
- [x] Unit tests for `canonicalizeEmail`: Gmail dot/plus/both, googlemail, non-Gmail dot+plus preservation, idempotence, degenerate empty-local, no-`@`
- [x] `setLoginToken` + `findByAuthId` canonicalize Gmail variants to one lookup; non-Gmail dots preserved
- [x] `hashEmail` unifies Gmail variants; non-Gmail unchanged; existing stability test still green
- [ ] Resolve any duplicate-account collisions, then apply the migration on dev and verify Gmail rows are stored canonical

Design spec and implementation plan included under `docs/superpowers/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Email canonicalization for Gmail addresses: dots and +suffixes are unified for user lookup, login tokens, and unsubscribe token handling so equivalent inboxes map to a single account/identity.

* **Tests**
  * Added tests covering canonicalization behavior across user lookup, login token flows, and unsubscribe token hashing/verification.

* **Chores**
  * Added changelog entry marking a backend minor release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->