### PR TITLE
feat(auth): track umami events on login flow failures

### DIFF
--- a/.changeset/amber-signals-report.md
+++ b/.changeset/amber-signals-report.md
@@ -1,0 +1,5 @@
+---
+'@opencupid/frontend': patch
+---
+
+Track Umami events for login flow failures: magic-link send failures, expired/invalid/malformed token verification failures and post-login bootstrap failures

--- a/apps/frontend/src/features/auth/__tests__/LoginView.spec.ts
+++ b/apps/frontend/src/features/auth/__tests__/LoginView.spec.ts
@@ -1,11 +1,13 @@
-import { mount } from '@vue/test-utils'
+import { flushPromises, mount } from '@vue/test-utils'
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { nextTick } from 'vue'
 
 const push = vi.fn()
 const sendMagicLink = vi.fn()
 const setLanguage = vi.fn()
+const track = vi.hoisted(() => vi.fn())
 
+vi.mock('@/lib/umami', () => ({ tracker: { track } }))
 vi.mock('vue-router', () => ({ useRouter: () => ({ push }) }))
 vi.mock('vue-i18n', () => ({ useI18n: () => ({ t: (key: string) => key }) }))
 vi.mock('../stores/authStore', () => ({ useAuthStore: () => ({ sendMagicLink }) }))
@@ -24,6 +26,7 @@ describe('LoginView', () => {
     push.mockReset()
     sendMagicLink.mockReset()
     setLanguage.mockReset()
+    track.mockReset()
   })
 
   it('prefills auth id input from localStorage', async () => {
@@ -49,5 +52,47 @@ describe('LoginView', () => {
     expect(wrapper.get('[data-test="auth-id-component"]').attributes('data-default-auth-id')).toBe(
       'test@example.com'
     )
+  })
+
+  const mountWithSubmittingLoginForm = () =>
+    mount(LoginView, {
+      global: {
+        stubs: {
+          LoginForm: {
+            template:
+              "<button data-test=\"submit\" @click=\"$emit('updated', { email: 'test@example.com', captchaSolution: 'ok', language: '' })\" />",
+          },
+          LocaleSelector: { template: '<div />' },
+          ErrorComponent: { template: '<div />' },
+          LogoComponent: { template: '<div />' },
+        },
+      },
+    })
+
+  it('tracks auth-magic-link-failed when sending the magic link fails', async () => {
+    sendMagicLink.mockResolvedValue({
+      success: false,
+      code: 'AUTH_RATE_LIMITED',
+      message: 'slow down',
+      restart: 'userid',
+    })
+
+    const wrapper = mountWithSubmittingLoginForm()
+    await wrapper.get('[data-test="submit"]').trigger('click')
+    await flushPromises()
+
+    expect(track).toHaveBeenCalledWith('auth-magic-link-failed', { code: 'AUTH_RATE_LIMITED' })
+    expect(push).not.toHaveBeenCalled()
+  })
+
+  it('does not track failure events when the magic link is sent', async () => {
+    sendMagicLink.mockResolvedValue({ success: true, user: {} })
+
+    const wrapper = mountWithSubmittingLoginForm()
+    await wrapper.get('[data-test="submit"]').trigger('click')
+    await flushPromises()
+
+    expect(track).not.toHaveBeenCalled()
+    expect(push).toHaveBeenCalledWith({ name: 'MagicLink' })
   })
 })

--- a/apps/frontend/src/features/auth/__tests__/MagicLink.spec.ts
+++ b/apps/frontend/src/features/auth/__tests__/MagicLink.spec.ts
@@ -21,6 +21,16 @@ const route = {
   query: {} as Record<string, unknown>,
 }
 
+const track = vi.hoisted(() => vi.fn())
+vi.mock('@/lib/umami', () => ({
+  tracker: { track },
+}))
+
+const bootstrapReady = vi.hoisted(() => vi.fn<() => Promise<void>>())
+vi.mock('@/lib/auth', () => ({
+  bootstrapReady,
+}))
+
 vi.mock('vue-router', () => ({
   useRoute: () => route,
   useRouter: () => ({ push }),
@@ -60,6 +70,9 @@ describe('MagicLink', () => {
     setActivePinia(createPinia())
     route.query = {}
     push.mockReset()
+    track.mockReset()
+    bootstrapReady.mockReset()
+    bootstrapReady.mockResolvedValue(undefined)
   })
 
   it('redirects to /browse on valid magic-link token', async () => {
@@ -104,5 +117,71 @@ describe('MagicLink', () => {
     expect(wrapper.text()).not.toContain('auth.token_check_messages')
     expect(wrapper.text()).toContain('auth.token_expired')
     expect(wrapper.text()).toContain('uicomponents.back_button_title')
+  })
+
+  it.each([
+    ['AUTH_EXPIRED_TOKEN', 'auth.token_expired'],
+    ['AUTH_INVALID_TOKEN', 'auth.token_invalid'],
+    ['AUTH_INVALID_INPUT', 'auth.token_different_device'],
+    ['AUTH_INTERNAL_ERROR', 'auth.token_unknown_error'],
+  ] as const)('tracks auth-token-failed with code %s', async (code, errorKey) => {
+    route.query = { token: '123456' }
+    const authStore = useAuthStore()
+    authStore.loginUser = emailLoginUser
+    vi.spyOn(authStore, 'verifyToken').mockResolvedValue({
+      success: false,
+      code,
+      message: 'failed',
+      restart: 'otp',
+    })
+
+    const wrapper = mountMagicLink()
+    await flushPromises()
+
+    expect(track).toHaveBeenCalledWith('auth-token-failed', { code })
+    expect(wrapper.text()).toContain(errorKey)
+  })
+
+  it('tracks auth-token-failed with AUTH_MALFORMED_LINK on malformed token param', async () => {
+    route.query = { token: '12' }
+    const authStore = useAuthStore()
+    authStore.loginUser = emailLoginUser
+    const verifyToken = vi.spyOn(authStore, 'verifyToken')
+
+    const wrapper = mountMagicLink()
+    await flushPromises()
+
+    expect(verifyToken).not.toHaveBeenCalled()
+    expect(track).toHaveBeenCalledWith('auth-token-failed', { code: 'AUTH_MALFORMED_LINK' })
+    expect(wrapper.text()).toContain('auth.token_invalid_link')
+  })
+
+  it('tracks auth-bootstrap-failed when bootstrap rejects after a valid token', async () => {
+    route.query = { token: '123456' }
+    const authStore = useAuthStore()
+    authStore.loginUser = emailLoginUser
+    vi.spyOn(authStore, 'verifyToken').mockResolvedValue({ success: true, status: '' })
+    bootstrapReady.mockRejectedValue(new Error('chunk load failed'))
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    const wrapper = mountMagicLink()
+    await flushPromises()
+
+    expect(track).toHaveBeenCalledWith('auth-bootstrap-failed')
+    expect(push).not.toHaveBeenCalled()
+    expect(wrapper.text()).toContain('auth.token_unknown_error')
+    consoleError.mockRestore()
+  })
+
+  it('does not track failure events on successful login', async () => {
+    route.query = { token: '123456' }
+    const authStore = useAuthStore()
+    authStore.loginUser = emailLoginUser
+    vi.spyOn(authStore, 'verifyToken').mockResolvedValue({ success: true, status: '' })
+
+    mountMagicLink()
+    await flushPromises()
+
+    expect(track).not.toHaveBeenCalled()
   })
 })

--- a/apps/frontend/src/features/auth/views/LoginView.vue
+++ b/apps/frontend/src/features/auth/views/LoginView.vue
@@ -6,6 +6,7 @@ import { type UserIdentifyPayload } from '@zod/user/user.dto'
 
 import { useI18nStore } from '@/store/i18nStore'
 import { useAuthStore } from '../stores/authStore'
+import { tracker } from '@/lib/umami'
 import LoginForm from '../components/LoginForm.vue'
 import LocaleSelector from '../../shared/ui/LocaleSelector.vue'
 
@@ -35,6 +36,7 @@ async function handleSendOtp(authIdCaptcha: UserIdentifyPayload) {
     if (res.success) {
       router.push({ name: 'MagicLink' })
     } else {
+      tracker.track('auth-magic-link-failed', { code: res.code })
       error.value = res.message || t('auth.unknown_error')
     }
   } finally {

--- a/apps/frontend/src/features/auth/views/MagicLink.vue
+++ b/apps/frontend/src/features/auth/views/MagicLink.vue
@@ -7,6 +7,7 @@ import { useI18n } from 'vue-i18n'
 
 import { useAuthStore } from '../stores/authStore'
 import { bootstrapReady } from '@/lib/auth'
+import { tracker } from '@/lib/umami'
 import AuthLayout from '../components/AuthLayout.vue'
 import ViewTitle from '@/features/shared/ui/ViewTitle.vue'
 import ChevronLeftIcon from '@/assets/icons/arrows/arrow-single-left.svg'
@@ -40,6 +41,7 @@ onMounted(async () => {
   }
   const params = TokenParamSchema.safeParse(route.query)
   if (!params.success) {
+    tracker.track('auth-token-failed', { code: 'AUTH_MALFORMED_LINK' })
     error.value = t('auth.token_invalid_link')
     isCheckingMagicLinkToken.value = false
     return
@@ -60,6 +62,7 @@ onMounted(async () => {
         await bootstrapReady()
       } catch (err) {
         console.error('Bootstrap failed after login:', err)
+        tracker.track('auth-bootstrap-failed')
         error.value = t('auth.token_unknown_error')
         isCheckingMagicLinkToken.value = false
         return
@@ -67,6 +70,7 @@ onMounted(async () => {
       await router.push('/browse')
       return
     }
+    tracker.track('auth-token-failed', { code: res.code })
     switch (res.code) {
       case 'AUTH_EXPIRED_TOKEN':
         error.value = t('auth.token_expired')


### PR DESCRIPTION
## Summary

Emit Umami analytics events at each failure point in the magic-link login flow, so login failures (expired/invalid tokens etc.) become visible in the Umami dashboard alongside the existing `auth-email-submitted` event.

## Events added

| Event | Where | Data |
|---|---|---|
| `auth-magic-link-failed` | `LoginView.vue` — sending the magic link fails | `{ code }` (e.g. `AUTH_RATE_LIMITED`, `AUTH_INVALID_CAPTCHA`, `AUTH_INTERNAL_ERROR`) |
| `auth-token-failed` | `MagicLink.vue` — token verification fails | `{ code }` (`AUTH_EXPIRED_TOKEN`, `AUTH_INVALID_TOKEN`, `AUTH_INVALID_INPUT`, `AUTH_INTERNAL_ERROR`, or client-side `AUTH_MALFORMED_LINK` when the link's token param fails validation) |
| `auth-bootstrap-failed` | `MagicLink.vue` — post-login bootstrap rejects after a valid token | — |

No events are emitted on successful logins (covered by tests). Tracking is a no-op when Umami is not configured, as before.

## Tests

- `MagicLink.spec.ts`: parametrized test over all backend error codes, malformed-link param case, bootstrap-failure case, and a no-tracking-on-success case
- `LoginView.spec.ts`: magic-link send failure tracks the event with its code; success tracks nothing

`pnpm test`, `pnpm lint` and `pnpm type-check` are green. Changeset included (patch bump for `@opencupid/frontend`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017tTq7Doun8b3DtGn6pVEHV

---
_Generated by [Claude Code](https://claude.ai/code/session_017tTq7Doun8b3DtGn6pVEHV)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved monitoring of authentication failures during magic-link requests, token verification, and post-login setup.
  * Users now receive clearer error handling when a magic link is malformed, expired, invalid, or cannot complete sign-in.
  * Loading states now end appropriately when post-login setup fails, preventing the sign-in flow from appearing stuck.

* **Tests**
  * Expanded coverage for successful and unsuccessful magic-link authentication scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->