### PR TITLE
fix(admin): sort users and profiles by createdAt desc only

### DIFF
--- a/.changeset/fix-admin-list-sort-order.md
+++ b/.changeset/fix-admin-list-sort-order.md
@@ -1,0 +1,5 @@
+---
+'@opencupid/backend': patch
+---
+
+Fix admin users and profiles lists to sort by createdAt desc only, so newest signups always appear first

--- a/apps/backend/src/api/routes/admin.route.ts
+++ b/apps/backend/src/api/routes/admin.route.ts
@@ -325,7 +325,7 @@ const adminRoutes: FastifyPluginAsync = async (fastify) => {
           where,
           skip,
           take: size,
-          orderBy: [{ isRegistrationConfirmed: 'desc' }, { createdAt: 'desc' }],
+          orderBy: [{ createdAt: 'desc' }],
           select: {
             id: true,
             email: true,
@@ -541,7 +541,7 @@ const adminRoutes: FastifyPluginAsync = async (fastify) => {
           where,
           skip,
           take: size,
-          orderBy: [{ isActive: 'desc' }, { createdAt: 'desc' }],
+          orderBy: [{ createdAt: 'desc' }],
           select: {
             id: true,
             publicName: true,


### PR DESCRIPTION
## Summary

- Removes boolean primary sort from the admin Users list (`isRegistrationConfirmed DESC`) and Profiles list (`isActive DESC`)
- Both lists now order by `createdAt DESC` only, so the newest signups always appear first regardless of their confirmation or active status

## Root cause

The compound `orderBy` was grouping all confirmed users above all unconfirmed ones (and all active profiles above inactive ones) before applying `createdAt`. A newly registered user who hadn't confirmed their email would appear below every older confirmed user on page 1.

**Test case:** `csehszakalszilvia@gmail.com` (joined 2026-06-22, unconfirmed) was invisible at the top of the Users list; `veronikafarfan9@gmail.com` (confirmed, joined 2026-06-17) sorted above her.

## Test plan

- [ ] Open admin Users list — newest signup appears first regardless of `isRegistrationConfirmed`
- [ ] Open admin Profiles list — newest profile appears first regardless of `isActive`
- [ ] Column-header sort (createdAt ▲/▼) still works correctly
- [ ] Pagination / infinite scroll still loads correct pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the poster profile thumbnail and name from event cards, leaving the event details cleaner.
  * Updated user and profile lists to show the newest entries first.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->