### PR TITLE
feat(auth): add junk-folder hint on magic-link screen

### DIFF
--- a/.changeset/junk-folder-hint.md
+++ b/.changeset/junk-folder-hint.md
@@ -1,0 +1,5 @@
+---
+'@opencupid/frontend': patch
+---
+
+Add a junk-folder hint below the check-email message on the magic-link screen (en, hu).

--- a/apps/frontend/src/features/auth/__tests__/MagicLink.spec.ts
+++ b/apps/frontend/src/features/auth/__tests__/MagicLink.spec.ts
@@ -82,6 +82,7 @@ describe('MagicLink', () => {
     await flushPromises()
 
     expect(wrapper.text()).toContain('auth.token_check_email')
+    expect(wrapper.text()).toContain('auth.token_check_junk')
   })
 
   it('shows only error and back button on failed magic link, hiding title and hint', async () => {
@@ -99,6 +100,7 @@ describe('MagicLink', () => {
     await flushPromises()
 
     expect(wrapper.text()).not.toContain('auth.token_check_email')
+    expect(wrapper.text()).not.toContain('auth.token_check_junk')
     expect(wrapper.text()).not.toContain('auth.token_check_messages')
     expect(wrapper.text()).toContain('auth.token_expired')
     expect(wrapper.text()).toContain('uicomponents.back_button_title')

--- a/apps/frontend/src/features/auth/views/MagicLink.vue
+++ b/apps/frontend/src/features/auth/views/MagicLink.vue
@@ -127,7 +127,10 @@ function handleBackButton() {
               {{ $t('auth.token_check_messages') }}
             </div>
           </div>
-          <p class="text-muted fs-6">{{ $t('auth.token_check_email') }}</p>
+          <p class="text-muted fs-6">
+            {{ $t('auth.token_check_email') }}<br />
+            {{ $t('auth.token_check_junk') }}
+          </p>
         </template>
         <div
           v-if="error"

--- a/packages/shared/i18n/en.json
+++ b/packages/shared/i18n/en.json
@@ -12,6 +12,7 @@
     "captcha_verifying": "Hang on a sec...",
     "login": "Continue",
     "token_check_email": "We sent you a login link. Check your email and click the link to log in.",
+    "token_check_junk": "If you don't see the email, please check your junk folder.",
     "token_check_messages": "Check your messages",
     "token_different_device": "It seems the login was started on a different device. Please go back and enter your email again.",
     "token_expired": "This code has expired. Please request a new one.",

--- a/packages/shared/i18n/hu.json
+++ b/packages/shared/i18n/hu.json
@@ -12,6 +12,7 @@
     "captcha_verifying": "Egy pillanat...",
     "login": "Tovább",
     "token_check_email": "Küldtünk egy bejelentkezési linket. Nézd meg az emailjeidet, és kattints a linkre a belépéshez.",
+    "token_check_junk": "Ha nem érkezik meg, nézd meg a spam mappát is.",
     "token_check_messages": "Nézz rá az üzeneteidre",
     "token_different_device": "Úgy tűnik, a bejelentkezést egy másik eszközön kezdted el. Menj vissza, és add meg újra az email címedet.",
     "token_expired": "Ez a kód lejárt, kérj újat.",


### PR DESCRIPTION
## Summary

Adds a hint telling users to check their junk/spam folder if they don't see the login email, displayed on a new line directly below the existing "check your email" message on the magic-link screen.

## Changes

- Add `token_check_junk` i18n string:
  - **en**: "If you don't see the email, please check your junk folder."
  - **hu**: "Ha nem érkezik meg, nézd meg a spam mappát is."
- Render it on a new line under `token_check_email` in `MagicLink.vue`.
- Update `MagicLink.spec.ts` to assert the new key appears with the check-email message and is hidden on the error state.

## Notes

Dependency install could not complete in this environment (an egress-policy 403 on a GitHub-hosted tarball dependency), so the frontend test suite was not run locally. The change is limited to two static i18n keys and one template line; edits are inline with the existing conditional block, so the added string shows/hides together with `token_check_email`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018XGDHQMqXrsmfPv276nPDD

---
_Generated by [Claude Code](https://claude.ai/code/session_018XGDHQMqXrsmfPv276nPDD)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a helpful reminder to check the junk or spam folder when a magic-link email hasn’t arrived.
  * Displayed the reminder in both English and Hungarian on the magic-link screen.

* **Bug Fixes**
  * Updated magic-link status messaging to accurately show the junk-folder guidance only when appropriate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->